### PR TITLE
Update URLs to point to new domain deprecations.info

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Never miss an AI model shutdown again. This is a simple RSS feed that tracks dep
 ## The Feed
 
 ```
-https://leblancfg.com/deprecations-rss/rss/v1/feed.xml
+https://deprecations.info/rss/v1/feed.xml
 ```
 
 Add this to your RSS reader and you'll get notified when OpenAI, Anthropic, Google, AWS, or Cohere announce they're shutting down a model.
@@ -25,7 +25,7 @@ Use [Blogtrottr](https://blogtrottr.com) or [FeedRabbit](https://feedrabbit.com)
 
 ### Slack Notifications
 ```
-/feed subscribe https://leblancfg.com/deprecations-rss/rss/v1/feed.xml
+/feed subscribe https://deprecations.info/rss/v1/feed.xml
 ```
 
 ## Build Your Own Automations
@@ -45,7 +45,7 @@ import requests
 from datetime import datetime
 
 # Parse the RSS feed
-feed = feedparser.parse('https://leblancfg.com/deprecations-rss/rss/v1/feed.xml')
+feed = feedparser.parse('https://deprecations.info/rss/v1/feed.xml')
 
 # Your GitHub token and repo
 GITHUB_TOKEN = 'your_token_here'
@@ -97,7 +97,7 @@ const parser = new Parser();
 const octokit = new Octokit({ auth: 'your_token_here' });
 
 async function checkDeprecations() {
-  const feed = await parser.parseURL('https://leblancfg.com/deprecations-rss/rss/v1/feed.xml');
+  const feed = await parser.parseURL('https://deprecations.info/rss/v1/feed.xml');
   
   // Models you use in your codebase
   const modelsInUse = ['gpt-4', 'claude-2', 'text-davinci-003'];
@@ -144,7 +144,7 @@ checkDeprecations().catch(console.error);
 #!/bin/bash
 
 # Fetch and parse RSS feed
-FEED_URL="https://leblancfg.com/deprecations-rss/rss/v1/feed.xml"
+FEED_URL="https://deprecations.info/rss/v1/feed.xml"
 GITHUB_TOKEN="your_token_here"
 REPO="owner/repo"
 
@@ -199,7 +199,7 @@ repo = 'owner/repo'
 models_in_use = ['gpt-4', 'claude-2', 'text-davinci-003']
 
 # Parse RSS feed
-rss = RSS::Parser.parse(URI.open('https://leblancfg.com/deprecations-rss/rss/v1/feed.xml'))
+rss = RSS::Parser.parse(URI.open('https://deprecations.info/rss/v1/feed.xml'))
 
 rss.items.each do |item|
   # Check if this affects our models
@@ -246,7 +246,7 @@ from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
 from datetime import datetime
 
-feed = feedparser.parse('https://leblancfg.com/deprecations-rss/rss/v1/feed.xml')
+feed = feedparser.parse('https://deprecations.info/rss/v1/feed.xml')
 
 # Email configuration
 SMTP_SERVER = 'smtp.gmail.com'
@@ -316,7 +316,7 @@ const transporter = nodemailer.createTransporter({
 });
 
 async function sendDeprecationAlerts() {
-  const feed = await parser.parseURL('https://leblancfg.com/deprecations-rss/rss/v1/feed.xml');
+  const feed = await parser.parseURL('https://deprecations.info/rss/v1/feed.xml');
   const teamEmails = ['dev1@example.com', 'dev2@example.com'];
   
   // Process recent entries
@@ -368,7 +368,7 @@ FROM_EMAIL="your-email@example.com"
 TO_EMAILS="dev1@example.com,dev2@example.com"
 
 # Fetch RSS feed
-FEED_URL="https://leblancfg.com/deprecations-rss/rss/v1/feed.xml"
+FEED_URL="https://deprecations.info/rss/v1/feed.xml"
 
 # Parse RSS and send emails for recent items
 curl -s "$FEED_URL" | xmlstarlet sel -t -m "//item[position()<=3]" \
@@ -431,7 +431,7 @@ end
 team_emails = ['dev1@example.com', 'dev2@example.com']
 
 # Parse RSS feed
-rss = RSS::Parser.parse(URI.open('https://leblancfg.com/deprecations-rss/rss/v1/feed.xml'))
+rss = RSS::Parser.parse(URI.open('https://deprecations.info/rss/v1/feed.xml'))
 
 # Send alerts for recent items
 rss.items.first(3).each do |item|
@@ -483,7 +483,7 @@ import requests
 import json
 from datetime import datetime
 
-feed = feedparser.parse('https://leblancfg.com/deprecations-rss/rss/v1/feed.xml')
+feed = feedparser.parse('https://deprecations.info/rss/v1/feed.xml')
 
 # Discord webhook URL
 WEBHOOK_URL = 'https://discord.com/api/webhooks/YOUR_WEBHOOK_URL'
@@ -536,7 +536,7 @@ const parser = new Parser();
 const WEBHOOK_URL = 'https://discord.com/api/webhooks/YOUR_WEBHOOK_URL';
 
 async function sendDiscordAlerts() {
-  const feed = await parser.parseURL('https://leblancfg.com/deprecations-rss/rss/v1/feed.xml');
+  const feed = await parser.parseURL('https://deprecations.info/rss/v1/feed.xml');
   
   for (const item of feed.items.slice(0, 3)) {
     const embed = {
@@ -585,7 +585,7 @@ sendDiscordAlerts().catch(console.error);
 #!/bin/bash
 
 WEBHOOK_URL="https://discord.com/api/webhooks/YOUR_WEBHOOK_URL"
-FEED_URL="https://leblancfg.com/deprecations-rss/rss/v1/feed.xml"
+FEED_URL="https://deprecations.info/rss/v1/feed.xml"
 
 # Parse RSS and send to Discord
 curl -s "$FEED_URL" | xmlstarlet sel -t -m "//item[position()<=3]" \
@@ -647,7 +647,7 @@ require 'time'
 webhook_url = 'https://discord.com/api/webhooks/YOUR_WEBHOOK_URL'
 
 # Parse RSS feed
-rss = RSS::Parser.parse(URI.open('https://leblancfg.com/deprecations-rss/rss/v1/feed.xml'))
+rss = RSS::Parser.parse(URI.open('https://deprecations.info/rss/v1/feed.xml'))
 
 # Send Discord notifications for recent items
 rss.items.first(3).each do |item|

--- a/docs/index.html
+++ b/docs/index.html
@@ -135,7 +135,7 @@ import requests
 from datetime import datetime
 
 # Parse the RSS feed
-feed = feedparser.parse('https://leblancfg.com/deprecations-rss/rss/v1/feed.xml')
+feed = feedparser.parse('https://deprecations.info/rss/v1/feed.xml')
 
 # Your GitHub token and repo
 GITHUB_TOKEN = 'your_token_here'
@@ -185,7 +185,7 @@ const parser = new Parser();
 const octokit = new Octokit({ auth: 'your_token_here' });
 
 async function checkDeprecations() {
-  const feed = await parser.parseURL('https://leblancfg.com/deprecations-rss/rss/v1/feed.xml');
+  const feed = await parser.parseURL('https://deprecations.info/rss/v1/feed.xml');
   
   // Models you use in your codebase
   const modelsInUse = ['gpt-4', 'claude-2', 'text-davinci-003'];
@@ -229,7 +229,7 @@ checkDeprecations().catch(console.error);</code></pre>
 # Install on RHEL/CentOS: yum install xmlstarlet
 
 # Fetch and parse RSS feed
-FEED_URL="https://leblancfg.com/deprecations-rss/rss/v1/feed.xml"
+FEED_URL="https://deprecations.info/rss/v1/feed.xml"
 GITHUB_TOKEN="your_token_here"
 REPO="owner/repo"
 
@@ -282,7 +282,7 @@ repo = 'owner/repo'
 models_in_use = ['gpt-4', 'claude-2', 'text-davinci-003']
 
 # Parse RSS feed
-rss = RSS::Parser.parse(URI.open('https://leblancfg.com/deprecations-rss/rss/v1/feed.xml'))
+rss = RSS::Parser.parse(URI.open('https://deprecations.info/rss/v1/feed.xml'))
 
 rss.items.each do |item|
   # Check if this affects our models
@@ -346,7 +346,7 @@ from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
 from datetime import datetime
 
-feed = feedparser.parse('https://leblancfg.com/deprecations-rss/rss/v1/feed.xml')
+feed = feedparser.parse('https://deprecations.info/rss/v1/feed.xml')
 
 # Email configuration
 SMTP_SERVER = 'smtp.gmail.com'
@@ -414,7 +414,7 @@ const transporter = nodemailer.createTransporter({
 });
 
 async function sendDeprecationAlerts() {
-  const feed = await parser.parseURL('https://leblancfg.com/deprecations-rss/rss/v1/feed.xml');
+  const feed = await parser.parseURL('https://deprecations.info/rss/v1/feed.xml');
   const teamEmails = ['dev1@example.com', 'dev2@example.com'];
   
   // Process recent entries
@@ -464,7 +464,7 @@ FROM_EMAIL="your-email@example.com"
 TO_EMAILS="dev1@example.com,dev2@example.com"
 
 # Fetch RSS feed
-FEED_URL="https://leblancfg.com/deprecations-rss/rss/v1/feed.xml"
+FEED_URL="https://deprecations.info/rss/v1/feed.xml"
 
 # Parse RSS and send emails for recent items
 curl -s "$FEED_URL" | xmlstarlet sel -t -m "//item[position()&lt;=3]" \
@@ -525,7 +525,7 @@ end
 team_emails = ['dev1@example.com', 'dev2@example.com']
 
 # Parse RSS feed
-rss = RSS::Parser.parse(URI.open('https://leblancfg.com/deprecations-rss/rss/v1/feed.xml'))
+rss = RSS::Parser.parse(URI.open('https://deprecations.info/rss/v1/feed.xml'))
 
 # Send alerts for recent items
 rss.items.first(3).each do |item|
@@ -594,7 +594,7 @@ import requests
 import json
 from datetime import datetime
 
-feed = feedparser.parse('https://leblancfg.com/deprecations-rss/rss/v1/feed.xml')
+feed = feedparser.parse('https://deprecations.info/rss/v1/feed.xml')
 
 # Discord webhook URL
 WEBHOOK_URL = 'https://discord.com/api/webhooks/YOUR_WEBHOOK_URL'
@@ -645,7 +645,7 @@ const parser = new Parser();
 const WEBHOOK_URL = 'https://discord.com/api/webhooks/YOUR_WEBHOOK_URL';
 
 async function sendDiscordAlerts() {
-  const feed = await parser.parseURL('https://leblancfg.com/deprecations-rss/rss/v1/feed.xml');
+  const feed = await parser.parseURL('https://deprecations.info/rss/v1/feed.xml');
   
   for (const item of feed.items.slice(0, 3)) {
     const embed = {
@@ -691,7 +691,7 @@ sendDiscordAlerts().catch(console.error);</code></pre>
 # Install on RHEL/CentOS: yum install xmlstarlet
 
 WEBHOOK_URL="https://discord.com/api/webhooks/YOUR_WEBHOOK_URL"
-FEED_URL="https://leblancfg.com/deprecations-rss/rss/v1/feed.xml"
+FEED_URL="https://deprecations.info/rss/v1/feed.xml"
 
 # Parse RSS and send to Discord
 curl -s "$FEED_URL" | xmlstarlet sel -t -m "//item[position()&lt;=3]" \
@@ -751,7 +751,7 @@ require 'time'
 webhook_url = 'https://discord.com/api/webhooks/YOUR_WEBHOOK_URL'
 
 # Parse RSS feed
-rss = RSS::Parser.parse(URI.open('https://leblancfg.com/deprecations-rss/rss/v1/feed.xml'))
+rss = RSS::Parser.parse(URI.open('https://deprecations.info/rss/v1/feed.xml'))
 
 # Send Discord notifications for recent items
 rss.items.first(3).each do |item|

--- a/docs/rss/v1/feed.xml
+++ b/docs/rss/v1/feed.xml
@@ -2,7 +2,7 @@
 <rss version="2.0">
   <channel>
     <title>AI Model Deprecations</title>
-    <link>https://leblancfg.com/deprecations-rss/</link>
+    <link>https://deprecations.info/</link>
     <description>RSS feed tracking deprecations across major AI providers</description>
     <lastBuildDate>Fri, 22 Aug 2025 20:28:55 GMT</lastBuildDate>
     <item>

--- a/rss_gen.py
+++ b/rss_gen.py
@@ -25,7 +25,7 @@ def create_rss_feed(data):
 
     # Add channel metadata
     ET.SubElement(channel, "title").text = "AI Model Deprecations"
-    ET.SubElement(channel, "link").text = "https://leblancfg.com/deprecations-rss/"
+    ET.SubElement(channel, "link").text = "https://deprecations.info/"
     ET.SubElement(
         channel, "description"
     ).text = "RSS feed tracking deprecations across major AI providers"


### PR DESCRIPTION
## Summary
- Updated all RSS feed URLs from `leblancfg.com/deprecations-rss` to `deprecations.info`
- Updated code examples in README.md and docs/index.html 
- Updated RSS feed generator and existing feed XML
- Kept personal website references (leblancfg.com) and GitHub repo URLs intact

## Test plan
- [ ] Verify all feed URLs are correctly updated
- [ ] Check that website loads correctly with new URLs
- [ ] Ensure RSS feed generation works with updated base URL