### PR TITLE
Add xAI provider deprecations scraper

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ We check these pages daily:
 - [Google Vertex AI Deprecations](https://cloud.google.com/vertex-ai/generative-ai/docs/deprecations)
 - [AWS Bedrock Model Lifecycle](https://docs.aws.amazon.com/bedrock/latest/userguide/model-lifecycle.html)
 - [Cohere Deprecations](https://docs.cohere.com/docs/deprecations)
+- [xAI Models](https://docs.x.ai/docs/models)
 
 ## Why This Exists
 AI providers deprecate models regularly, sometimes with just a few months

--- a/docs/index.html
+++ b/docs/index.html
@@ -35,6 +35,7 @@
                         <a href="https://docs.cohere.com/docs/deprecations" target="_blank" rel="noopener" title="Cohere" class="provider-badge cohere">COH</a>
                         <a href="https://cloud.google.com/vertex-ai/generative-ai/docs/deprecations" target="_blank" rel="noopener" title="Google Vertex AI" class="provider-badge google">GCP</a>
                         <a href="https://docs.aws.amazon.com/bedrock/latest/userguide/model-lifecycle.html" target="_blank" rel="noopener" title="AWS Bedrock" class="provider-badge aws">AWS</a>
+                        <a href="https://docs.x.ai/docs/models" target="_blank" rel="noopener" title="xAI" class="provider-badge xai">xAI</a>
                         <a href="https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/model-retirements" target="_blank" rel="noopener" title="Microsoft Azure" class="provider-badge azure">AZR</a>
                     </div>
                     <a href="https://github.com/leblancfg/deprecations-rss" target="_blank" rel="noopener"
@@ -54,7 +55,7 @@
 
         <section class="intro">
             <p class="lead">
-                Track AI model deprecations from OpenAI, Anthropic, Google Vertex AI, AWS Bedrock, and Cohere.
+                Track AI model deprecations from OpenAI, Anthropic, Google Vertex AI, AWS Bedrock, Cohere, and xAI.
                 Available as <strong>JSON API</strong>, <strong>JSON Feed</strong>, and <strong>RSS</strong> - perfect
                 for programmatic access and automation.
                 When they announce a model is being shut down, it shows up here. That's it.
@@ -143,6 +144,7 @@ t19 -45.5t-18.5 -45t-44.5 -19.5zM551 477q-27 0 -46 19t-19 45.5t19 45.5t45.5 19t4
                 <button class="filter-badge cohere" data-filter="cohere">COH</button>
                 <button class="filter-badge google" data-filter="google">GCP</button>
                 <button class="filter-badge aws" data-filter="aws">AWS</button>
+                <button class="filter-badge xai" data-filter="xai">xAI</button>
                 <button class="filter-badge azure" data-filter="azure">AZR</button>
             </div>
 
@@ -256,6 +258,7 @@ t19 -45.5t-18.5 -45t-44.5 -19.5zM551 477q-27 0 -46 19t-19 45.5t19 45.5t45.5 19t4
                         'cohere': 'Cohere',
                         'aws': 'AWS',
                         'awsbedrock': 'AWS Bedrock',
+                        'xai': 'xAI',
                         'azure': 'Azure OpenAI'
                     };
                     
@@ -369,6 +372,7 @@ t19 -45.5t-18.5 -45t-44.5 -19.5zM551 477q-27 0 -46 19t-19 45.5t19 45.5t45.5 19t4
                                 'cohere': 'cohere',
                                 'aws': 'aws',
                                 'awsbedrock': 'aws',
+                                'xai': 'xai',
                                 'azure': 'azure',
                                 'azureopenai': 'azure'
                             };
@@ -1289,6 +1293,7 @@ end</code></pre>
                 <li><a href="https://docs.aws.amazon.com/bedrock/latest/userguide/model-lifecycle.html"
                         target="_blank">AWS Bedrock Model Lifecycle</a></li>
                 <li><a href="https://docs.cohere.com/docs/deprecations" target="_blank">Cohere Deprecations</a></li>
+                <li><a href="https://docs.x.ai/docs/models" target="_blank">xAI Models</a></li>
             </ul>
         </section>
 

--- a/src/providers.py
+++ b/src/providers.py
@@ -6,6 +6,7 @@ from .scrapers.anthropic_scraper import AnthropicScraper
 from .scrapers.google_vertex_scraper import GoogleVertexScraper
 from .scrapers.aws_bedrock_scraper import AWSBedrockScraper
 from .scrapers.cohere_scraper import CohereScraper
+from .scrapers.xai_scraper import XAIScraper
 
 # List of all scrapers - using the new enhanced versions
 SCRAPERS = [
@@ -14,4 +15,5 @@ SCRAPERS = [
     GoogleVertexScraper,
     AWSBedrockScraper,
     CohereScraper,
+    XAIScraper,
 ]

--- a/src/scrapers/xai_scraper.py
+++ b/src/scrapers/xai_scraper.py
@@ -1,0 +1,412 @@
+"""xAI deprecations scraper with support for interactive deprecated models display."""
+
+import re
+from typing import List, Any
+from bs4 import BeautifulSoup
+from playwright.sync_api import sync_playwright
+
+from ..base_scraper import EnhancedBaseScraper
+from ..models import DeprecationItem
+
+
+class XAIScraper(EnhancedBaseScraper):
+    """Scraper for xAI models page with deprecated models."""
+
+    provider_name = "xAI"
+    url = "https://docs.x.ai/docs/models"
+    requires_playwright = True  # Requires interaction to show deprecated models
+
+    def fetch_with_playwright(self, url: str) -> str:
+        """Fetch content using Playwright with interaction to reveal deprecated models."""
+        with sync_playwright() as p:
+            browser = p.chromium.launch(
+                headless=True,
+                args=[
+                    "--disable-blink-features=AutomationControlled",
+                    "--disable-dev-shm-usage",
+                    "--no-sandbox",
+                    "--disable-setuid-sandbox",
+                    "--disable-web-security",
+                ],
+            )
+            context = browser.new_context(
+                viewport={"width": 1920, "height": 1080},
+                user_agent=self.headers["User-Agent"],
+            )
+            page = context.new_page()
+
+            try:
+                page.goto(url, wait_until="domcontentloaded", timeout=60000)
+                page.wait_for_timeout(3000)  # Wait for initial content load
+
+                # Look for "see deprecated models" link/button and click it
+                deprecated_selectors = [
+                    "text='see deprecated models'",
+                    "text='See deprecated models'",
+                    "text='Show deprecated models'",
+                    "text='show deprecated models'",
+                    "[data-testid*='deprecated']",
+                    "[class*='deprecated']",
+                    "button:has-text('deprecated')",
+                    "a:has-text('deprecated')",
+                ]
+
+                clicked = False
+                for selector in deprecated_selectors:
+                    try:
+                        if page.locator(selector).is_visible():
+                            page.locator(selector).click()
+                            page.wait_for_timeout(2000)  # Wait for content to load
+                            clicked = True
+                            print(
+                                f"  → Clicked deprecated models toggle using selector: {selector}"
+                            )
+                            break
+                    except Exception:
+                        continue
+
+                if not clicked:
+                    print(
+                        "  → Could not find deprecated models toggle, proceeding with static content"
+                    )
+
+                # Wait for any dynamic content to load
+                page.wait_for_timeout(2000)
+                html = page.content()
+
+            finally:
+                browser.close()
+
+            return html
+
+    def extract_structured_deprecations(self, html: str) -> List[DeprecationItem]:
+        """Extract deprecations from xAI's models page."""
+        items = []
+        soup = BeautifulSoup(html, "html.parser")
+
+        # Look for tables containing model information
+        tables = soup.find_all("table")
+
+        for table in tables:
+            # Check if this table contains model information
+            headers = table.find("thead") or table.find("tr")
+            if not headers:
+                continue
+
+            header_text = headers.get_text().lower()
+            if "model" not in header_text:
+                continue
+
+            # Extract from this table
+            table_items = self._extract_from_models_table(table)
+            items.extend(table_items)
+
+        # Also look for rows with deprecation indicators (circle with bar in left gutter)
+        deprecated_rows = soup.find_all(
+            lambda tag: tag.name == "tr" and self._has_deprecation_indicator(tag)
+        )
+
+        for row in deprecated_rows:
+            row_items = self._extract_from_deprecated_row(row)
+            items.extend(row_items)
+
+        # Look for any text mentioning deprecated models
+        deprecated_sections = soup.find_all(
+            lambda tag: tag.name in ["div", "section", "p"]
+            and "deprecat" in tag.get_text().lower()
+        )
+
+        for section in deprecated_sections:
+            section_items = self._extract_from_deprecated_section(section)
+            items.extend(section_items)
+
+        return items
+
+    def _has_deprecation_indicator(self, row_element) -> bool:
+        """Check if a table row has a deprecation indicator."""
+        # Look for visual indicators that might suggest deprecation
+        row_classes = " ".join(row_element.get("class", []))
+
+        # Check for deprecation-related classes
+        deprecation_indicators = [
+            "deprecated",
+            "legacy",
+            "discontinued",
+            "sunset",
+            "warning",
+            "alert",
+            "strikethrough",
+        ]
+
+        for indicator in deprecation_indicators:
+            if indicator in row_classes.lower():
+                return True
+
+        # Look for styling that might indicate deprecation
+        style = row_element.get("style", "")
+        if any(
+            style_hint in style.lower()
+            for style_hint in ["line-through", "opacity", "disabled"]
+        ):
+            return True
+
+        # Check for icons or symbols in the first cell (left gutter)
+        first_cell = row_element.find("td")
+        if first_cell:
+            # Look for SVG icons, Unicode symbols, or specific classes
+            if (
+                first_cell.find("svg")
+                or "⊖" in first_cell.get_text()
+                or "⊝" in first_cell.get_text()
+                or "🚫" in first_cell.get_text()
+                or any(
+                    cls in " ".join(first_cell.get("class", [])).lower()
+                    for cls in ["icon", "deprecated", "warning"]
+                )
+            ):
+                return True
+
+        return False
+
+    def _extract_from_models_table(self, table: Any) -> List[DeprecationItem]:
+        """Extract model information from a standard models table."""
+        items = []
+        rows = table.find_all("tr")
+
+        if len(rows) <= 1:
+            return items
+
+        # Parse headers to understand table structure
+        headers = []
+        header_row = rows[0]
+        for th in header_row.find_all(["th", "td"]):
+            headers.append(th.get_text(strip=True).lower())
+
+        # Find relevant column indices
+        model_idx = None
+        status_idx = None
+        date_idx = None
+        description_idx = None
+
+        for i, header in enumerate(headers):
+            if "model" in header or "name" in header:
+                model_idx = i
+            elif "status" in header or "state" in header:
+                status_idx = i
+            elif "date" in header or "deprecated" in header:
+                date_idx = i
+            elif "description" in header or "notes" in header:
+                description_idx = i
+
+        if model_idx is None:
+            return items
+
+        # Process each row
+        for row in rows[1:]:
+            cells = row.find_all("td")
+            if len(cells) <= model_idx:
+                continue
+
+            model_name = cells[model_idx].get_text(strip=True)
+            if not model_name or model_name.lower() in ["model", "name"]:
+                continue
+
+            # Check if this row indicates deprecation
+            is_deprecated = self._has_deprecation_indicator(row)
+
+            # Check status column for deprecation
+            if not is_deprecated and status_idx is not None and status_idx < len(cells):
+                status_text = cells[status_idx].get_text(strip=True).lower()
+                if any(
+                    dep_word in status_text
+                    for dep_word in ["deprecat", "legacy", "discontinued"]
+                ):
+                    is_deprecated = True
+
+            # Only process if deprecated
+            if not is_deprecated:
+                continue
+
+            # Extract additional information
+            deprecation_date = ""
+            if date_idx is not None and date_idx < len(cells):
+                date_text = cells[date_idx].get_text(strip=True)
+                deprecation_date = self.parse_date(date_text)
+
+            description = ""
+            if description_idx is not None and description_idx < len(cells):
+                description = cells[description_idx].get_text(strip=True)
+
+            # Create deprecation item
+            item = DeprecationItem(
+                provider=self.provider_name,
+                model_id=model_name,
+                model_name=model_name,
+                announcement_date=deprecation_date,
+                shutdown_date=deprecation_date,
+                replacement_model=None,  # Would need additional parsing
+                deprecation_context=description,
+                url=self.url,
+            )
+
+            items.append(item)
+
+        return items
+
+    def _extract_from_deprecated_row(self, row: Any) -> List[DeprecationItem]:
+        """Extract model info from a row identified as having deprecation indicators."""
+        items = []
+        cells = row.find_all(["td", "th"])
+
+        if not cells:
+            return items
+
+        # Try to find the model name in the cells
+        for cell in cells:
+            text = cell.get_text(strip=True)
+
+            # Skip empty cells or cells with just symbols
+            if not text or len(text) < 2:
+                continue
+
+            # Skip cells that are clearly not model names
+            if text.lower() in ["status", "date", "description", "notes", "deprecated"]:
+                continue
+
+            # Look for model name patterns (containing letters, numbers, hyphens)
+            if re.match(r"^[a-zA-Z][a-zA-Z0-9\-_\.]*$", text):
+                item = DeprecationItem(
+                    provider=self.provider_name,
+                    model_id=text,
+                    model_name=text,
+                    announcement_date="",
+                    shutdown_date="",
+                    replacement_model=None,
+                    deprecation_context="Found in deprecated models section",
+                    url=self.url,
+                )
+                items.append(item)
+                break  # Take the first valid model name from the row
+
+        return items
+
+    def _extract_from_deprecated_section(self, section: Any) -> List[DeprecationItem]:
+        """Extract model names from text sections mentioning deprecated models."""
+        items = []
+        text = section.get_text()
+
+        # Look for model names in deprecation-related text
+        model_pattern = re.compile(
+            r"\b([a-z][a-z0-9\-_]*(?:-\d+)?(?:-preview|turbo|mini|large)?)\b"
+        )
+
+        # Only process if the text clearly mentions deprecation
+        if not any(
+            word in text.lower()
+            for word in ["deprecat", "legacy", "discontinued", "sunset"]
+        ):
+            return items
+
+        potential_models = model_pattern.findall(text.lower())
+
+        # Filter out common words that aren't model names
+        common_words = {
+            "the",
+            "and",
+            "or",
+            "but",
+            "in",
+            "on",
+            "at",
+            "to",
+            "for",
+            "of",
+            "with",
+            "by",
+            "from",
+            "as",
+            "is",
+            "are",
+            "was",
+            "were",
+            "been",
+            "have",
+            "has",
+            "will",
+            "would",
+            "could",
+            "should",
+            "may",
+            "might",
+            "can",
+            "must",
+            "models",
+            "model",
+            "api",
+            "docs",
+            "documentation",
+            "see",
+            "more",
+            "info",
+            "information",
+            "details",
+            "page",
+            "section",
+            "text",
+            "deprecated",
+        }
+
+        for model in potential_models:
+            if model not in common_words and len(model) > 2:
+                item = DeprecationItem(
+                    provider=self.provider_name,
+                    model_id=model,
+                    model_name=model,
+                    announcement_date="",
+                    shutdown_date="",
+                    replacement_model=None,
+                    deprecation_context=text[:200] + "..." if len(text) > 200 else text,
+                    url=self.url,
+                )
+                items.append(item)
+
+        return items
+
+    def extract_unstructured_deprecations(self, html: str) -> List[DeprecationItem]:
+        """Extract deprecated models from unstructured content."""
+        items = []
+        soup = BeautifulSoup(html, "html.parser")
+
+        # Look for any text mentioning specific deprecated models
+        text_content = soup.get_text()
+
+        # Common patterns for mentioning deprecated models
+        deprecation_patterns = [
+            r"(\w+(?:-\w+)*)\s+(?:is|has been|will be)\s+deprecat",
+            r"deprecat(?:ed|ing)\s+(?:model[s]?)?\s*:?\s*(\w+(?:-\w+)*)",
+            r"legacy\s+(?:model[s]?)?\s*:?\s*(\w+(?:-\w+)*)",
+            r"discontinued\s+(?:model[s]?)?\s*:?\s*(\w+(?:-\w+)*)",
+        ]
+
+        for pattern in deprecation_patterns:
+            matches = re.finditer(pattern, text_content, re.IGNORECASE)
+            for match in matches:
+                model_name = match.group(1)
+                if len(model_name) > 2:  # Filter out very short matches
+                    context_start = max(0, match.start() - 100)
+                    context_end = min(len(text_content), match.end() + 100)
+                    context = text_content[context_start:context_end].strip()
+
+                    item = DeprecationItem(
+                        provider=self.provider_name,
+                        model_id=model_name,
+                        model_name=model_name,
+                        announcement_date="",
+                        shutdown_date="",
+                        replacement_model=None,
+                        deprecation_context=context,
+                        url=self.url,
+                    )
+                    items.append(item)
+
+        return items

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -26,6 +26,7 @@ def test_scraper_imports():
         from src.scrapers.google_vertex_scraper import GoogleVertexScraper  # noqa: F401
         from src.scrapers.aws_bedrock_scraper import AWSBedrockScraper  # noqa: F401
         from src.scrapers.cohere_scraper import CohereScraper  # noqa: F401
+        from src.scrapers.xai_scraper import XAIScraper  # noqa: F401
 
         assert True
     except ImportError as e:


### PR DESCRIPTION
## Summary
Implements xAI provider support for the deprecations RSS system as requested in #44.

## Changes
- ✅ **New XAI Scraper** (`src/scrapers/xai_scraper.py`)
  - Interactive Playwright scraper for `https://docs.x.ai/docs/models`
  - Automatically clicks "see deprecated models" to reveal hidden content
  - Multiple extraction methods: table parsing, visual indicators, text analysis
  - Handles xAI-specific deprecation markers (circle with bar in left gutter)

- ✅ **Provider Integration** (`src/providers.py`)
  - Added XAIScraper to provider registry

- ✅ **Test Coverage** (`tests/test_basic.py`)
  - Added xAI scraper to import tests

- ✅ **Documentation Updates**
  - Updated `README.md` to include xAI in tracked providers
  - Updated `docs/index.html` with xAI provider badge and filters
  - Added xAI to provider mapping and filter controls

## Test Plan
- [x] All existing tests pass
- [x] New xAI scraper imports successfully
- [x] Code formatting and linting checks pass
- [x] Syntax validation completed

## Implementation Details
The scraper handles xAI's unique page structure where deprecated models are initially hidden and revealed via JavaScript interaction. It uses multiple detection strategies to ensure robust data extraction even as the page structure evolves.

Fixes #44