### PR TITLE
Add Google provider for AI/Gemini deprecations

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ https://deprecations.info/api/v1/deprecations.json
 We check these pages daily:
 - [OpenAI Deprecations](https://platform.openai.com/docs/deprecations)
 - [Anthropic Model Deprecations](https://docs.anthropic.com/en/docs/about-claude/model-deprecations)
+- [Google AI/Gemini Deprecations](https://ai.google.dev/gemini-api/docs/changelog)
 - [Google Vertex AI Deprecations](https://cloud.google.com/vertex-ai/generative-ai/docs/deprecations)
 - [AWS Bedrock Model Lifecycle](https://docs.aws.amazon.com/bedrock/latest/userguide/model-lifecycle.html)
 - [Cohere Deprecations](https://docs.cohere.com/docs/deprecations)

--- a/docs/index.html
+++ b/docs/index.html
@@ -48,8 +48,9 @@
                     <div class="provider-badges">
                         <a href="https://platform.openai.com/docs/deprecations" target="_blank" rel="noopener" title="OpenAI" class="provider-badge openai">OAI</a>
                         <a href="https://docs.anthropic.com/en/docs/about-claude/model-deprecations" target="_blank" rel="noopener" title="Anthropic" class="provider-badge anthropic">ANT</a>
+                        <a href="https://ai.google.dev/gemini-api/docs/changelog" target="_blank" rel="noopener" title="Google AI/Gemini" class="provider-badge google">GOO</a>
                         <a href="https://docs.cohere.com/docs/deprecations" target="_blank" rel="noopener" title="Cohere" class="provider-badge cohere">COH</a>
-                        <a href="https://cloud.google.com/vertex-ai/generative-ai/docs/deprecations" target="_blank" rel="noopener" title="Google Vertex AI" class="provider-badge google">GCP</a>
+                        <a href="https://cloud.google.com/vertex-ai/generative-ai/docs/deprecations" target="_blank" rel="noopener" title="Google Vertex AI" class="provider-badge google-vertex">GCP</a>
                         <a href="https://docs.aws.amazon.com/bedrock/latest/userguide/model-lifecycle.html" target="_blank" rel="noopener" title="AWS Bedrock" class="provider-badge aws">AWS</a>
                         <a href="https://docs.x.ai/docs/models" target="_blank" rel="noopener" title="xAI" class="provider-badge xai">xAI</a>
                         <a href="https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/model-retirements" target="_blank" rel="noopener" title="Microsoft Azure" class="provider-badge azure">AZR</a>
@@ -71,7 +72,7 @@
 
         <section class="intro">
             <p class="lead">
-                Track AI model deprecations from OpenAI, Anthropic, Google Vertex AI, AWS Bedrock, Cohere, and xAI.
+                Track AI model deprecations from OpenAI, Anthropic, Google AI/Gemini, Google Vertex AI, AWS Bedrock, Cohere, and xAI.
                 Available as <strong>JSON API</strong>, <strong>JSON Feed</strong>, and <strong>RSS</strong> - perfect
                 for programmatic access and automation.
                 When they announce a model is being shut down, it shows up here. That's it.
@@ -157,8 +158,9 @@ t19 -45.5t-18.5 -45t-44.5 -19.5zM551 477q-27 0 -46 19t-19 45.5t19 45.5t45.5 19t4
                 <button class="filter-badge now active" data-filter="now">NOW</button>
                 <button class="filter-badge openai" data-filter="openai">OAI</button>
                 <button class="filter-badge anthropic" data-filter="anthropic">ANT</button>
+                <button class="filter-badge google" data-filter="google">GOO</button>
                 <button class="filter-badge cohere" data-filter="cohere">COH</button>
-                <button class="filter-badge google" data-filter="google">GCP</button>
+                <button class="filter-badge google-vertex" data-filter="google-vertex">GCP</button>
                 <button class="filter-badge aws" data-filter="aws">AWS</button>
                 <button class="filter-badge xai" data-filter="xai">xAI</button>
                 <button class="filter-badge azure" data-filter="azure">AZR</button>
@@ -270,6 +272,7 @@ t19 -45.5t-18.5 -45t-44.5 -19.5zM551 477q-27 0 -46 19t-19 45.5t19 45.5t45.5 19t4
                         'openai': 'OpenAI',
                         'anthropic': 'Anthropic',
                         'google': 'Google',
+                        'googlevertex': 'Google Vertex',
                         'googlevertexai': 'Google Vertex AI',
                         'cohere': 'Cohere',
                         'aws': 'AWS',
@@ -384,7 +387,8 @@ t19 -45.5t-18.5 -45t-44.5 -19.5zM551 477q-27 0 -46 19t-19 45.5t19 45.5t45.5 19t4
                                 'openai': 'openai',
                                 'anthropic': 'anthropic',
                                 'google': 'google',
-                                'googlevertexai': 'google',
+                                'googlevertex': 'google-vertex',
+                                'googlevertexai': 'google-vertex',
                                 'cohere': 'cohere',
                                 'aws': 'aws',
                                 'awsbedrock': 'aws',
@@ -1304,6 +1308,7 @@ end</code></pre>
                 <li><a href="https://platform.openai.com/docs/deprecations" target="_blank">OpenAI Deprecations</a></li>
                 <li><a href="https://docs.anthropic.com/en/docs/about-claude/model-deprecations"
                         target="_blank">Anthropic Model Deprecations</a></li>
+                <li><a href="https://ai.google.dev/gemini-api/docs/changelog" target="_blank">Google AI/Gemini Deprecations</a></li>
                 <li><a href="https://cloud.google.com/vertex-ai/generative-ai/docs/deprecations" target="_blank">Google
                         Vertex AI Deprecations</a></li>
                 <li><a href="https://docs.aws.amazon.com/bedrock/latest/userguide/model-lifecycle.html"

--- a/src/providers.py
+++ b/src/providers.py
@@ -3,6 +3,7 @@
 # Import the new enhanced scrapers
 from .scrapers.openai_scraper import OpenAIScraper
 from .scrapers.anthropic_scraper import AnthropicScraper
+from .scrapers.google_scraper import GoogleScraper
 from .scrapers.google_vertex_scraper import GoogleVertexScraper
 from .scrapers.aws_bedrock_scraper import AWSBedrockScraper
 from .scrapers.cohere_scraper import CohereScraper
@@ -13,6 +14,7 @@ from .scrapers.azure_foundry_scraper import AzureFoundryScraper
 SCRAPERS = [
     OpenAIScraper,
     AnthropicScraper,
+    GoogleScraper,
     GoogleVertexScraper,
     AWSBedrockScraper,
     CohereScraper,

--- a/src/scrapers/google_scraper.py
+++ b/src/scrapers/google_scraper.py
@@ -32,17 +32,17 @@ class GoogleScraper(EnhancedBaseScraper):
 
         for section_header in sections:
             section_title = section_header.get_text(strip=True)
-            
+
             # Skip non-date sections
-            date_match = re.search(r'(\w+ \d+, \d{4})', section_title)
+            date_match = re.search(r"(\w+ \d+, \d{4})", section_title)
             if not date_match:
                 continue
-                
+
             section_date = self.parse_date(date_match.group(1))
 
             # Look for deprecation info after the header
             next_elem = section_header.next_sibling
-            
+
             while next_elem:
                 if hasattr(next_elem, "name"):
                     if next_elem.name in ["h2", "h3"]:
@@ -52,26 +52,31 @@ class GoogleScraper(EnhancedBaseScraper):
                     text = next_elem.get_text(strip=True)
 
                     # Look for deprecation patterns
-                    if any(keyword in text.lower() for keyword in [
-                        "deprecated", "deprecation", "no longer supported", 
-                        "removed", "will be deprecated", "retirement"
-                    ]):
+                    if any(
+                        keyword in text.lower()
+                        for keyword in [
+                            "deprecated",
+                            "deprecation",
+                            "no longer supported",
+                            "removed",
+                            "will be deprecated",
+                            "retirement",
+                        ]
+                    ):
                         # Extract model names and dates
                         model_matches = re.findall(
-                            r'(gemini-[a-zA-Z0-9\-\.]+)', text.lower()
+                            r"(gemini-[a-zA-Z0-9\-\.]+)", text.lower()
                         )
-                        
+
                         # Look for specific deprecation dates in text
-                        future_date_match = re.search(
-                            r'(\w+ \d+, \d{4})', text
-                        )
+                        future_date_match = re.search(r"(\w+ \d+, \d{4})", text)
                         deprecation_date = ""
                         if future_date_match:
                             parsed_date = self.parse_date(future_date_match.group(1))
                             # Only use if it's a future date (likely shutdown date)
                             if parsed_date and parsed_date > section_date:
                                 deprecation_date = parsed_date
-                        
+
                         if not deprecation_date:
                             deprecation_date = section_date
 
@@ -79,18 +84,18 @@ class GoogleScraper(EnhancedBaseScraper):
                         if model_matches:
                             for model_id in model_matches:
                                 # Clean up model name
-                                model_name = model_id.replace('-', ' ').title()
-                                if 'Pro' in model_name:
-                                    model_name = model_name.replace('Pro', 'Pro')
-                                if 'Flash' in model_name:
-                                    model_name = model_name.replace('Flash', 'Flash')
-                                
+                                model_name = model_id.replace("-", " ").title()
+                                if "Pro" in model_name:
+                                    model_name = model_name.replace("Pro", "Pro")
+                                if "Flash" in model_name:
+                                    model_name = model_name.replace("Flash", "Flash")
+
                                 # Look for replacement models
                                 replacement = None
                                 repl_patterns = [
-                                    r'redirect(?:ing)?\s+to\s+(gemini-[a-zA-Z0-9\-\.]+)',
-                                    r'use\s+(gemini-[a-zA-Z0-9\-\.]+)',
-                                    r'replaced\s+(?:by|with)\s+(gemini-[a-zA-Z0-9\-\.]+)'
+                                    r"redirect(?:ing)?\s+to\s+(gemini-[a-zA-Z0-9\-\.]+)",
+                                    r"use\s+(gemini-[a-zA-Z0-9\-\.]+)",
+                                    r"replaced\s+(?:by|with)\s+(gemini-[a-zA-Z0-9\-\.]+)",
                                 ]
                                 for pattern in repl_patterns:
                                     repl_match = re.search(pattern, text.lower())
@@ -103,7 +108,9 @@ class GoogleScraper(EnhancedBaseScraper):
                                     model_id=model_id,
                                     model_name=model_name,
                                     announcement_date=section_date,
-                                    shutdown_date=deprecation_date if deprecation_date != section_date else "",
+                                    shutdown_date=deprecation_date
+                                    if deprecation_date != section_date
+                                    else "",
                                     replacement_model=replacement,
                                     deprecation_context=text,
                                     url=f"{self.url}#{section_date.replace('-', '')}",
@@ -114,22 +121,24 @@ class GoogleScraper(EnhancedBaseScraper):
                             if "gemini" in text.lower():
                                 # Try to extract model from context
                                 general_model_patterns = [
-                                    r'gemini\s+1\.0\s+pro\s+vision',
-                                    r'gemini\s+1\.0\s+pro',
-                                    r'gemini\s+1\.5\s+(?:pro|flash)',
+                                    r"gemini\s+1\.0\s+pro\s+vision",
+                                    r"gemini\s+1\.0\s+pro",
+                                    r"gemini\s+1\.5\s+(?:pro|flash)",
                                 ]
-                                
+
                                 for pattern in general_model_patterns:
                                     if re.search(pattern, text.lower()):
                                         model_name = re.search(pattern, text.lower()).group(0)
-                                        model_id = model_name.lower().replace(' ', '-')
-                                        
+                                        model_id = model_name.lower().replace(" ", "-")
+
                                         item = DeprecationItem(
                                             provider=self.provider_name,
                                             model_id=model_id,
                                             model_name=model_name.title(),
                                             announcement_date=section_date,
-                                            shutdown_date=deprecation_date if deprecation_date != section_date else "",
+                                            shutdown_date=deprecation_date
+                                            if deprecation_date != section_date
+                                            else "",
                                             replacement_model=None,
                                             deprecation_context=text,
                                             url=f"{self.url}#{section_date.replace('-', '')}",

--- a/src/scrapers/google_scraper.py
+++ b/src/scrapers/google_scraper.py
@@ -1,0 +1,146 @@
+"""Google AI/Gemini deprecations scraper with individual model extraction."""
+
+import re
+from typing import List
+from bs4 import BeautifulSoup
+
+from ..base_scraper import EnhancedBaseScraper
+from ..models import DeprecationItem
+
+
+class GoogleScraper(EnhancedBaseScraper):
+    """Scraper for Google AI/Gemini deprecations page."""
+
+    provider_name = "Google"
+    url = "https://ai.google.dev/gemini-api/docs/changelog"
+    requires_playwright = False  # Static content, httpx is fine
+
+    def extract_structured_deprecations(self, html: str) -> List[DeprecationItem]:
+        """Extract deprecations from Google AI changelog format."""
+        items = []
+        soup = BeautifulSoup(html, "html.parser")
+
+        # Find main content
+        content = soup.find("article") or soup.find(
+            "div", class_="devsite-article-body"
+        )
+        if not content:
+            return items
+
+        # Google AI uses date-based sections with h2 headers
+        sections = content.find_all(["h2", "h3"])
+
+        for section_header in sections:
+            section_title = section_header.get_text(strip=True)
+            
+            # Skip non-date sections
+            date_match = re.search(r'(\w+ \d+, \d{4})', section_title)
+            if not date_match:
+                continue
+                
+            section_date = self.parse_date(date_match.group(1))
+
+            # Look for deprecation info after the header
+            next_elem = section_header.next_sibling
+            
+            while next_elem:
+                if hasattr(next_elem, "name"):
+                    if next_elem.name in ["h2", "h3"]:
+                        # Next section
+                        break
+
+                    text = next_elem.get_text(strip=True)
+
+                    # Look for deprecation patterns
+                    if any(keyword in text.lower() for keyword in [
+                        "deprecated", "deprecation", "no longer supported", 
+                        "removed", "will be deprecated", "retirement"
+                    ]):
+                        # Extract model names and dates
+                        model_matches = re.findall(
+                            r'(gemini-[a-zA-Z0-9\-\.]+)', text.lower()
+                        )
+                        
+                        # Look for specific deprecation dates in text
+                        future_date_match = re.search(
+                            r'(\w+ \d+, \d{4})', text
+                        )
+                        deprecation_date = ""
+                        if future_date_match:
+                            parsed_date = self.parse_date(future_date_match.group(1))
+                            # Only use if it's a future date (likely shutdown date)
+                            if parsed_date and parsed_date > section_date:
+                                deprecation_date = parsed_date
+                        
+                        if not deprecation_date:
+                            deprecation_date = section_date
+
+                        # Create items for each model found
+                        if model_matches:
+                            for model_id in model_matches:
+                                # Clean up model name
+                                model_name = model_id.replace('-', ' ').title()
+                                if 'Pro' in model_name:
+                                    model_name = model_name.replace('Pro', 'Pro')
+                                if 'Flash' in model_name:
+                                    model_name = model_name.replace('Flash', 'Flash')
+                                
+                                # Look for replacement models
+                                replacement = None
+                                repl_patterns = [
+                                    r'redirect(?:ing)?\s+to\s+(gemini-[a-zA-Z0-9\-\.]+)',
+                                    r'use\s+(gemini-[a-zA-Z0-9\-\.]+)',
+                                    r'replaced\s+(?:by|with)\s+(gemini-[a-zA-Z0-9\-\.]+)'
+                                ]
+                                for pattern in repl_patterns:
+                                    repl_match = re.search(pattern, text.lower())
+                                    if repl_match:
+                                        replacement = repl_match.group(1)
+                                        break
+
+                                item = DeprecationItem(
+                                    provider=self.provider_name,
+                                    model_id=model_id,
+                                    model_name=model_name,
+                                    announcement_date=section_date,
+                                    shutdown_date=deprecation_date if deprecation_date != section_date else "",
+                                    replacement_model=replacement,
+                                    deprecation_context=text,
+                                    url=f"{self.url}#{section_date.replace('-', '')}",
+                                )
+                                items.append(item)
+                        else:
+                            # Handle general deprecation entries
+                            if "gemini" in text.lower():
+                                # Try to extract model from context
+                                general_model_patterns = [
+                                    r'gemini\s+1\.0\s+pro\s+vision',
+                                    r'gemini\s+1\.0\s+pro',
+                                    r'gemini\s+1\.5\s+(?:pro|flash)',
+                                ]
+                                
+                                for pattern in general_model_patterns:
+                                    if re.search(pattern, text.lower()):
+                                        model_name = re.search(pattern, text.lower()).group(0)
+                                        model_id = model_name.lower().replace(' ', '-')
+                                        
+                                        item = DeprecationItem(
+                                            provider=self.provider_name,
+                                            model_id=model_id,
+                                            model_name=model_name.title(),
+                                            announcement_date=section_date,
+                                            shutdown_date=deprecation_date if deprecation_date != section_date else "",
+                                            replacement_model=None,
+                                            deprecation_context=text,
+                                            url=f"{self.url}#{section_date.replace('-', '')}",
+                                        )
+                                        items.append(item)
+                                        break
+
+                next_elem = next_elem.next_sibling
+
+        return items
+
+    def extract_unstructured_deprecations(self, html: str) -> List[DeprecationItem]:
+        """Google AI uses structured changelog, so no unstructured extraction needed."""
+        return []

--- a/src/scrapers/google_vertex_scraper.py
+++ b/src/scrapers/google_vertex_scraper.py
@@ -11,7 +11,7 @@ from ..models import DeprecationItem
 class GoogleVertexScraper(EnhancedBaseScraper):
     """Scraper for Google Vertex AI deprecations page."""
 
-    provider_name = "Google Vertex AI"
+    provider_name = "Google Vertex"
     url = "https://cloud.google.com/vertex-ai/generative-ai/docs/deprecations"
     requires_playwright = False  # Static content, httpx is fine
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -23,6 +23,7 @@ def test_scraper_imports():
     try:
         from src.scrapers.openai_scraper import OpenAIScraper  # noqa: F401
         from src.scrapers.anthropic_scraper import AnthropicScraper  # noqa: F401
+        from src.scrapers.google_scraper import GoogleScraper  # noqa: F401
         from src.scrapers.google_vertex_scraper import GoogleVertexScraper  # noqa: F401
         from src.scrapers.aws_bedrock_scraper import AWSBedrockScraper  # noqa: F401
         from src.scrapers.cohere_scraper import CohereScraper  # noqa: F401


### PR DESCRIPTION
## Summary
- Add new `GoogleScraper` for Google AI/Gemini deprecations from https://ai.google.dev/gemini-api/docs/changelog
- Rename Google Vertex AI provider to "Google Vertex" to align with https://models.dev naming conventions
- Update tests to include new provider
- Update README and documentation to list the new provider

## Changes
- **New provider**: `google` for Google AI/Gemini models
- **Renamed provider**: `google-vertex` (was "Google Vertex AI")
- **Updated docs**: README.md and docs/index.html now include both Google providers
- **Tests**: Added import test for new GoogleScraper

## Test plan
- [x] Syntax check passes for all Python files
- [x] New provider imports correctly
- [x] Updated tests include new scraper
- [ ] CI checks pass (will monitor)

Fixes #48