### PR TITLE
Fix GitHub Actions permissions for automated scraping

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.BOT_PAT }}
       
       - name: Install uv
         uses: astral-sh/setup-uv@v3


### PR DESCRIPTION
Fixes automated scraping workflow to push directly to main.

Changes:
- Add contents: write permission
- Use BOT_PAT to bypass branch protection
- Enable fully automated daily updates

Related: #63