### PR TITLE
Fix scrape checkout authentication

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -20,8 +20,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6.0.2
-        with:
-          token: ${{ secrets.BOT_PAT }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.0.0


### PR DESCRIPTION
## Summary
- Remove the custom `BOT_PAT` from `actions/checkout`.
- Let checkout use the built-in workflow `GITHUB_TOKEN`; the job already grants `contents: write` for the later push step.
- Rebased after #95 so this PR is workflow-only and no longer carries generated feed changes.

## Testing
- Previously reproduced the scheduled-run failure as checkout auth failure before scraping.
- Previously verified a manual run on this branch passed end-to-end.
- Re-triggering `scrape.yml` after the rebase to confirm the current branch still passes.

## Diagnosis
The 2026-05-01 scheduled scrape failed before scraping, in `actions/checkout`, with: `fatal: could not read Username for 'https://github.com': terminal prompts disabled`. That points to the `BOT_PAT` secret being unavailable or invalid.