### PR TITLE
Fix provider scraper accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ https://deprecations.info/api/v1/deprecations.json
 We check these pages daily:
 - [OpenAI Deprecations](https://platform.openai.com/docs/deprecations)
 - [Anthropic Model Deprecations](https://docs.anthropic.com/en/docs/about-claude/model-deprecations)
-- [Google AI/Gemini Deprecations](https://ai.google.dev/gemini-api/docs/changelog)
+- [Google AI/Gemini Deprecations](https://ai.google.dev/gemini-api/docs/deprecations)
 - [Google Vertex AI Deprecations](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/deprecations/partner-models)
 - [AWS Bedrock Model Lifecycle](https://docs.aws.amazon.com/bedrock/latest/userguide/model-lifecycle.html)
 - [Cohere Deprecations](https://docs.cohere.com/docs/deprecations)

--- a/data.json
+++ b/data.json
@@ -5,13 +5,31 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-07-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "5.4-mini"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "ef67ac992153d5f0",
-    "scraped_at": "2026-04-23T04:51:54.525170+00:00",
+    "scraped_at": "2026-05-01T21:39:21.868836+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "OpenAI",
+    "model_id": "computer-use-preview",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-07-23",
+    "deprecation_date": "2026-04-22",
+    "replacement_models": [
+      "5.4-mini"
+    ],
+    "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
+    "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
+    "content_hash": "bcf7d1748d204634",
+    "scraped_at": "2026-05-01T21:39:21.868877+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -19,13 +37,15 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-07-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-audio"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "6e559087aa9f66be",
-    "scraped_at": "2026-04-23T04:51:54.525206+00:00",
+    "scraped_at": "2026-05-01T21:39:21.868910+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -33,13 +53,15 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-07-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-audio"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "947035e404950459",
-    "scraped_at": "2026-04-23T04:51:54.525228+00:00",
+    "scraped_at": "2026-05-01T21:39:21.868932+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -47,13 +69,15 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-07-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-realtime-mini"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "90fd9b271351e489",
-    "scraped_at": "2026-04-23T04:51:54.525243+00:00",
+    "scraped_at": "2026-05-01T21:39:21.868951+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -61,13 +85,15 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-07-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "4.1-mini"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "54b1bd491d30bc72",
-    "scraped_at": "2026-04-23T04:51:54.525273+00:00",
+    "scraped_at": "2026-05-01T21:39:21.868968+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -75,13 +101,15 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-07-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-realtime"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "46f8ed5a5fd3c799",
-    "scraped_at": "2026-04-23T04:51:54.525284+00:00",
+    "scraped_at": "2026-05-01T21:39:21.868985+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -89,13 +117,15 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-07-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-4.1-mini"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "ab799d88d4bb3448",
-    "scraped_at": "2026-04-23T04:51:54.525295+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869000+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -103,13 +133,15 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-07-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-5.3-chat-latest"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "94b9bd980083e8ec",
-    "scraped_at": "2026-04-23T04:51:54.525314+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869016+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -117,13 +149,15 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-07-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-5.4"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "e1162ef1e18b042c",
-    "scraped_at": "2026-04-23T04:51:54.525329+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869031+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -131,13 +165,15 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-07-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-5.3-chat-latest"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "a02dc956835f75af",
-    "scraped_at": "2026-04-23T04:51:54.525340+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869046+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -145,13 +181,15 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-07-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-5"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "00f5c58b4da9ca88",
-    "scraped_at": "2026-04-23T04:51:54.525351+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869061+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -159,13 +197,15 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-07-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-5.4"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "395fbef9211a3706",
-    "scraped_at": "2026-04-23T04:51:54.525361+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869077+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -173,13 +213,15 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-07-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-5.4-mini"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "2c68ded2a590010e",
-    "scraped_at": "2026-04-23T04:51:54.525371+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869092+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -187,13 +229,15 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-07-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-audio"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "e902de424f32319a",
-    "scraped_at": "2026-04-23T04:51:54.525381+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869106+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -201,13 +245,15 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-07-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-realtime-mini"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "d94d349c7530e67c",
-    "scraped_at": "2026-04-23T04:51:54.525391+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869126+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -215,13 +261,31 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-07-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "5.4-Pro"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "3027ab0668ff7684",
-    "scraped_at": "2026-04-23T04:51:54.525400+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869144+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "OpenAI",
+    "model_id": "o3-deep-research",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-07-23",
+    "deprecation_date": "2026-04-22",
+    "replacement_models": [
+      "5.4-Pro"
+    ],
+    "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
+    "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
+    "content_hash": "2fb2f1948cb5f40c",
+    "scraped_at": "2026-05-01T21:39:21.869150+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -229,13 +293,31 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-07-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "5.4-Pro"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "d78cfac58c61f716",
-    "scraped_at": "2026-04-23T04:51:54.525409+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869166+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "OpenAI",
+    "model_id": "o4-mini-deep-research",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-07-23",
+    "deprecation_date": "2026-04-22",
+    "replacement_models": [
+      "5.4-Pro"
+    ],
+    "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
+    "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
+    "content_hash": "0935d48962005eb2",
+    "scraped_at": "2026-05-01T21:39:21.869172+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -243,13 +325,15 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-07-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-5.4"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "6bfc76fde10da4e4",
-    "scraped_at": "2026-04-23T04:51:54.525419+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869186+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -257,13 +341,47 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-10-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-4.1-mini"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "0dcdb171408e9370",
-    "scraped_at": "2026-04-23T04:51:54.525428+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869204+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "OpenAI",
+    "model_id": "gpt-3.5-turbo",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-10-23",
+    "deprecation_date": "2026-04-22",
+    "replacement_models": [
+      "gpt-4.1-mini"
+    ],
+    "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
+    "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
+    "content_hash": "f63778b2618b8631",
+    "scraped_at": "2026-05-01T21:39:21.869210+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "OpenAI",
+    "model_id": "gpt-3.5-turbo-completions",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-10-23",
+    "deprecation_date": "2026-04-22",
+    "replacement_models": [
+      "gpt-4.1-mini"
+    ],
+    "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
+    "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
+    "content_hash": "46bd24227d34b521",
+    "scraped_at": "2026-05-01T21:39:21.869214+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -271,13 +389,63 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-10-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-4.1"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "18a2fc1ab49d3146",
-    "scraped_at": "2026-04-23T04:51:54.525437+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869274+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "OpenAI",
+    "model_id": "gpt-4",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-10-23",
+    "deprecation_date": "2026-04-22",
+    "replacement_models": [
+      "gpt-4.1"
+    ],
+    "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
+    "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
+    "content_hash": "b1cf8fa52f11e1a8",
+    "scraped_at": "2026-05-01T21:39:21.869293+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "OpenAI",
+    "model_id": "gpt-4-0613-completions",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-10-23",
+    "deprecation_date": "2026-04-22",
+    "replacement_models": [
+      "gpt-4.1"
+    ],
+    "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
+    "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
+    "content_hash": "ba38613e6dede54f",
+    "scraped_at": "2026-05-01T21:39:21.869302+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "OpenAI",
+    "model_id": "gpt-4-completions",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-10-23",
+    "deprecation_date": "2026-04-22",
+    "replacement_models": [
+      "gpt-4.1"
+    ],
+    "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
+    "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
+    "content_hash": "09d420371810c007",
+    "scraped_at": "2026-05-01T21:39:21.869308+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -285,13 +453,15 @@
     "announcement_date": "2026-03-26",
     "shutdown_date": "2026-10-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-4.1"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "0cd83d946b9ac51a",
-    "scraped_at": "2026-04-23T04:51:54.525446+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869329+00:00",
     "first_observed": "2026-03-26",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -299,13 +469,47 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-10-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-4.1"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "3ec298b507c96fa1",
-    "scraped_at": "2026-04-23T04:51:54.525455+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869350+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "OpenAI",
+    "model_id": "gpt-4-turbo-2024-04-09",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-10-23",
+    "deprecation_date": "2026-04-22",
+    "replacement_models": [
+      "gpt-4.1"
+    ],
+    "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
+    "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
+    "content_hash": "13705242151f2e9d",
+    "scraped_at": "2026-05-01T21:39:21.869362+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "OpenAI",
+    "model_id": "gpt-4-turbo-completions",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-10-23",
+    "deprecation_date": "2026-04-22",
+    "replacement_models": [
+      "gpt-4.1"
+    ],
+    "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
+    "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
+    "content_hash": "c37dc59f9011d275",
+    "scraped_at": "2026-05-01T21:39:21.869450+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -313,13 +517,31 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-10-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-5-nano"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "3c4ce71e3a1d5d92",
-    "scraped_at": "2026-04-23T04:51:54.525464+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869494+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "OpenAI",
+    "model_id": "gpt-4.1-nano-2025-04-14",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-10-23",
+    "deprecation_date": "2026-04-22",
+    "replacement_models": [
+      "gpt-5-nano"
+    ],
+    "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
+    "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
+    "content_hash": "2a982d793b6b8f0c",
+    "scraped_at": "2026-05-01T21:39:21.869503+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -327,13 +549,15 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-10-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-4.1"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "7adaafff1d94c1f9",
-    "scraped_at": "2026-04-23T04:51:54.525473+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869524+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -341,13 +565,15 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-10-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-image-1.5"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "55a981c6faea7977",
-    "scraped_at": "2026-04-23T04:51:54.525487+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869547+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -355,13 +581,31 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-10-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "o3"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "6cce9cef09ff6992",
-    "scraped_at": "2026-04-23T04:51:54.525496+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869568+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "OpenAI",
+    "model_id": "o1",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-10-23",
+    "deprecation_date": "2026-04-22",
+    "replacement_models": [
+      "o3"
+    ],
+    "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
+    "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
+    "content_hash": "b822aec1c97a54fd",
+    "scraped_at": "2026-05-01T21:39:21.869574+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -369,13 +613,31 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-10-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "5.4-Pro"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "f9b5ac3f2401b58f",
-    "scraped_at": "2026-04-23T04:51:54.525506+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869591+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "OpenAI",
+    "model_id": "o1-pro",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-10-23",
+    "deprecation_date": "2026-04-22",
+    "replacement_models": [
+      "5.4-Pro"
+    ],
+    "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
+    "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
+    "content_hash": "8f44100a18b4417b",
+    "scraped_at": "2026-05-01T21:39:21.869596+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -383,13 +645,31 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-10-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "o3"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "8e25665c4346d538",
-    "scraped_at": "2026-04-23T04:51:54.525515+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869612+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "OpenAI",
+    "model_id": "o3-mini",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-10-23",
+    "deprecation_date": "2026-04-22",
+    "replacement_models": [
+      "o3"
+    ],
+    "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
+    "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
+    "content_hash": "776618f6972a36aa",
+    "scraped_at": "2026-05-01T21:39:21.869618+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -397,13 +677,15 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-10-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-5-mini"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "10e24c5e1850759e",
-    "scraped_at": "2026-04-23T04:51:54.525524+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869633+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -411,13 +693,31 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-10-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-5-mini"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "7ed63fc9f3f95dbc",
-    "scraped_at": "2026-04-23T04:51:54.525533+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869648+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "OpenAI",
+    "model_id": "o4-mini",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-10-23",
+    "deprecation_date": "2026-04-22",
+    "replacement_models": [
+      "gpt-5-mini"
+    ],
+    "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
+    "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
+    "content_hash": "2b348b0f1d565845",
+    "scraped_at": "2026-05-01T21:39:21.869654+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -425,13 +725,15 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-10-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-4.1-mini"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "56cccd7d42d33e7b",
-    "scraped_at": "2026-04-23T04:51:54.525557+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869737+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -439,13 +741,15 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-10-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-4.1"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "afeb72021dd9dfb9",
-    "scraped_at": "2026-04-23T04:51:54.525567+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869755+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -453,13 +757,15 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-10-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-5-nano"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "e0f4d75398046174",
-    "scraped_at": "2026-04-23T04:51:54.525577+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869771+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -467,13 +773,15 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-10-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-5-mini"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "875b4a305dc7e676",
-    "scraped_at": "2026-04-23T04:51:54.525586+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869786+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -481,93 +789,85 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-10-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-5-mini"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "47779aff2ec07bfe",
-    "scraped_at": "2026-04-23T04:51:54.525595+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869800+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
     "model_id": "sora-2",
     "announcement_date": "2026-03-27",
     "shutdown_date": "2026-09-24",
-    "replacement_models": [
-      "---"
-    ],
+    "deprecation_date": "2026-03-24",
+    "replacement_models": null,
     "deprecation_context": "On March 24th, 2026, we notified developers using the Videos API and Sora 2 video generation model aliases and snapshots of their deprecation and removal from the API on September 24, 2026.",
     "url": "https://platform.openai.com/docs/deprecations#2026-03-24-sora-2-video-generation-models-and-videos-api",
     "content_hash": "fe4030bdd7c7cacf",
-    "scraped_at": "2026-03-27T04:35:42.378612+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869964+00:00",
     "first_observed": "2026-03-27",
-    "last_observed": "2026-03-27",
-    "deprecation_date": "2026-03-24"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
     "model_id": "sora-2-pro",
     "announcement_date": "2026-03-27",
     "shutdown_date": "2026-09-24",
-    "replacement_models": [
-      "---"
-    ],
+    "deprecation_date": "2026-03-24",
+    "replacement_models": null,
     "deprecation_context": "On March 24th, 2026, we notified developers using the Videos API and Sora 2 video generation model aliases and snapshots of their deprecation and removal from the API on September 24, 2026.",
     "url": "https://platform.openai.com/docs/deprecations#2026-03-24-sora-2-video-generation-models-and-videos-api",
     "content_hash": "2b9043d1aa5d2a95",
-    "scraped_at": "2026-03-27T04:35:42.378649+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869986+00:00",
     "first_observed": "2026-03-27",
-    "last_observed": "2026-03-27",
-    "deprecation_date": "2026-03-24"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
     "model_id": "sora-2-2025-10-06",
     "announcement_date": "2026-03-27",
     "shutdown_date": "2026-09-24",
-    "replacement_models": [
-      "---"
-    ],
+    "deprecation_date": "2026-03-24",
+    "replacement_models": null,
     "deprecation_context": "On March 24th, 2026, we notified developers using the Videos API and Sora 2 video generation model aliases and snapshots of their deprecation and removal from the API on September 24, 2026.",
     "url": "https://platform.openai.com/docs/deprecations#2026-03-24-sora-2-video-generation-models-and-videos-api",
     "content_hash": "1515760838a34125",
-    "scraped_at": "2026-03-27T04:35:42.378673+00:00",
+    "scraped_at": "2026-05-01T21:39:21.870005+00:00",
     "first_observed": "2026-03-27",
-    "last_observed": "2026-03-27",
-    "deprecation_date": "2026-03-24"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
     "model_id": "sora-2-2025-12-08",
     "announcement_date": "2026-03-27",
     "shutdown_date": "2026-09-24",
-    "replacement_models": [
-      "---"
-    ],
+    "deprecation_date": "2026-03-24",
+    "replacement_models": null,
     "deprecation_context": "On March 24th, 2026, we notified developers using the Videos API and Sora 2 video generation model aliases and snapshots of their deprecation and removal from the API on September 24, 2026.",
     "url": "https://platform.openai.com/docs/deprecations#2026-03-24-sora-2-video-generation-models-and-videos-api",
     "content_hash": "1d50d8b250da24a7",
-    "scraped_at": "2026-03-27T04:35:42.378692+00:00",
+    "scraped_at": "2026-05-01T21:39:21.870021+00:00",
     "first_observed": "2026-03-27",
-    "last_observed": "2026-03-27",
-    "deprecation_date": "2026-03-24"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
     "model_id": "sora-2-pro-2025-10-06",
     "announcement_date": "2026-03-27",
     "shutdown_date": "2026-09-24",
-    "replacement_models": [
-      "---"
-    ],
+    "deprecation_date": "2026-03-24",
+    "replacement_models": null,
     "deprecation_context": "On March 24th, 2026, we notified developers using the Videos API and Sora 2 video generation model aliases and snapshots of their deprecation and removal from the API on September 24, 2026.",
     "url": "https://platform.openai.com/docs/deprecations#2026-03-24-sora-2-video-generation-models-and-videos-api",
     "content_hash": "cc702b0e0fe4a5c5",
-    "scraped_at": "2026-03-27T04:35:42.378709+00:00",
+    "scraped_at": "2026-05-01T21:39:21.870035+00:00",
     "first_observed": "2026-03-27",
-    "last_observed": "2026-03-27",
-    "deprecation_date": "2026-03-24"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -1925,646 +2225,818 @@
   },
   {
     "provider": "Google",
-    "model_id": "gemini-robotics-er-1.6-preview",
-    "announcement_date": "2026-04-15",
-    "shutdown_date": "",
-    "deprecation_date": "2026-04-14",
-    "replacement_models": null,
-    "deprecation_context": "Released gemini-robotics-er-1.6-preview , our updated robotics model.\nIt now has new capabilities like instrument reading, improved spatial and\nphysical reasoning capabilities. To learn more, see Gemini Robotics-ER page and the blog .",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20260414",
-    "content_hash": "8bd769e777bca254",
-    "scraped_at": "2026-04-15T04:47:23.808563+00:00",
-    "first_observed": "2026-04-15",
-    "last_observed": "2026-04-15"
-  },
-  {
-    "provider": "Google",
-    "model_id": "gemini-robotics-er-1.5-preview",
-    "announcement_date": "2026-04-15",
-    "shutdown_date": "",
-    "deprecation_date": "2026-04-14",
-    "replacement_models": null,
-    "deprecation_context": "Deprecation announcement: The gemini-robotics-er-1.5-preview model\nwill be shut down on April 30, 2026 at 9AM\nPST.",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20260414",
-    "content_hash": "0736e81a21067282",
-    "scraped_at": "2026-04-15T04:47:23.808648+00:00",
-    "first_observed": "2026-04-15",
-    "last_observed": "2026-04-15"
-  },
-  {
-    "provider": "Google",
-    "model_id": "gemini-embedding-2-preview",
-    "announcement_date": "2026-03-12",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "Released gemini-embedding-2-preview , our first multimodal embedding model.\nIt supports text, image, video, audio, and PDF inputs,\nmapping all modalities into a unified embedding space. To learn more, see Embeddings .",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20260310",
-    "content_hash": "604343c746f293f5",
-    "scraped_at": "2026-03-12T04:07:19.839599+00:00",
-    "first_observed": "2026-03-12",
-    "last_observed": "2026-03-12",
-    "deprecation_date": "2026-03-10"
-  },
-  {
-    "provider": "Google",
-    "model_id": "gemini-2.5-flash-lite-preview-09-2025",
-    "announcement_date": "2026-03-12",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "Deprecation announcement: The gemini-2.5-flash-lite-preview-09-2025 model\nwill be shut down on March 31, 2026.",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20260310",
-    "content_hash": "c2dcde220fb02fab",
-    "scraped_at": "2026-03-12T04:07:19.839689+00:00",
-    "first_observed": "2026-03-12",
-    "last_observed": "2026-03-12",
-    "deprecation_date": "2026-03-10"
-  },
-  {
-    "provider": "Google",
     "model_id": "gemini-3-pro-preview",
     "announcement_date": "2026-02-27",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "Deprecation announcement: Gemini 3 Pro Preview ( gemini-3-pro-preview )\nwill be shut down March 9, 2026.",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20260226",
-    "content_hash": "d3c4f9815f87ea3b",
-    "scraped_at": "2026-02-27T04:06:58.664291+00:00",
-    "first_observed": "2026-02-27",
-    "last_observed": "2026-02-27",
-    "deprecation_date": "2026-02-26"
-  },
-  {
-    "provider": "Google",
-    "model_id": "gemini-2.0-flash",
-    "announcement_date": "2026-02-20",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "Deprecation announcement: The following models will be shut down June 1, 2026: gemini-2.0-flash gemini-2.0-flash-001 gemini-2.0-flash-lite gemini-2.0-flash-lite-001",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20260218",
-    "content_hash": "889ed6ddbeaafb68",
-    "scraped_at": "2026-02-20T04:09:02.875598+00:00",
-    "first_observed": "2026-02-20",
-    "last_observed": "2026-02-20",
-    "deprecation_date": "2026-02-18"
-  },
-  {
-    "provider": "Google",
-    "model_id": "gemini-2.0-flash-001",
-    "announcement_date": "2026-02-20",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "Deprecation announcement: The following models will be shut down June 1, 2026: gemini-2.0-flash gemini-2.0-flash-001 gemini-2.0-flash-lite gemini-2.0-flash-lite-001",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20260218",
-    "content_hash": "2847532834f9d9e1",
-    "scraped_at": "2026-02-20T04:09:02.875718+00:00",
-    "first_observed": "2026-02-20",
-    "last_observed": "2026-02-20",
-    "deprecation_date": "2026-02-18"
-  },
-  {
-    "provider": "Google",
-    "model_id": "gemini-2.0-flash-lite",
-    "announcement_date": "2026-02-20",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "Deprecation announcement: The following models will be shut down June 1, 2026: gemini-2.0-flash gemini-2.0-flash-001 gemini-2.0-flash-lite gemini-2.0-flash-lite-001",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20260218",
-    "content_hash": "f2696084dbec3762",
-    "scraped_at": "2026-02-20T04:09:02.875804+00:00",
-    "first_observed": "2026-02-20",
-    "last_observed": "2026-02-20",
-    "deprecation_date": "2026-02-18"
-  },
-  {
-    "provider": "Google",
-    "model_id": "gemini-2.0-flash-lite-001",
-    "announcement_date": "2026-02-20",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "Deprecation announcement: The following models will be shut down June 1, 2026: gemini-2.0-flash gemini-2.0-flash-001 gemini-2.0-flash-lite gemini-2.0-flash-lite-001",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20260218",
-    "content_hash": "2351ca191e09f807",
-    "scraped_at": "2026-02-20T04:09:02.875883+00:00",
-    "first_observed": "2026-02-20",
-    "last_observed": "2026-02-20",
-    "deprecation_date": "2026-02-18"
-  },
-  {
-    "provider": "Google",
-    "model_id": "gemini-2.5-flash-preview-09-25",
-    "announcement_date": "2026-01-16",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "gemini-2.5-flash-preview-09-25",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20260115",
-    "content_hash": "fe1c89e97d73d1dd",
-    "scraped_at": "2026-01-16T03:24:29.958726+00:00",
-    "summary": "Insufficient information provided in the deprecation notice to complete analysis.",
-    "first_observed": "2026-01-16",
-    "last_observed": "2026-01-16",
-    "raw_content": "",
-    "content": "Insufficient information provided in the deprecation notice to complete analysis.",
-    "deprecation_date": "2026-01-15"
-  },
-  {
-    "provider": "Google",
-    "model_id": "imagen-4.0-generate-preview-06-06",
-    "announcement_date": "2026-01-16",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "imagen-4.0-generate-preview-06-06",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20260115",
-    "content_hash": "977571ca9e68cea8",
-    "scraped_at": "2026-01-16T03:24:29.958876+00:00",
-    "summary": "Insufficient information provided in the deprecation notice. Unable to extract specific details about model deprecation.",
-    "first_observed": "2026-01-16",
-    "last_observed": "2026-01-16",
-    "raw_content": "",
-    "content": "Insufficient information provided in the deprecation notice. Unable to extract specific details about model deprecation.",
-    "deprecation_date": "2026-01-15"
-  },
-  {
-    "provider": "Google",
-    "model_id": "imagen-4.0-ultra-generate-preview-06-06",
-    "announcement_date": "2026-01-16",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "imagen-4.0-ultra-generate-preview-06-06",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20260115",
-    "content_hash": "ef075c84f9cd6743",
-    "scraped_at": "2026-01-16T03:24:29.958925+00:00",
-    "summary": "Insufficient information provided in the deprecation notice to extract specific details.",
-    "first_observed": "2026-01-16",
-    "last_observed": "2026-01-16",
-    "raw_content": "",
-    "content": "Insufficient information provided in the deprecation notice to extract specific details.",
-    "deprecation_date": "2026-01-15"
-  },
-  {
-    "provider": "Google",
-    "model_id": "gemini-2.5-flash-image-preview",
-    "announcement_date": "2026-03-26",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "The gemini-2.5-flash-image-preview model has been shut down.",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20260115",
-    "content_hash": "46d302343637e255",
-    "scraped_at": "2026-03-26T13:07:23.859614+00:00",
-    "first_observed": "2026-03-26",
-    "last_observed": "2026-03-26",
-    "deprecation_date": "2026-01-15"
-  },
-  {
-    "provider": "Google",
-    "model_id": "veo-3.0-fast-generate-preview",
-    "announcement_date": "2025-12-05",
-    "shutdown_date": "2025-11-12",
-    "replacement_models": null,
-    "deprecation_context": "November 12: veo-3.0-fast-generate-preview veo-3.0-generate-preview",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251111",
-    "content_hash": "7477153d2249a270",
-    "scraped_at": "2025-12-05T16:52:41.232765+00:00",
-    "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-11-11"
-  },
-  {
-    "provider": "Google",
-    "model_id": "veo-3.0-generate-preview",
-    "announcement_date": "2025-12-05",
-    "shutdown_date": "2025-11-12",
-    "replacement_models": null,
-    "deprecation_context": "November 12: veo-3.0-fast-generate-preview veo-3.0-generate-preview",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251111",
-    "content_hash": "d74290d51e2b341e",
-    "scraped_at": "2025-12-05T16:52:41.232794+00:00",
-    "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-11-11"
-  },
-  {
-    "provider": "Google",
-    "model_id": "gemini-2.0-flash-exp-image-generation",
-    "announcement_date": "2025-12-05",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "gemini-2.0-flash-exp-image-generation",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251111",
-    "content_hash": "833d13ab0f88083b",
-    "scraped_at": "2025-12-05T16:52:41.232807+00:00",
-    "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-11-11"
-  },
-  {
-    "provider": "Google",
-    "model_id": "gemini-2.0-flash-preview-image-generation",
-    "announcement_date": "2025-12-05",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "gemini-2.0-flash-preview-image-generation",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251111",
-    "content_hash": "4a56ce13c77ab958",
-    "scraped_at": "2025-12-05T16:52:41.232818+00:00",
-    "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-11-11"
-  },
-  {
-    "provider": "Google",
-    "model_id": "imagen-3.0-generate-002",
-    "announcement_date": "2025-12-05",
-    "shutdown_date": "",
+    "shutdown_date": "2026-03-09",
+    "deprecation_date": "2026-03-09",
     "replacement_models": [
-      "imagen 4"
+      "gemini-3.1-pro-preview"
     ],
-    "deprecation_context": "The following model is shut down: imagen-3.0-generate-002 Use Imagen 4 instead. Refer to the Gemini deprecations table for more details.",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251110",
-    "content_hash": "428594f26fdaa768",
-    "scraped_at": "2025-12-05T16:52:41.232888+00:00",
-    "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-11-10"
+    "deprecation_context": "Gemini deprecations table: Gemini 3 models. Release date: 2025-11-18. Shutdown date: 2026-03-09. Recommended replacement: gemini-3.1-pro-preview.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-3-models",
+    "content_hash": "3f157fb9c4faef2d",
+    "scraped_at": "2026-05-01T21:43:36.810852+00:00",
+    "first_observed": "2026-02-27",
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Google",
-    "model_id": "gemini-2.5-flash-lite-preview-06-17",
+    "model_id": "gemini-2.5-pro",
     "announcement_date": "2025-12-05",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "gemini-2.5-flash-lite-preview-06-17",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
-    "content_hash": "f45c36e3fb9e800b",
-    "scraped_at": "2025-12-05T16:52:41.232941+00:00",
+    "shutdown_date": "2026-06-17",
+    "deprecation_date": "2026-06-17",
+    "replacement_models": [
+      "gemini-3.1-pro-preview"
+    ],
+    "deprecation_context": "Gemini deprecations table: Gemini 2.5 Pro models. Release date: 2025-06-17. Shutdown date: 2026-06-17. Recommended replacement: gemini-3.1-pro-preview.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.5-pro-models",
+    "content_hash": "05ef1fab10b274d9",
+    "scraped_at": "2026-05-01T21:43:36.811332+00:00",
     "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-11-04"
-  },
-  {
-    "provider": "Google",
-    "model_id": "gemini-2.5-flash-preview-05-20",
-    "announcement_date": "2025-12-05",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "gemini-2.5-flash-preview-05-20",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
-    "content_hash": "0bf60925c7f70027",
-    "scraped_at": "2025-12-05T16:52:41.232953+00:00",
-    "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-11-04"
-  },
-  {
-    "provider": "Google",
-    "model_id": "gemini-2.0-flash-thinking-exp",
-    "announcement_date": "2025-12-05",
-    "shutdown_date": "2025-12-02",
-    "replacement_models": null,
-    "deprecation_context": "December 2nd: gemini-2.0-flash-thinking-exp gemini-2.0-flash-thinking-exp-01-21 gemini-2.0-flash-thinking-exp-1219 gemini-2.5-pro-preview-03-25 gemini-2.5-pro-preview-05-06 gemini-2.5-pro-preview-06-05",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
-    "content_hash": "4999d7a107e2988a",
-    "scraped_at": "2025-12-05T16:52:41.232981+00:00",
-    "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-11-04"
-  },
-  {
-    "provider": "Google",
-    "model_id": "gemini-2.0-flash-thinking-exp-01-21",
-    "announcement_date": "2025-12-05",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "gemini-2.0-flash-thinking-exp-01-21",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
-    "content_hash": "09f03046955ec872",
-    "scraped_at": "2025-12-05T16:52:41.232993+00:00",
-    "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-11-04"
-  },
-  {
-    "provider": "Google",
-    "model_id": "gemini-2.0-flash-thinking-exp-1219",
-    "announcement_date": "2025-12-05",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "gemini-2.0-flash-thinking-exp-1219",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
-    "content_hash": "9b00e199081bdc1f",
-    "scraped_at": "2025-12-05T16:52:41.233003+00:00",
-    "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-11-04"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Google",
     "model_id": "gemini-2.5-pro-preview-03-25",
     "announcement_date": "2025-12-05",
     "shutdown_date": "2025-12-02",
-    "replacement_models": null,
-    "deprecation_context": "December 2nd: gemini-2.0-flash-thinking-exp gemini-2.0-flash-thinking-exp-01-21 gemini-2.0-flash-thinking-exp-1219 gemini-2.5-pro-preview-03-25 gemini-2.5-pro-preview-05-06 gemini-2.5-pro-preview-06-05",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
-    "content_hash": "942d02346fd8d63d",
-    "scraped_at": "2025-12-05T16:52:41.233029+00:00",
+    "deprecation_date": "2025-12-02",
+    "replacement_models": [
+      "gemini-3.1-pro-preview"
+    ],
+    "deprecation_context": "Gemini deprecations table: Gemini 2.5 Pro models. Release date: 2025-03-03. Shutdown date: 2025-12-02. Recommended replacement: gemini-3.1-pro-preview.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.5-pro-models",
+    "content_hash": "fcf9f4824ea77b2d",
+    "scraped_at": "2026-05-01T21:43:36.811516+00:00",
     "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-11-04"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Google",
     "model_id": "gemini-2.5-pro-preview-05-06",
     "announcement_date": "2025-12-05",
     "shutdown_date": "2025-12-02",
-    "replacement_models": null,
-    "deprecation_context": "December 2nd: gemini-2.0-flash-thinking-exp gemini-2.0-flash-thinking-exp-01-21 gemini-2.0-flash-thinking-exp-1219 gemini-2.5-pro-preview-03-25 gemini-2.5-pro-preview-05-06 gemini-2.5-pro-preview-06-05",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
-    "content_hash": "f3d8530a217ebf75",
-    "scraped_at": "2025-12-05T16:52:41.233055+00:00",
+    "deprecation_date": "2025-12-02",
+    "replacement_models": [
+      "gemini-3.1-pro-preview"
+    ],
+    "deprecation_context": "Gemini deprecations table: Gemini 2.5 Pro models. Release date: 2025-05-06. Shutdown date: 2025-12-02. Recommended replacement: gemini-3.1-pro-preview.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.5-pro-models",
+    "content_hash": "8354c3046da9f72f",
+    "scraped_at": "2026-05-01T21:43:36.811657+00:00",
     "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-11-04"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Google",
     "model_id": "gemini-2.5-pro-preview-06-05",
     "announcement_date": "2025-12-05",
     "shutdown_date": "2025-12-02",
-    "replacement_models": null,
-    "deprecation_context": "December 2nd: gemini-2.0-flash-thinking-exp gemini-2.0-flash-thinking-exp-01-21 gemini-2.0-flash-thinking-exp-1219 gemini-2.5-pro-preview-03-25 gemini-2.5-pro-preview-05-06 gemini-2.5-pro-preview-06-05",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
-    "content_hash": "7fa76fe7274e3106",
-    "scraped_at": "2025-12-05T16:52:41.233079+00:00",
+    "deprecation_date": "2025-12-02",
+    "replacement_models": [
+      "gemini-3.1-pro-preview"
+    ],
+    "deprecation_context": "Gemini deprecations table: Gemini 2.5 Pro models. Release date: 2025-06-05. Shutdown date: 2025-12-02. Recommended replacement: gemini-3.1-pro-preview.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.5-pro-models",
+    "content_hash": "25eef711a126c99f",
+    "scraped_at": "2026-05-01T21:43:36.811794+00:00",
     "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-11-04"
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-2.5-flash",
+    "announcement_date": "2025-12-05",
+    "shutdown_date": "2026-06-17",
+    "deprecation_date": "2026-06-17",
+    "replacement_models": [
+      "gemini-3-flash-preview"
+    ],
+    "deprecation_context": "Gemini deprecations table: Gemini 2.5 Flash models. Release date: 2025-06-17. Shutdown date: 2026-06-17. Recommended replacement: gemini-3-flash-preview.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.5-flash-models",
+    "content_hash": "0b1eb669860c5edf",
+    "scraped_at": "2026-05-01T21:43:36.812091+00:00",
+    "first_observed": "2025-12-05",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-2.5-flash-image",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-10-02",
+    "deprecation_date": "2026-10-02",
+    "replacement_models": [
+      "gemini-3.1-flash-image-preview"
+    ],
+    "deprecation_context": "Gemini deprecations table: Gemini 2.5 Flash models. Release date: 2025-10-02. Shutdown date: 2026-10-02. Recommended replacement: gemini-3.1-flash-image-preview.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.5-flash-models",
+    "content_hash": "da1b0e80f4ab45da",
+    "scraped_at": "2026-05-01T21:43:36.812255+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-2.5-flash-lite",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-07-22",
+    "deprecation_date": "2026-07-22",
+    "replacement_models": [
+      "gemini-3.1-flash-lite-preview"
+    ],
+    "deprecation_context": "Gemini deprecations table: Gemini 2.5 Flash models. Release date: 2025-07-22. Shutdown date: 2026-07-22. Recommended replacement: gemini-3.1-flash-lite-preview.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.5-flash-models",
+    "content_hash": "d505ac64b7fea2e1",
+    "scraped_at": "2026-05-01T21:43:36.812419+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-2.5-flash-lite-preview-09-2025",
+    "announcement_date": "2026-03-12",
+    "shutdown_date": "2026-03-31",
+    "deprecation_date": "2026-03-31",
+    "replacement_models": [
+      "gemini-3.1-flash-lite-preview"
+    ],
+    "deprecation_context": "Gemini deprecations table: Gemini 2.5 Flash models. Release date: 2025-09-25. Shutdown date: 2026-03-31. Recommended replacement: gemini-3.1-flash-lite-preview.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.5-flash-models",
+    "content_hash": "1e48a972a96a0345",
+    "scraped_at": "2026-05-01T21:43:36.812586+00:00",
+    "first_observed": "2026-03-12",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-2.5-flash-preview-05-20",
+    "announcement_date": "2025-12-05",
+    "shutdown_date": "2025-11-18",
+    "deprecation_date": "2025-11-18",
+    "replacement_models": [
+      "gemini-3-flash-preview"
+    ],
+    "deprecation_context": "Gemini deprecations table: Gemini 2.5 Flash models. Release date: 2025-05-20. Shutdown date: 2025-11-18. Recommended replacement: gemini-3-flash-preview.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.5-flash-models",
+    "content_hash": "b44520f661ca01b1",
+    "scraped_at": "2026-05-01T21:43:36.812719+00:00",
+    "first_observed": "2025-12-05",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-2.5-flash-image-preview",
+    "announcement_date": "2026-03-26",
+    "shutdown_date": "2026-01-15",
+    "deprecation_date": "2026-01-15",
+    "replacement_models": [
+      "gemini-2.5-flash-image"
+    ],
+    "deprecation_context": "Gemini deprecations table: Gemini 2.5 Flash models. Release date: 2025-05-07. Shutdown date: 2026-01-15. Recommended replacement: gemini-2.5-flash-image.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.5-flash-models",
+    "content_hash": "50ebd7c8c1faa535",
+    "scraped_at": "2026-05-01T21:39:32.402819+00:00",
+    "first_observed": "2026-03-26",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-2.5-flash-preview-09-25",
+    "announcement_date": "2026-01-16",
+    "shutdown_date": "2026-02-17",
+    "deprecation_date": "2026-02-17",
+    "replacement_models": [
+      "gemini-3-flash-preview"
+    ],
+    "deprecation_context": "Gemini deprecations table: Gemini 2.5 Flash models. Release date: 2025-09-25. Shutdown date: 2026-02-17. Recommended replacement: gemini-3-flash-preview.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.5-flash-models",
+    "content_hash": "f3d2383e375ba0c3",
+    "scraped_at": "2026-05-01T21:43:36.812991+00:00",
+    "first_observed": "2026-01-16",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-2.0-flash",
+    "announcement_date": "2026-02-20",
+    "shutdown_date": "2026-06-01",
+    "deprecation_date": "2026-06-01",
+    "replacement_models": [
+      "gemini-2.5-flash"
+    ],
+    "deprecation_context": "Gemini deprecations table: Gemini 2.0 models. Release date: 2025-02-05. Shutdown date: 2026-06-01. Recommended replacement: gemini-2.5-flash.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.0-models",
+    "content_hash": "37959faf4dadf47e",
+    "scraped_at": "2026-05-01T21:43:36.813281+00:00",
+    "first_observed": "2026-02-20",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-2.0-flash-001",
+    "announcement_date": "2026-02-20",
+    "shutdown_date": "2026-06-01",
+    "deprecation_date": "2026-06-01",
+    "replacement_models": [
+      "gemini-2.5-flash"
+    ],
+    "deprecation_context": "Gemini deprecations table: Gemini 2.0 models. Release date: 2025-02-05. Shutdown date: 2026-06-01. Recommended replacement: gemini-2.5-flash.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.0-models",
+    "content_hash": "4e70bbd684dd1268",
+    "scraped_at": "2026-05-01T21:43:36.813411+00:00",
+    "first_observed": "2026-02-20",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-2.0-flash-lite",
+    "announcement_date": "2026-02-20",
+    "shutdown_date": "2026-06-01",
+    "deprecation_date": "2026-06-01",
+    "replacement_models": [
+      "gemini-2.5-flash-lite"
+    ],
+    "deprecation_context": "Gemini deprecations table: Gemini 2.0 models. Release date: 2025-02-25. Shutdown date: 2026-06-01. Recommended replacement: gemini-2.5-flash-lite.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.0-models",
+    "content_hash": "3c27622388237fce",
+    "scraped_at": "2026-05-01T21:43:36.813544+00:00",
+    "first_observed": "2026-02-20",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-2.0-flash-lite-001",
+    "announcement_date": "2026-02-20",
+    "shutdown_date": "2026-06-01",
+    "deprecation_date": "2026-06-01",
+    "replacement_models": [
+      "gemini-2.5-flash-lite"
+    ],
+    "deprecation_context": "Gemini deprecations table: Gemini 2.0 models. Release date: 2025-02-25. Shutdown date: 2026-06-01. Recommended replacement: gemini-2.5-flash-lite.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.0-models",
+    "content_hash": "ced31dc8fffd254e",
+    "scraped_at": "2026-05-01T21:43:36.813674+00:00",
+    "first_observed": "2026-02-20",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-2.0-flash-preview-image-generation",
+    "announcement_date": "2025-12-05",
+    "shutdown_date": "2025-11-14",
+    "deprecation_date": "2025-11-14",
+    "replacement_models": [
+      "gemini-2.5-flash-image"
+    ],
+    "deprecation_context": "Gemini deprecations table: Gemini 2.0 models. Release date: 2025-05-07. Shutdown date: 2025-11-14. Recommended replacement: gemini-2.5-flash-image.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.0-models",
+    "content_hash": "f94b5ad701ee2c22",
+    "scraped_at": "2026-05-01T21:43:36.813829+00:00",
+    "first_observed": "2025-12-05",
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Google",
     "model_id": "gemini-2.0-flash-lite-preview",
     "announcement_date": "2026-03-26",
     "shutdown_date": "2025-12-09",
-    "replacement_models": null,
-    "deprecation_context": "December 9th: gemini-2.0-flash-lite-preview gemini-2.0-flash-lite-preview-02-05 gemini-2.0-flash-exp gemini-2.0-pro-exp gemini-2.0-pro-exp-02-05",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
-    "content_hash": "34626f312f5ab436",
-    "scraped_at": "2026-03-26T13:07:23.861760+00:00",
+    "deprecation_date": "2025-12-09",
+    "replacement_models": [
+      "gemini-2.5-flash-lite"
+    ],
+    "deprecation_context": "Gemini deprecations table: Gemini 2.0 models. Release date: 2025-02-05. Shutdown date: 2025-12-09. Recommended replacement: gemini-2.5-flash-lite.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.0-models",
+    "content_hash": "7d1bdcef07c402ae",
+    "scraped_at": "2026-05-01T21:43:36.813956+00:00",
     "first_observed": "2026-03-26",
-    "last_observed": "2026-03-26",
-    "deprecation_date": "2025-11-04"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Google",
     "model_id": "gemini-2.0-flash-lite-preview-02-05",
     "announcement_date": "2025-12-05",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "gemini-2.0-flash-lite-preview-02-05",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
-    "content_hash": "3362915ce2b590bd",
-    "scraped_at": "2025-12-05T16:52:41.233112+00:00",
-    "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-11-04"
-  },
-  {
-    "provider": "Google",
-    "model_id": "gemini-2.0-flash-exp",
-    "announcement_date": "2026-01-29",
     "shutdown_date": "2025-12-09",
-    "replacement_models": null,
-    "deprecation_context": "December 9th: gemini-2.0-flash-lite-preview gemini-2.0-flash-lite-preview-02-05 gemini-2.0-flash-exp gemini-2.0-pro-exp gemini-2.0-pro-exp-02-05",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
-    "content_hash": "ed83bc1c163356c0",
-    "scraped_at": "2026-01-29T04:02:00.403641+00:00",
-    "first_observed": "2026-01-29",
-    "last_observed": "2026-01-29",
-    "deprecation_date": "2025-11-04"
-  },
-  {
-    "provider": "Google",
-    "model_id": "gemini-2.0-pro-exp",
-    "announcement_date": "2026-01-29",
-    "shutdown_date": "2025-12-09",
-    "replacement_models": null,
-    "deprecation_context": "December 9th: gemini-2.0-flash-lite-preview gemini-2.0-flash-lite-preview-02-05 gemini-2.0-flash-exp gemini-2.0-pro-exp gemini-2.0-pro-exp-02-05",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
-    "content_hash": "f0f832b7736bdccd",
-    "scraped_at": "2026-01-29T04:02:00.403734+00:00",
-    "first_observed": "2026-01-29",
-    "last_observed": "2026-01-29",
-    "deprecation_date": "2025-11-04"
-  },
-  {
-    "provider": "Google",
-    "model_id": "gemini-2.0-pro-exp-02-05",
-    "announcement_date": "2026-01-29",
-    "shutdown_date": "2025-12-09",
-    "replacement_models": null,
-    "deprecation_context": "December 9th: gemini-2.0-flash-lite-preview gemini-2.0-flash-lite-preview-02-05 gemini-2.0-flash-exp gemini-2.0-pro-exp gemini-2.0-pro-exp-02-05",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
-    "content_hash": "28b9783352ec4a78",
-    "scraped_at": "2026-01-29T04:02:00.403817+00:00",
-    "first_observed": "2026-01-29",
-    "last_observed": "2026-01-29",
-    "deprecation_date": "2025-11-04"
-  },
-  {
-    "provider": "Google",
-    "model_id": "gemini-2.5-flash-preview-native-audio-dialog",
-    "announcement_date": "2025-12-05",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "gemini-2.5-flash-preview-native-audio-dialog",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251020",
-    "content_hash": "a6db09acf9586d17",
-    "scraped_at": "2025-12-05T16:52:41.233151+00:00",
-    "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-10-20"
-  },
-  {
-    "provider": "Google",
-    "model_id": "gemini-2.5-flash-exp-native-audio-thinking-dialog",
-    "announcement_date": "2025-12-05",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "gemini-2.5-flash-exp-native-audio-thinking-dialog",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251020",
-    "content_hash": "d653454cc95f2094",
-    "scraped_at": "2025-12-05T16:52:41.233162+00:00",
-    "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-10-20"
-  },
-  {
-    "provider": "Google",
-    "model_id": "gemini-2.5-flash-native-audio-preview-09-2025",
-    "announcement_date": "2025-12-05",
-    "shutdown_date": "",
+    "deprecation_date": "2025-12-09",
     "replacement_models": [
-      "gemini-2.5-flash-native-audio-preview-09-2025"
+      "gemini-2.5-flash-lite"
     ],
-    "deprecation_context": "You can use gemini-2.5-flash-native-audio-preview-09-2025 instead.",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251020",
-    "content_hash": "940f19fd10e7c46b",
-    "scraped_at": "2025-12-05T16:52:41.233176+00:00",
+    "deprecation_context": "Gemini deprecations table: Gemini 2.0 models. Release date: 2025-02-05. Shutdown date: 2025-12-09. Recommended replacement: gemini-2.5-flash-lite.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.0-models",
+    "content_hash": "8a725acd38d9859c",
+    "scraped_at": "2026-05-01T21:43:36.814091+00:00",
     "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-10-20"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Google",
     "model_id": "gemini-2.0-flash-live-001",
     "announcement_date": "2025-12-05",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "Deprecation announcement: Shut down for gemini-2.0-flash-live-001 and gemini-live-2.5-flash-preview coming December 09, 2025.",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251020",
-    "content_hash": "61cc267215361e67",
-    "scraped_at": "2025-12-05T16:52:41.233192+00:00",
+    "shutdown_date": "2025-12-09",
+    "deprecation_date": "2025-12-09",
+    "replacement_models": [
+      "gemini-3.1-flash-live-preview"
+    ],
+    "deprecation_context": "Gemini deprecations table: Live API models. Release date: 2025-04-09. Shutdown date: 2025-12-09. Recommended replacement: gemini-3.1-flash-live-preview.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#live-api-models",
+    "content_hash": "1281b430644aa797",
+    "scraped_at": "2026-05-01T21:43:36.814360+00:00",
     "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-10-20"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Google",
     "model_id": "gemini-live-2.5-flash-preview",
     "announcement_date": "2025-12-05",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "Deprecation announcement: Shut down for gemini-2.0-flash-live-001 and gemini-live-2.5-flash-preview coming December 09, 2025.",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251020",
-    "content_hash": "7348812caddd830f",
-    "scraped_at": "2025-12-05T16:52:41.233205+00:00",
+    "shutdown_date": "2025-12-09",
+    "deprecation_date": "2025-12-09",
+    "replacement_models": [
+      "gemini-3.1-flash-live-preview"
+    ],
+    "deprecation_context": "Gemini deprecations table: Live API models. Release date: 2025-06-17. Shutdown date: 2025-12-09. Recommended replacement: gemini-3.1-flash-live-preview.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#live-api-models",
+    "content_hash": "10a243f5fa902758",
+    "scraped_at": "2026-05-01T21:43:36.814597+00:00",
     "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-10-20"
-  },
-  {
-    "provider": "Google",
-    "model_id": "gemini-embedding-exp-03-07",
-    "announcement_date": "2025-12-05",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "gemini-embedding-exp-03-07 ( gemini-embedding-exp )",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20250916",
-    "content_hash": "f19ba4ca0f34fc6a",
-    "scraped_at": "2025-12-05T16:52:41.233344+00:00",
-    "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-09-16"
-  },
-  {
-    "provider": "Google",
-    "model_id": "gemini-embedding-exp",
-    "announcement_date": "2025-12-05",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "gemini-embedding-exp-03-07 ( gemini-embedding-exp )",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20250916",
-    "content_hash": "f2377e29f3dca6ba",
-    "scraped_at": "2025-12-05T16:52:41.233356+00:00",
-    "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-09-16"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Google",
     "model_id": "gemini-embedding-001",
     "announcement_date": "2025-12-05",
-    "shutdown_date": "",
+    "shutdown_date": "2026-07-14",
+    "deprecation_date": "2026-07-14",
     "replacement_models": null,
-    "deprecation_context": "Released gemini-embedding-001 , the stable version of our\ntext embedding model. To learn more, see embeddings . The gemini-embedding-exp-03-07 model will be deprecated on August 14, 2025.",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20250714",
-    "content_hash": "6e276cebfb8270f4",
-    "scraped_at": "2025-12-05T16:52:41.233467+00:00",
+    "deprecation_context": "Gemini deprecations table: Embedding models. Release date: 2025-07-14. Shutdown date: 2026-07-14.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#embedding-models",
+    "content_hash": "d5844c73290161b7",
+    "scraped_at": "2026-05-01T21:43:36.815121+00:00",
     "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-07-14"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Google",
-    "model_id": "gemini-2.5-pro",
-    "announcement_date": "2025-12-05",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "Released gemini-2.5-pro , the stable version of our most powerful\nmodel, now with adaptive thinking. To learn more, see Gemini 2.5 Pro and Thinking . gemini-2.5-pro-preview-05-06 will be redirected to gemini-2.5-pro on June 26, 2025.",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20250617",
-    "content_hash": "32d67caea6ef685e",
-    "scraped_at": "2025-12-05T16:52:41.233549+00:00",
-    "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-06-17"
+    "model_id": "text-embedding-004",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-01-14",
+    "deprecation_date": "2026-01-14",
+    "replacement_models": [
+      "gemini-embedding-001"
+    ],
+    "deprecation_context": "Gemini deprecations table: Embedding models. Release date: 2024-04-09. Shutdown date: 2026-01-14. Recommended replacement: gemini-embedding-001.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#embedding-models",
+    "content_hash": "0e9799854657595b",
+    "scraped_at": "2026-05-01T21:43:36.815257+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Google",
-    "model_id": "gemini-2.5-flash",
-    "announcement_date": "2025-12-05",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "Released gemini-2.5-flash , our first stable 2.5 Flash model. To learn\nmore, see Gemini 2.5 Flash . gemini-2.5-flash-preview-04-17 will be deprecated on July 15, 2025.",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20250617",
-    "content_hash": "b92463f415925e71",
-    "scraped_at": "2025-12-05T16:52:41.233598+00:00",
-    "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-06-17"
+    "model_id": "embedding-001",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2025-10-30",
+    "deprecation_date": "2025-10-30",
+    "replacement_models": [
+      "gemini-embedding-001"
+    ],
+    "deprecation_context": "Gemini deprecations table: Embedding models. Release date: 2024-04-09. Shutdown date: 2025-10-30. Recommended replacement: gemini-embedding-001.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#embedding-models",
+    "content_hash": "887ccfb53324069d",
+    "scraped_at": "2026-05-01T21:43:36.815415+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Google",
-    "model_id": "gemini-2.5-flash-preview-04-17",
+    "model_id": "embedding-gecko-001",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2025-10-30",
+    "deprecation_date": "2025-10-30",
+    "replacement_models": [
+      "gemini-embedding-001"
+    ],
+    "deprecation_context": "Gemini deprecations table: Embedding models. Shutdown date: 2025-10-30. Recommended replacement: gemini-embedding-001.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#embedding-models",
+    "content_hash": "62ad77277267c0a6",
+    "scraped_at": "2026-05-01T21:43:36.815516+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-embedding-exp",
     "announcement_date": "2025-12-05",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "Released gemini-2.5-flash , our first stable 2.5 Flash model. To learn\nmore, see Gemini 2.5 Flash . gemini-2.5-flash-preview-04-17 will be deprecated on July 15, 2025.",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20250617",
-    "content_hash": "193dd2401fcb40e2",
-    "scraped_at": "2025-12-05T16:52:41.233613+00:00",
+    "shutdown_date": "2025-10-30",
+    "deprecation_date": "2025-10-30",
+    "replacement_models": [
+      "gemini-embedding-001"
+    ],
+    "deprecation_context": "Gemini deprecations table: Embedding models. Shutdown date: 2025-10-30. Recommended replacement: gemini-embedding-001.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#embedding-models",
+    "content_hash": "37a64c8f379d3e44",
+    "scraped_at": "2026-05-01T21:43:36.815615+00:00",
     "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-06-17"
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-embedding-exp-03-07",
+    "announcement_date": "2025-12-05",
+    "shutdown_date": "2025-10-30",
+    "deprecation_date": "2025-10-30",
+    "replacement_models": [
+      "gemini-embedding-001"
+    ],
+    "deprecation_context": "Gemini deprecations table: Embedding models. Shutdown date: 2025-10-30. Recommended replacement: gemini-embedding-001.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#embedding-models",
+    "content_hash": "d3ff4ac737be58ed",
+    "scraped_at": "2026-05-01T21:43:36.815714+00:00",
+    "first_observed": "2025-12-05",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "imagen-4.0-generate-001",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-06-24",
+    "deprecation_date": "2026-06-24",
+    "replacement_models": [
+      "gemini-3-pro-image-preview",
+      "gemini-2.5-flash-image"
+    ],
+    "deprecation_context": "Gemini deprecations table: Imagen models. Release date: 2025-06-24. Shutdown date: 2026-06-24. Recommended replacement: gemini-3-pro-image-preview, gemini-2.5-flash-image.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#imagen-models",
+    "content_hash": "0c7252b63e3ce811",
+    "scraped_at": "2026-05-01T21:43:36.815981+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "imagen-4.0-ultra-generate-001",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-06-24",
+    "deprecation_date": "2026-06-24",
+    "replacement_models": [
+      "gemini-3-pro-image-preview",
+      "gemini-2.5-flash-image"
+    ],
+    "deprecation_context": "Gemini deprecations table: Imagen models. Release date: 2025-06-24. Shutdown date: 2026-06-24. Recommended replacement: gemini-3-pro-image-preview, gemini-2.5-flash-image.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#imagen-models",
+    "content_hash": "0664f2cf2f1ba3b4",
+    "scraped_at": "2026-05-01T21:43:36.816114+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "imagen-4.0-fast-generate-001",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-06-24",
+    "deprecation_date": "2026-06-24",
+    "replacement_models": [
+      "gemini-3-pro-image-preview",
+      "gemini-2.5-flash-image"
+    ],
+    "deprecation_context": "Gemini deprecations table: Imagen models. Release date: 2025-06-24. Shutdown date: 2026-06-24. Recommended replacement: gemini-3-pro-image-preview, gemini-2.5-flash-image.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#imagen-models",
+    "content_hash": "2a9204b7421569a7",
+    "scraped_at": "2026-05-01T21:43:36.816246+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "imagen-3.0-generate-002",
+    "announcement_date": "2025-12-05",
+    "shutdown_date": "2025-11-10",
+    "deprecation_date": "2025-11-10",
+    "replacement_models": [
+      "imagen-4.0-generate-001"
+    ],
+    "deprecation_context": "Gemini deprecations table: Imagen models. Release date: 2025-02-06. Shutdown date: 2025-11-10. Recommended replacement: imagen-4.0-generate-001.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#imagen-models",
+    "content_hash": "490f9a42a3755b65",
+    "scraped_at": "2026-05-01T21:39:32.406953+00:00",
+    "first_observed": "2025-12-05",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "imagen-4.0-generate-preview-06-06",
+    "announcement_date": "2026-01-16",
+    "shutdown_date": "2026-02-17",
+    "deprecation_date": "2026-02-17",
+    "replacement_models": [
+      "imagen-4.0-generate-001"
+    ],
+    "deprecation_context": "Gemini deprecations table: Imagen models. Release date: 2025-06-24. Shutdown date: 2026-02-17. Recommended replacement: imagen-4.0-generate-001.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#imagen-models",
+    "content_hash": "971af8046555b5db",
+    "scraped_at": "2026-05-01T21:43:36.816629+00:00",
+    "first_observed": "2026-01-16",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "imagen-4.0-ultra-generate-preview-06-06",
+    "announcement_date": "2026-01-16",
+    "shutdown_date": "2026-02-17",
+    "deprecation_date": "2026-02-17",
+    "replacement_models": [
+      "imagen-4.0-ultra-generate-001"
+    ],
+    "deprecation_context": "Gemini deprecations table: Imagen models. Release date: 2025-06-24. Shutdown date: 2026-02-17. Recommended replacement: imagen-4.0-ultra-generate-001.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#imagen-models",
+    "content_hash": "daeac3d4e66242e9",
+    "scraped_at": "2026-05-01T21:43:36.816783+00:00",
+    "first_observed": "2026-01-16",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "veo-3.0-generate-preview",
+    "announcement_date": "2025-12-05",
+    "shutdown_date": "2025-11-12",
+    "deprecation_date": "2025-11-12",
+    "replacement_models": [
+      "veo-3.1-generate-preview"
+    ],
+    "deprecation_context": "Gemini deprecations table: Veo models. Release date: 2025-07-31. Shutdown date: 2025-11-12. Recommended replacement: veo-3.1-generate-preview.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#veo-models",
+    "content_hash": "d3699091e748d06c",
+    "scraped_at": "2026-05-01T21:43:36.817475+00:00",
+    "first_observed": "2025-12-05",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "veo-3.0-fast-generate-preview",
+    "announcement_date": "2025-12-05",
+    "shutdown_date": "2025-11-12",
+    "deprecation_date": "2025-11-12",
+    "replacement_models": [
+      "veo-3.1-fast-generate-preview"
+    ],
+    "deprecation_context": "Gemini deprecations table: Veo models. Release date: 2025-07-31. Shutdown date: 2025-11-12. Recommended replacement: veo-3.1-fast-generate-preview.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#veo-models",
+    "content_hash": "7a843bd1ead3ca19",
+    "scraped_at": "2026-05-01T21:43:36.817610+00:00",
+    "first_observed": "2025-12-05",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-robotics-er-1.5-preview",
+    "announcement_date": "2026-04-15",
+    "shutdown_date": "2026-04-30",
+    "deprecation_date": "2026-04-30",
+    "replacement_models": [
+      "gemini-robotics-er-1.6-preview"
+    ],
+    "deprecation_context": "Gemini deprecations table: Robotics models. Release date: 2025-09-25. Shutdown date: 2026-04-30. Recommended replacement: gemini-robotics-er-1.6-preview.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#robotics-models",
+    "content_hash": "8572e476a6dc50b4",
+    "scraped_at": "2026-05-01T21:43:36.818151+00:00",
+    "first_observed": "2026-04-15",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-2.0-flash-exp-image-generation",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2025-11-14",
+    "deprecation_date": "2025-11-11",
+    "replacement_models": null,
+    "deprecation_context": "Deprecation announcement: The following models will be shut down: November 12: veo-3.0-fast-generate-preview veo-3.0-generate-preview November 14: gemini-2.0-flash-exp-image-generation gemini-2.0-flash-preview-image-generation",
+    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251111",
+    "content_hash": "f95fc122df4b57e4",
+    "scraped_at": "2026-05-01T21:41:37.792318+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-2.5-flash-lite-preview-06-17",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2025-11-18",
+    "deprecation_date": "2025-11-04",
+    "replacement_models": null,
+    "deprecation_context": "Deprecation announcement: The following models will be shut down: November 18th: gemini-2.5-flash-lite-preview-06-17 gemini-2.5-flash-preview-05-20 December 2nd: gemini-2.0-flash-thinking-exp gemini-2.0-flash-thinking-exp-01-21 gemini-2.0-flash-thinking-exp-1219 gemini-2.5-pro-preview-03-25 gemini-2.5-pro-preview-05-06 gemini-2.5-pro-preview-06-05 December 9th: gemini-2.0-flash-lite-preview gemini-2.0-flash-lite-preview-02-05 gemini-2.0-flash-exp gemini-2.0-pro-exp gemini-2.0-pro-exp-02-05",
+    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
+    "content_hash": "297d2d7799ed7266",
+    "scraped_at": "2026-05-01T21:41:37.792860+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-2.0-flash-thinking-exp",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2025-12-02",
+    "deprecation_date": "2025-11-04",
+    "replacement_models": null,
+    "deprecation_context": "Deprecation announcement: The following models will be shut down: November 18th: gemini-2.5-flash-lite-preview-06-17 gemini-2.5-flash-preview-05-20 December 2nd: gemini-2.0-flash-thinking-exp gemini-2.0-flash-thinking-exp-01-21 gemini-2.0-flash-thinking-exp-1219 gemini-2.5-pro-preview-03-25 gemini-2.5-pro-preview-05-06 gemini-2.5-pro-preview-06-05 December 9th: gemini-2.0-flash-lite-preview gemini-2.0-flash-lite-preview-02-05 gemini-2.0-flash-exp gemini-2.0-pro-exp gemini-2.0-pro-exp-02-05",
+    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
+    "content_hash": "4999d7a107e2988a",
+    "scraped_at": "2026-05-01T21:41:37.792942+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-2.0-flash-thinking-exp-01-21",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2025-12-02",
+    "deprecation_date": "2025-11-04",
+    "replacement_models": null,
+    "deprecation_context": "Deprecation announcement: The following models will be shut down: November 18th: gemini-2.5-flash-lite-preview-06-17 gemini-2.5-flash-preview-05-20 December 2nd: gemini-2.0-flash-thinking-exp gemini-2.0-flash-thinking-exp-01-21 gemini-2.0-flash-thinking-exp-1219 gemini-2.5-pro-preview-03-25 gemini-2.5-pro-preview-05-06 gemini-2.5-pro-preview-06-05 December 9th: gemini-2.0-flash-lite-preview gemini-2.0-flash-lite-preview-02-05 gemini-2.0-flash-exp gemini-2.0-pro-exp gemini-2.0-pro-exp-02-05",
+    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
+    "content_hash": "179f6530449831a2",
+    "scraped_at": "2026-05-01T21:41:37.792951+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-2.0-flash-thinking-exp-1219",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2025-12-02",
+    "deprecation_date": "2025-11-04",
+    "replacement_models": null,
+    "deprecation_context": "Deprecation announcement: The following models will be shut down: November 18th: gemini-2.5-flash-lite-preview-06-17 gemini-2.5-flash-preview-05-20 December 2nd: gemini-2.0-flash-thinking-exp gemini-2.0-flash-thinking-exp-01-21 gemini-2.0-flash-thinking-exp-1219 gemini-2.5-pro-preview-03-25 gemini-2.5-pro-preview-05-06 gemini-2.5-pro-preview-06-05 December 9th: gemini-2.0-flash-lite-preview gemini-2.0-flash-lite-preview-02-05 gemini-2.0-flash-exp gemini-2.0-pro-exp gemini-2.0-pro-exp-02-05",
+    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
+    "content_hash": "22cd13d98890bd2f",
+    "scraped_at": "2026-05-01T21:41:37.792957+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-2.0-flash-exp",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2025-12-09",
+    "deprecation_date": "2025-11-04",
+    "replacement_models": null,
+    "deprecation_context": "Deprecation announcement: The following models will be shut down: November 18th: gemini-2.5-flash-lite-preview-06-17 gemini-2.5-flash-preview-05-20 December 2nd: gemini-2.0-flash-thinking-exp gemini-2.0-flash-thinking-exp-01-21 gemini-2.0-flash-thinking-exp-1219 gemini-2.5-pro-preview-03-25 gemini-2.5-pro-preview-05-06 gemini-2.5-pro-preview-06-05 December 9th: gemini-2.0-flash-lite-preview gemini-2.0-flash-lite-preview-02-05 gemini-2.0-flash-exp gemini-2.0-pro-exp gemini-2.0-pro-exp-02-05",
+    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
+    "content_hash": "ed83bc1c163356c0",
+    "scraped_at": "2026-05-01T21:41:37.793047+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-2.0-pro-exp",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2025-12-09",
+    "deprecation_date": "2025-11-04",
+    "replacement_models": null,
+    "deprecation_context": "Deprecation announcement: The following models will be shut down: November 18th: gemini-2.5-flash-lite-preview-06-17 gemini-2.5-flash-preview-05-20 December 2nd: gemini-2.0-flash-thinking-exp gemini-2.0-flash-thinking-exp-01-21 gemini-2.0-flash-thinking-exp-1219 gemini-2.5-pro-preview-03-25 gemini-2.5-pro-preview-05-06 gemini-2.5-pro-preview-06-05 December 9th: gemini-2.0-flash-lite-preview gemini-2.0-flash-lite-preview-02-05 gemini-2.0-flash-exp gemini-2.0-pro-exp gemini-2.0-pro-exp-02-05",
+    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
+    "content_hash": "f0f832b7736bdccd",
+    "scraped_at": "2026-05-01T21:41:37.793052+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-2.0-pro-exp-02-05",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2025-12-09",
+    "deprecation_date": "2025-11-04",
+    "replacement_models": null,
+    "deprecation_context": "Deprecation announcement: The following models will be shut down: November 18th: gemini-2.5-flash-lite-preview-06-17 gemini-2.5-flash-preview-05-20 December 2nd: gemini-2.0-flash-thinking-exp gemini-2.0-flash-thinking-exp-01-21 gemini-2.0-flash-thinking-exp-1219 gemini-2.5-pro-preview-03-25 gemini-2.5-pro-preview-05-06 gemini-2.5-pro-preview-06-05 December 9th: gemini-2.0-flash-lite-preview gemini-2.0-flash-lite-preview-02-05 gemini-2.0-flash-exp gemini-2.0-pro-exp gemini-2.0-pro-exp-02-05",
+    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
+    "content_hash": "28b9783352ec4a78",
+    "scraped_at": "2026-05-01T21:41:37.793056+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-2.5-flash-preview-native-audio-dialog",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2025-10-20",
+    "deprecation_date": "2025-10-20",
+    "replacement_models": null,
+    "deprecation_context": "The following Gemini Live API models are now shut down: gemini-2.5-flash-preview-native-audio-dialog gemini-2.5-flash-exp-native-audio-thinking-dialog You can use gemini-2.5-flash-native-audio-preview-09-2025 instead.",
+    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251020",
+    "content_hash": "10ae2df8d53261a5",
+    "scraped_at": "2026-05-01T21:41:37.793796+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-2.5-flash-exp-native-audio-thinking-dialog",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2025-10-20",
+    "deprecation_date": "2025-10-20",
+    "replacement_models": null,
+    "deprecation_context": "The following Gemini Live API models are now shut down: gemini-2.5-flash-preview-native-audio-dialog gemini-2.5-flash-exp-native-audio-thinking-dialog You can use gemini-2.5-flash-native-audio-preview-09-2025 instead.",
+    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251020",
+    "content_hash": "95fd5becec1923b7",
+    "scraped_at": "2026-05-01T21:41:37.793808+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-1.5-pro",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2025-09-29",
+    "deprecation_date": "2025-09-29",
+    "replacement_models": null,
+    "deprecation_context": "The following Gemini 1.5 models are now shut down: gemini-1.5-pro gemini-1.5-flash-8b gemini-1.5-flash",
+    "url": "https://ai.google.dev/gemini-api/docs/changelog#20250929",
+    "content_hash": "85398405d856fb29",
+    "scraped_at": "2026-05-01T21:41:37.794509+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-1.5-flash-8b",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2025-09-29",
+    "deprecation_date": "2025-09-29",
+    "replacement_models": null,
+    "deprecation_context": "The following Gemini 1.5 models are now shut down: gemini-1.5-pro gemini-1.5-flash-8b gemini-1.5-flash",
+    "url": "https://ai.google.dev/gemini-api/docs/changelog#20250929",
+    "content_hash": "aa0b855680cd8d0e",
+    "scraped_at": "2026-05-01T21:41:37.794521+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Google",
     "model_id": "gemini-1.5-flash",
-    "announcement_date": "2025-12-05",
-    "shutdown_date": "",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2025-09-29",
+    "deprecation_date": "2025-09-29",
     "replacement_models": null,
-    "deprecation_context": "The last available tuning model, Gemini 1.5 Flash 001, has been shut down.\nTuning is no longer supported on any models.\nSeeFine tuning with the Gemini API.",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20250527",
-    "content_hash": "8f9dc738c3dfd3cc",
-    "scraped_at": "2025-12-05T16:52:41.233724+00:00",
-    "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-05-27"
+    "deprecation_context": "The following Gemini 1.5 models are now shut down: gemini-1.5-pro gemini-1.5-flash-8b gemini-1.5-flash",
+    "url": "https://ai.google.dev/gemini-api/docs/changelog#20250929",
+    "content_hash": "6d3e7c4b7657ff7b",
+    "scraped_at": "2026-05-01T21:41:37.794527+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-2.5-pro-exp-03-25",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2025-06-26",
+    "deprecation_date": "2025-06-26",
+    "replacement_models": null,
+    "deprecation_context": "gemini-2.5-pro-exp-03-25 is shut down.",
+    "url": "https://ai.google.dev/gemini-api/docs/changelog#20250626",
+    "content_hash": "d49beed5b21cd203",
+    "scraped_at": "2026-05-01T21:41:37.795869+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-2.5-flash-preview-04-17",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2025-07-15",
+    "deprecation_date": "2025-06-17",
+    "replacement_models": null,
+    "deprecation_context": "Released gemini-2.5-flash , our first stable 2.5 Flash model. To learn more, see Gemini 2.5 Flash . gemini-2.5-flash-preview-04-17 will be deprecated on July 15, 2025.",
+    "url": "https://ai.google.dev/gemini-api/docs/changelog#20250617",
+    "content_hash": "83a90cc20c75a1ad",
+    "scraped_at": "2026-05-01T21:41:37.796124+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Google",
     "model_id": "gemini-1.0-pro",
-    "announcement_date": "2025-12-05",
-    "shutdown_date": "",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2025-02-18",
+    "deprecation_date": "2025-02-18",
     "replacement_models": null,
-    "deprecation_context": "Gemini 1.0 Pro is no longer supported. For the list of supported models, seeGemini models.",
+    "deprecation_context": "Gemini 1.0 Pro is no longer supported. For the list of supported models, see Gemini models .",
     "url": "https://ai.google.dev/gemini-api/docs/changelog#20250218",
-    "content_hash": "f8f77fd5aa429cef",
-    "scraped_at": "2025-12-05T16:52:41.233930+00:00",
-    "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-02-18"
+    "content_hash": "128d0f8ecb13d754",
+    "scraped_at": "2026-05-01T21:41:37.797350+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Google",
     "model_id": "gemini-1.0-pro-vision",
-    "announcement_date": "2025-12-05",
-    "shutdown_date": "",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2024-07-12",
+    "deprecation_date": "2024-07-12",
     "replacement_models": null,
     "deprecation_context": "Support for Gemini 1.0 Pro Vision removed from Google AI services and tools.",
     "url": "https://ai.google.dev/gemini-api/docs/changelog#20240712",
-    "content_hash": "2531fc166d518039",
-    "scraped_at": "2025-12-05T16:52:41.234181+00:00",
-    "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2024-07-12"
+    "content_hash": "3e1182c8c673612e",
+    "scraped_at": "2026-05-01T21:41:37.799166+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Google Vertex",
@@ -2987,6 +3459,236 @@
     "deprecation_date": "2026-01-07"
   },
   {
+    "provider": "Cohere",
+    "model_id": "embed-english-v2.0",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-04-04",
+    "deprecation_date": "2026-04-04",
+    "replacement_models": [
+      "embed-english-v3.0",
+      "embed-multilingual-v3.0",
+      "embed-v4.0"
+    ],
+    "deprecation_context": "Effective April 4th, 2026, the following models will be retired: * `embed-english-v2.0` * `embed-english-light-v2.0` * `embed-multilingual-v2.0` * `c4ai-aya-expanse-8b` * `c4ai-aya-vision-8b` We encourage you to migrate to our latest models, which offer enhanced performance, improved accuracy, and expanded capabilities: * Embedding tasks alternatives: * `embed-english-v3.0` * `embed-multilingual-v3.0` * `embed-v4.0` * Chat tasks alternatives: * `command-r7b-12-2024` * `command-a-03-2025` * `command-a-reasoning-08-2025` Our team is here to ensure a seamless transition. For questions or assistance, please don\u2019t hesitate reaching out to us at [support@cohere.com](mailto:support@cohere.com). Thank you for your continued partnership. We look forward to powering your applications with our latest AI advancements.",
+    "url": "https://docs.cohere.com/docs/deprecations#2026-04-04-embed-v2-0-aya-expanse-8b",
+    "content_hash": "e22828ef84934124",
+    "scraped_at": "2026-05-01T21:39:32.667159+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Cohere",
+    "model_id": "embed-english-light-v2.0",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-04-04",
+    "deprecation_date": "2026-04-04",
+    "replacement_models": [
+      "embed-english-v3.0",
+      "embed-multilingual-v3.0",
+      "embed-v4.0"
+    ],
+    "deprecation_context": "Effective April 4th, 2026, the following models will be retired: * `embed-english-v2.0` * `embed-english-light-v2.0` * `embed-multilingual-v2.0` * `c4ai-aya-expanse-8b` * `c4ai-aya-vision-8b` We encourage you to migrate to our latest models, which offer enhanced performance, improved accuracy, and expanded capabilities: * Embedding tasks alternatives: * `embed-english-v3.0` * `embed-multilingual-v3.0` * `embed-v4.0` * Chat tasks alternatives: * `command-r7b-12-2024` * `command-a-03-2025` * `command-a-reasoning-08-2025` Our team is here to ensure a seamless transition. For questions or assistance, please don\u2019t hesitate reaching out to us at [support@cohere.com](mailto:support@cohere.com). Thank you for your continued partnership. We look forward to powering your applications with our latest AI advancements.",
+    "url": "https://docs.cohere.com/docs/deprecations#2026-04-04-embed-v2-0-aya-expanse-8b",
+    "content_hash": "3a5d5641c008de6b",
+    "scraped_at": "2026-05-01T21:39:32.667216+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Cohere",
+    "model_id": "embed-multilingual-v2.0",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-04-04",
+    "deprecation_date": "2026-04-04",
+    "replacement_models": [
+      "embed-english-v3.0",
+      "embed-multilingual-v3.0",
+      "embed-v4.0"
+    ],
+    "deprecation_context": "Effective April 4th, 2026, the following models will be retired: * `embed-english-v2.0` * `embed-english-light-v2.0` * `embed-multilingual-v2.0` * `c4ai-aya-expanse-8b` * `c4ai-aya-vision-8b` We encourage you to migrate to our latest models, which offer enhanced performance, improved accuracy, and expanded capabilities: * Embedding tasks alternatives: * `embed-english-v3.0` * `embed-multilingual-v3.0` * `embed-v4.0` * Chat tasks alternatives: * `command-r7b-12-2024` * `command-a-03-2025` * `command-a-reasoning-08-2025` Our team is here to ensure a seamless transition. For questions or assistance, please don\u2019t hesitate reaching out to us at [support@cohere.com](mailto:support@cohere.com). Thank you for your continued partnership. We look forward to powering your applications with our latest AI advancements.",
+    "url": "https://docs.cohere.com/docs/deprecations#2026-04-04-embed-v2-0-aya-expanse-8b",
+    "content_hash": "8fd92b457a3bcc95",
+    "scraped_at": "2026-05-01T21:39:32.667257+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Cohere",
+    "model_id": "c4ai-aya-expanse-8b",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-04-04",
+    "deprecation_date": "2026-04-04",
+    "replacement_models": [
+      "command-r7b-12-2024",
+      "command-a-03-2025",
+      "command-a-reasoning-08-2025"
+    ],
+    "deprecation_context": "Effective April 4th, 2026, the following models will be retired: * `embed-english-v2.0` * `embed-english-light-v2.0` * `embed-multilingual-v2.0` * `c4ai-aya-expanse-8b` * `c4ai-aya-vision-8b` We encourage you to migrate to our latest models, which offer enhanced performance, improved accuracy, and expanded capabilities: * Embedding tasks alternatives: * `embed-english-v3.0` * `embed-multilingual-v3.0` * `embed-v4.0` * Chat tasks alternatives: * `command-r7b-12-2024` * `command-a-03-2025` * `command-a-reasoning-08-2025` Our team is here to ensure a seamless transition. For questions or assistance, please don\u2019t hesitate reaching out to us at [support@cohere.com](mailto:support@cohere.com). Thank you for your continued partnership. We look forward to powering your applications with our latest AI advancements.",
+    "url": "https://docs.cohere.com/docs/deprecations#2026-04-04-embed-v2-0-aya-expanse-8b",
+    "content_hash": "4042ca6f1e047813",
+    "scraped_at": "2026-05-01T21:39:32.667293+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Cohere",
+    "model_id": "c4ai-aya-vision-8b",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-04-04",
+    "deprecation_date": "2026-04-04",
+    "replacement_models": [
+      "command-r7b-12-2024",
+      "command-a-03-2025",
+      "command-a-reasoning-08-2025"
+    ],
+    "deprecation_context": "Effective April 4th, 2026, the following models will be retired: * `embed-english-v2.0` * `embed-english-light-v2.0` * `embed-multilingual-v2.0` * `c4ai-aya-expanse-8b` * `c4ai-aya-vision-8b` We encourage you to migrate to our latest models, which offer enhanced performance, improved accuracy, and expanded capabilities: * Embedding tasks alternatives: * `embed-english-v3.0` * `embed-multilingual-v3.0` * `embed-v4.0` * Chat tasks alternatives: * `command-r7b-12-2024` * `command-a-03-2025` * `command-a-reasoning-08-2025` Our team is here to ensure a seamless transition. For questions or assistance, please don\u2019t hesitate reaching out to us at [support@cohere.com](mailto:support@cohere.com). Thank you for your continued partnership. We look forward to powering your applications with our latest AI advancements.",
+    "url": "https://docs.cohere.com/docs/deprecations#2026-04-04-embed-v2-0-aya-expanse-8b",
+    "content_hash": "ff93362baaf77425",
+    "scraped_at": "2026-05-01T21:39:32.667327+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Cohere",
+    "model_id": "command-r-03-2024",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "",
+    "deprecation_date": "2025-09-15",
+    "replacement_models": [
+      "command-r-08-2024",
+      "command-r-plus-08-2024",
+      "command-a-03-2025"
+    ],
+    "deprecation_context": "Effective September 15, 2025, the following deprecations will roll out. Deprecated Models: * `command-r-03-2024`  (and the alias `command-r`) * `command-r-plus-04-2024`  (and the alias `command-r-plus`) * `command-light` * `command` * `summarize` (Refer to [the migration guide](https://docs.cohere.com/docs/summarizing-text#migration-from-summarize-to-chat-endpoint) for alternatives). For command model replacements, we recommend you use `command-r-08-2024`, `command-r-plus-08-2024`, or `command-a-03-2025` (which is the strongest-performing model across domains) instead. Retired Fine-Tuning Capabilities: Fine-tuning for the `command-light`, `command`, `command-r`, `classify`, and `rerank` models is being retired. This covers both the Cohere dashboard and API. Previously fine-tuned models will no longer be accessible. Deprecated Features and API Endpoints: * `/v1/connectors` (Managed connectors for RAG) * `/v1/chat` parameters: `connectors`, `search_queries_only` * `/v1/generate` (Legacy generative endpoint) * `/v1/summarize` (Legacy summarization endpoint) * `/v1/classify` * Slack App integration * Coral Web UI (chat.cohere.com and coral.cohere.com) These changes reflect our commitment to innovation and performance optimization. We encourage users to assess their current implementations and migrate to recommended alternatives. Our support team is available at [support@cohere.com](mailto:support@cohere.com) to assist with the transition. For detailed guidance, please refer to our migration resources and technical documentation.",
+    "url": "https://docs.cohere.com/docs/deprecations#2025-09-15-various-older-command-models-a-number-of-endpoints-all-of-fine-tuning",
+    "content_hash": "c49e9808e9c2d9a4",
+    "scraped_at": "2026-05-01T21:39:32.667381+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Cohere",
+    "model_id": "command-r",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "",
+    "deprecation_date": "2025-09-15",
+    "replacement_models": [
+      "command-r-08-2024",
+      "command-r-plus-08-2024",
+      "command-a-03-2025"
+    ],
+    "deprecation_context": "Effective September 15, 2025, the following deprecations will roll out. Deprecated Models: * `command-r-03-2024`  (and the alias `command-r`) * `command-r-plus-04-2024`  (and the alias `command-r-plus`) * `command-light` * `command` * `summarize` (Refer to [the migration guide](https://docs.cohere.com/docs/summarizing-text#migration-from-summarize-to-chat-endpoint) for alternatives). For command model replacements, we recommend you use `command-r-08-2024`, `command-r-plus-08-2024`, or `command-a-03-2025` (which is the strongest-performing model across domains) instead. Retired Fine-Tuning Capabilities: Fine-tuning for the `command-light`, `command`, `command-r`, `classify`, and `rerank` models is being retired. This covers both the Cohere dashboard and API. Previously fine-tuned models will no longer be accessible. Deprecated Features and API Endpoints: * `/v1/connectors` (Managed connectors for RAG) * `/v1/chat` parameters: `connectors`, `search_queries_only` * `/v1/generate` (Legacy generative endpoint) * `/v1/summarize` (Legacy summarization endpoint) * `/v1/classify` * Slack App integration * Coral Web UI (chat.cohere.com and coral.cohere.com) These changes reflect our commitment to innovation and performance optimization. We encourage users to assess their current implementations and migrate to recommended alternatives. Our support team is available at [support@cohere.com](mailto:support@cohere.com) to assist with the transition. For detailed guidance, please refer to our migration resources and technical documentation.",
+    "url": "https://docs.cohere.com/docs/deprecations#2025-09-15-various-older-command-models-a-number-of-endpoints-all-of-fine-tuning",
+    "content_hash": "77f1c626c22a5fb8",
+    "scraped_at": "2026-05-01T21:39:32.667391+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Cohere",
+    "model_id": "command-r-plus-04-2024",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "",
+    "deprecation_date": "2025-09-15",
+    "replacement_models": [
+      "command-r-08-2024",
+      "command-r-plus-08-2024",
+      "command-a-03-2025"
+    ],
+    "deprecation_context": "Effective September 15, 2025, the following deprecations will roll out. Deprecated Models: * `command-r-03-2024`  (and the alias `command-r`) * `command-r-plus-04-2024`  (and the alias `command-r-plus`) * `command-light` * `command` * `summarize` (Refer to [the migration guide](https://docs.cohere.com/docs/summarizing-text#migration-from-summarize-to-chat-endpoint) for alternatives). For command model replacements, we recommend you use `command-r-08-2024`, `command-r-plus-08-2024`, or `command-a-03-2025` (which is the strongest-performing model across domains) instead. Retired Fine-Tuning Capabilities: Fine-tuning for the `command-light`, `command`, `command-r`, `classify`, and `rerank` models is being retired. This covers both the Cohere dashboard and API. Previously fine-tuned models will no longer be accessible. Deprecated Features and API Endpoints: * `/v1/connectors` (Managed connectors for RAG) * `/v1/chat` parameters: `connectors`, `search_queries_only` * `/v1/generate` (Legacy generative endpoint) * `/v1/summarize` (Legacy summarization endpoint) * `/v1/classify` * Slack App integration * Coral Web UI (chat.cohere.com and coral.cohere.com) These changes reflect our commitment to innovation and performance optimization. We encourage users to assess their current implementations and migrate to recommended alternatives. Our support team is available at [support@cohere.com](mailto:support@cohere.com) to assist with the transition. For detailed guidance, please refer to our migration resources and technical documentation.",
+    "url": "https://docs.cohere.com/docs/deprecations#2025-09-15-various-older-command-models-a-number-of-endpoints-all-of-fine-tuning",
+    "content_hash": "5fe9a262b5c7bfaa",
+    "scraped_at": "2026-05-01T21:39:32.667396+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Cohere",
+    "model_id": "command-r-plus",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "",
+    "deprecation_date": "2025-09-15",
+    "replacement_models": [
+      "command-r-08-2024",
+      "command-r-plus-08-2024",
+      "command-a-03-2025"
+    ],
+    "deprecation_context": "Effective September 15, 2025, the following deprecations will roll out. Deprecated Models: * `command-r-03-2024`  (and the alias `command-r`) * `command-r-plus-04-2024`  (and the alias `command-r-plus`) * `command-light` * `command` * `summarize` (Refer to [the migration guide](https://docs.cohere.com/docs/summarizing-text#migration-from-summarize-to-chat-endpoint) for alternatives). For command model replacements, we recommend you use `command-r-08-2024`, `command-r-plus-08-2024`, or `command-a-03-2025` (which is the strongest-performing model across domains) instead. Retired Fine-Tuning Capabilities: Fine-tuning for the `command-light`, `command`, `command-r`, `classify`, and `rerank` models is being retired. This covers both the Cohere dashboard and API. Previously fine-tuned models will no longer be accessible. Deprecated Features and API Endpoints: * `/v1/connectors` (Managed connectors for RAG) * `/v1/chat` parameters: `connectors`, `search_queries_only` * `/v1/generate` (Legacy generative endpoint) * `/v1/summarize` (Legacy summarization endpoint) * `/v1/classify` * Slack App integration * Coral Web UI (chat.cohere.com and coral.cohere.com) These changes reflect our commitment to innovation and performance optimization. We encourage users to assess their current implementations and migrate to recommended alternatives. Our support team is available at [support@cohere.com](mailto:support@cohere.com) to assist with the transition. For detailed guidance, please refer to our migration resources and technical documentation.",
+    "url": "https://docs.cohere.com/docs/deprecations#2025-09-15-various-older-command-models-a-number-of-endpoints-all-of-fine-tuning",
+    "content_hash": "fa8450ce908c56a3",
+    "scraped_at": "2026-05-01T21:39:32.667401+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Cohere",
+    "model_id": "command-light",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "",
+    "deprecation_date": "2025-09-15",
+    "replacement_models": [
+      "command-r-08-2024",
+      "command-r-plus-08-2024",
+      "command-a-03-2025"
+    ],
+    "deprecation_context": "Effective September 15, 2025, the following deprecations will roll out. Deprecated Models: * `command-r-03-2024`  (and the alias `command-r`) * `command-r-plus-04-2024`  (and the alias `command-r-plus`) * `command-light` * `command` * `summarize` (Refer to [the migration guide](https://docs.cohere.com/docs/summarizing-text#migration-from-summarize-to-chat-endpoint) for alternatives). For command model replacements, we recommend you use `command-r-08-2024`, `command-r-plus-08-2024`, or `command-a-03-2025` (which is the strongest-performing model across domains) instead. Retired Fine-Tuning Capabilities: Fine-tuning for the `command-light`, `command`, `command-r`, `classify`, and `rerank` models is being retired. This covers both the Cohere dashboard and API. Previously fine-tuned models will no longer be accessible. Deprecated Features and API Endpoints: * `/v1/connectors` (Managed connectors for RAG) * `/v1/chat` parameters: `connectors`, `search_queries_only` * `/v1/generate` (Legacy generative endpoint) * `/v1/summarize` (Legacy summarization endpoint) * `/v1/classify` * Slack App integration * Coral Web UI (chat.cohere.com and coral.cohere.com) These changes reflect our commitment to innovation and performance optimization. We encourage users to assess their current implementations and migrate to recommended alternatives. Our support team is available at [support@cohere.com](mailto:support@cohere.com) to assist with the transition. For detailed guidance, please refer to our migration resources and technical documentation.",
+    "url": "https://docs.cohere.com/docs/deprecations#2025-09-15-various-older-command-models-a-number-of-endpoints-all-of-fine-tuning",
+    "content_hash": "3dd7dfbe6e9b5f6c",
+    "scraped_at": "2026-05-01T21:39:32.667406+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Cohere",
+    "model_id": "command",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "",
+    "deprecation_date": "2025-09-15",
+    "replacement_models": [
+      "command-r-08-2024",
+      "command-r-plus-08-2024",
+      "command-a-03-2025"
+    ],
+    "deprecation_context": "Effective September 15, 2025, the following deprecations will roll out. Deprecated Models: * `command-r-03-2024`  (and the alias `command-r`) * `command-r-plus-04-2024`  (and the alias `command-r-plus`) * `command-light` * `command` * `summarize` (Refer to [the migration guide](https://docs.cohere.com/docs/summarizing-text#migration-from-summarize-to-chat-endpoint) for alternatives). For command model replacements, we recommend you use `command-r-08-2024`, `command-r-plus-08-2024`, or `command-a-03-2025` (which is the strongest-performing model across domains) instead. Retired Fine-Tuning Capabilities: Fine-tuning for the `command-light`, `command`, `command-r`, `classify`, and `rerank` models is being retired. This covers both the Cohere dashboard and API. Previously fine-tuned models will no longer be accessible. Deprecated Features and API Endpoints: * `/v1/connectors` (Managed connectors for RAG) * `/v1/chat` parameters: `connectors`, `search_queries_only` * `/v1/generate` (Legacy generative endpoint) * `/v1/summarize` (Legacy summarization endpoint) * `/v1/classify` * Slack App integration * Coral Web UI (chat.cohere.com and coral.cohere.com) These changes reflect our commitment to innovation and performance optimization. We encourage users to assess their current implementations and migrate to recommended alternatives. Our support team is available at [support@cohere.com](mailto:support@cohere.com) to assist with the transition. For detailed guidance, please refer to our migration resources and technical documentation.",
+    "url": "https://docs.cohere.com/docs/deprecations#2025-09-15-various-older-command-models-a-number-of-endpoints-all-of-fine-tuning",
+    "content_hash": "292d47b466348948",
+    "scraped_at": "2026-05-01T21:39:32.667410+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Cohere",
+    "model_id": "rerank-english-v2.0",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2025-04-30",
+    "deprecation_date": "2024-12-02",
+    "replacement_models": [
+      "rerank-v3.5"
+    ],
+    "deprecation_context": "On December 2nd, 2024, we announced the release of Rerank-v3.5 along with the deprecation of the Rerank-v2.0 model family. Fine-tuned models created from these base models are not affected by this deprecation. | Shutdown Date | Deprecated Model           | Deprecated Model Price | Recommended Replacement | | ------------- | -------------------------- | ---------------------- | ----------------------- | | 2025-04-30    | `rerank-english-v2.0`      | \\$1.00 / 1K searches   | `rerank-v3.5`           | | 2025-04-30    | `rerank-multilingual-v2.0` | \\$1.00 / 1K searches   | `rerank-v3.5`           | # Best Practices: 1. Regularly check our documentation for updates on announcements regarding the status of models. 2. Test applications with newer models well before the shutdown date of your current model. 3. Update any production code to use an active model as soon as possible. 4. Contact [support@cohere.ai](mailto:support@cohere.ai) if you need any assistance with migration or have any questions.",
+    "url": "https://docs.cohere.com/docs/deprecations#2024-12-02-rerank-v2-0",
+    "content_hash": "8514ec8565d5661f",
+    "scraped_at": "2026-05-01T21:39:32.667519+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Cohere",
+    "model_id": "rerank-multilingual-v2.0",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2025-04-30",
+    "deprecation_date": "2024-12-02",
+    "replacement_models": [
+      "rerank-v3.5"
+    ],
+    "deprecation_context": "On December 2nd, 2024, we announced the release of Rerank-v3.5 along with the deprecation of the Rerank-v2.0 model family. Fine-tuned models created from these base models are not affected by this deprecation. | Shutdown Date | Deprecated Model           | Deprecated Model Price | Recommended Replacement | | ------------- | -------------------------- | ---------------------- | ----------------------- | | 2025-04-30    | `rerank-english-v2.0`      | \\$1.00 / 1K searches   | `rerank-v3.5`           | | 2025-04-30    | `rerank-multilingual-v2.0` | \\$1.00 / 1K searches   | `rerank-v3.5`           | # Best Practices: 1. Regularly check our documentation for updates on announcements regarding the status of models. 2. Test applications with newer models well before the shutdown date of your current model. 3. Update any production code to use an active model as soon as possible. 4. Contact [support@cohere.ai](mailto:support@cohere.ai) if you need any assistance with migration or have any questions.",
+    "url": "https://docs.cohere.com/docs/deprecations#2024-12-02-rerank-v2-0",
+    "content_hash": "d6c535dc8fc536cb",
+    "scraped_at": "2026-05-01T21:39:32.667541+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
     "provider": "Azure",
     "model_id": "codex-mini",
     "announcement_date": "2026-04-25",
@@ -3120,15 +3822,15 @@
     "provider": "Azure",
     "model_id": "gpt-4o-transcribe-diarize",
     "announcement_date": "2026-04-25",
-    "shutdown_date": "2027-04-16",
-    "deprecation_date": "2027-04-16",
+    "shutdown_date": "2026-10-15",
+    "deprecation_date": "2026-10-15",
     "replacement_models": null,
     "deprecation_context": "Azure OpenAI",
     "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
-    "content_hash": "ae02ba4e5f42c80b",
-    "scraped_at": "2026-04-25T04:37:34.697793+00:00",
+    "content_hash": "b170b46eb302432c",
+    "scraped_at": "2026-05-01T21:39:32.794046+00:00",
     "first_observed": "2026-04-25",
-    "last_observed": "2026-04-25"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Azure",
@@ -3148,17 +3850,17 @@
     "provider": "Azure",
     "model_id": "gpt-5-chat",
     "announcement_date": "2026-04-25",
-    "shutdown_date": "2026-05-13",
-    "deprecation_date": "2026-05-13",
+    "shutdown_date": "2026-06-09",
+    "deprecation_date": "2026-06-09",
     "replacement_models": [
       "gpt-5.3-chat"
     ],
     "deprecation_context": "Azure OpenAI",
     "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
-    "content_hash": "accf6b6d5cb420b0",
-    "scraped_at": "2026-04-25T04:37:34.697899+00:00",
+    "content_hash": "6ade3ca1c8539bcc",
+    "scraped_at": "2026-05-01T21:39:32.794174+00:00",
     "first_observed": "2026-04-25",
-    "last_observed": "2026-04-25"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Azure",
@@ -3234,17 +3936,17 @@
     "provider": "Azure",
     "model_id": "gpt-5.1-chat",
     "announcement_date": "2026-04-25",
-    "shutdown_date": "2026-05-13",
-    "deprecation_date": "2026-05-13",
+    "shutdown_date": "2026-06-09",
+    "deprecation_date": "2026-06-09",
     "replacement_models": [
       "gpt-5.3-chat"
     ],
     "deprecation_context": "Azure OpenAI",
     "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
-    "content_hash": "e28d78c89b9e71b2",
-    "scraped_at": "2026-04-25T04:37:34.698274+00:00",
+    "content_hash": "ea6dd1af0ebbe8ee",
+    "scraped_at": "2026-05-01T21:39:32.794622+00:00",
     "first_observed": "2026-04-25",
-    "last_observed": "2026-04-25"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Azure",
@@ -3306,17 +4008,17 @@
     "provider": "Azure",
     "model_id": "gpt-5.2-chat",
     "announcement_date": "2026-04-25",
-    "shutdown_date": "2026-05-13",
-    "deprecation_date": "2026-05-13",
+    "shutdown_date": "2026-06-09",
+    "deprecation_date": "2026-06-09",
     "replacement_models": [
       "gpt-5.3-chat"
     ],
     "deprecation_context": "Azure OpenAI",
     "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
-    "content_hash": "c334c11ca689daeb",
-    "scraped_at": "2026-04-25T04:37:34.698534+00:00",
+    "content_hash": "e2c11ecce76c11fe",
+    "scraped_at": "2026-05-01T21:39:32.794939+00:00",
     "first_observed": "2026-04-25",
-    "last_observed": "2026-04-25"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Azure",
@@ -3336,15 +4038,15 @@
     "provider": "Azure",
     "model_id": "gpt-5.3-chat",
     "announcement_date": "2026-04-25",
-    "shutdown_date": "2026-06-03",
-    "deprecation_date": "2026-06-03",
+    "shutdown_date": "2026-06-09",
+    "deprecation_date": "2026-06-09",
     "replacement_models": null,
     "deprecation_context": "Azure OpenAI",
     "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
-    "content_hash": "6bd863f35eb4c576",
-    "scraped_at": "2026-04-25T04:37:34.698723+00:00",
+    "content_hash": "0c46900e355ddc84",
+    "scraped_at": "2026-05-01T21:39:32.795129+00:00",
     "first_observed": "2026-04-25",
-    "last_observed": "2026-04-25"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Azure",
@@ -3462,15 +4164,15 @@
     "provider": "Azure",
     "model_id": "gpt-audio-mini",
     "announcement_date": "2026-04-25",
-    "shutdown_date": "2027-04-07",
-    "deprecation_date": "2027-04-07",
+    "shutdown_date": "2026-07-23",
+    "deprecation_date": "2026-07-23",
     "replacement_models": null,
     "deprecation_context": "Azure OpenAI",
     "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
-    "content_hash": "70d512379d4d005b",
-    "scraped_at": "2026-04-25T04:37:34.699132+00:00",
+    "content_hash": "2edcfbcaf3436a25",
+    "scraped_at": "2026-05-01T21:39:32.795695+00:00",
     "first_observed": "2026-04-25",
-    "last_observed": "2026-04-25"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Azure",
@@ -3560,15 +4262,15 @@
     "provider": "Azure",
     "model_id": "gpt-realtime-mini",
     "announcement_date": "2026-04-25",
-    "shutdown_date": "2027-04-07",
-    "deprecation_date": "2027-04-07",
+    "shutdown_date": "2026-07-23",
+    "deprecation_date": "2026-07-23",
     "replacement_models": null,
     "deprecation_context": "Azure OpenAI",
     "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
-    "content_hash": "ccc7c5c25ea6d587",
-    "scraped_at": "2026-04-25T04:37:34.699510+00:00",
+    "content_hash": "1e5794106bddf9ef",
+    "scraped_at": "2026-05-01T21:39:32.796194+00:00",
     "first_observed": "2026-04-25",
-    "last_observed": "2026-04-25"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Azure",
@@ -3716,43 +4418,43 @@
     "provider": "Azure",
     "model_id": "tts",
     "announcement_date": "2026-04-25",
-    "shutdown_date": "2026-06-18",
-    "deprecation_date": "2026-06-18",
+    "shutdown_date": "2026-12-15",
+    "deprecation_date": "2026-12-15",
     "replacement_models": null,
     "deprecation_context": "Azure OpenAI",
     "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
-    "content_hash": "5d94bac6e93772dd",
-    "scraped_at": "2026-04-25T04:37:34.700273+00:00",
+    "content_hash": "d6ea8347c42ce73b",
+    "scraped_at": "2026-05-01T21:39:32.797034+00:00",
     "first_observed": "2026-04-25",
-    "last_observed": "2026-04-25"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Azure",
     "model_id": "tts-hd",
     "announcement_date": "2026-04-25",
-    "shutdown_date": "2026-06-18",
-    "deprecation_date": "2026-06-18",
+    "shutdown_date": "2026-12-15",
+    "deprecation_date": "2026-12-15",
     "replacement_models": null,
     "deprecation_context": "Azure OpenAI",
     "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
-    "content_hash": "a2d02a168c0318f5",
-    "scraped_at": "2026-04-25T04:37:34.700324+00:00",
+    "content_hash": "8624b76057618bb1",
+    "scraped_at": "2026-05-01T21:39:32.797099+00:00",
     "first_observed": "2026-04-25",
-    "last_observed": "2026-04-25"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Azure",
     "model_id": "whisper",
     "announcement_date": "2026-04-25",
-    "shutdown_date": "2026-06-18",
-    "deprecation_date": "2026-06-18",
+    "shutdown_date": "2026-12-15",
+    "deprecation_date": "2026-12-15",
     "replacement_models": null,
     "deprecation_context": "Azure OpenAI",
     "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
-    "content_hash": "9f9b4c57b0441f07",
-    "scraped_at": "2026-04-25T04:37:34.700376+00:00",
+    "content_hash": "84ed70b66ac134fe",
+    "scraped_at": "2026-05-01T21:39:32.797163+00:00",
     "first_observed": "2026-04-25",
-    "last_observed": "2026-04-25"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Azure",
@@ -3932,6 +4634,20 @@
   },
   {
     "provider": "Azure",
+    "model_id": "claude-opus-4-7",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2027-04-06",
+    "deprecation_date": "2027-04-06",
+    "replacement_models": null,
+    "deprecation_context": "Anthropic",
+    "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
+    "content_hash": "fb8e0fdd4ec9403c",
+    "scraped_at": "2026-05-01T21:39:32.800598+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Azure",
     "model_id": "claude-sonnet-4-5",
     "announcement_date": "2026-04-28",
     "shutdown_date": "2026-10-19",
@@ -4002,6 +4718,188 @@
     "scraped_at": "2026-04-25T04:37:34.703256+00:00",
     "first_observed": "2026-01-14",
     "last_observed": "2026-04-25"
+  },
+  {
+    "provider": "Azure",
+    "model_id": "FW-DeepSeek-V3.1",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-07-01",
+    "deprecation_date": "2026-07-01",
+    "replacement_models": null,
+    "deprecation_context": "Fireworks",
+    "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
+    "content_hash": "47c61306de0f7c29",
+    "scraped_at": "2026-05-01T21:39:32.801413+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Azure",
+    "model_id": "FW-DeepSeek-V3.2",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-07-01",
+    "deprecation_date": "2026-07-01",
+    "replacement_models": null,
+    "deprecation_context": "Fireworks",
+    "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
+    "content_hash": "de3d993e0e491ef2",
+    "scraped_at": "2026-05-01T21:39:32.801476+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Azure",
+    "model_id": "FW-GLM-4.7",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-07-01",
+    "deprecation_date": "2026-07-01",
+    "replacement_models": null,
+    "deprecation_context": "Fireworks",
+    "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
+    "content_hash": "4674d6265f93c4d5",
+    "scraped_at": "2026-05-01T21:39:32.801536+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Azure",
+    "model_id": "FW-GLM-5",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-07-01",
+    "deprecation_date": "2026-07-01",
+    "replacement_models": null,
+    "deprecation_context": "Fireworks",
+    "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
+    "content_hash": "35ff79076ee598ae",
+    "scraped_at": "2026-05-01T21:39:32.801595+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Azure",
+    "model_id": "FW-GLM-5.1",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-08-01",
+    "deprecation_date": "2026-08-01",
+    "replacement_models": null,
+    "deprecation_context": "Fireworks",
+    "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
+    "content_hash": "d522400ec22c2de1",
+    "scraped_at": "2026-05-01T21:39:32.801653+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Azure",
+    "model_id": "FW-GPT-OSS-120B",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-07-01",
+    "deprecation_date": "2026-07-01",
+    "replacement_models": null,
+    "deprecation_context": "Fireworks",
+    "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
+    "content_hash": "d22c3645f6d920bd",
+    "scraped_at": "2026-05-01T21:39:32.801715+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Azure",
+    "model_id": "FW-Kimi-K2-Instruct-0905",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-07-01",
+    "deprecation_date": "2026-07-01",
+    "replacement_models": null,
+    "deprecation_context": "Fireworks",
+    "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
+    "content_hash": "59867fc88f0a8c64",
+    "scraped_at": "2026-05-01T21:39:32.801775+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Azure",
+    "model_id": "FW-Kimi-K2-Thinking",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-07-01",
+    "deprecation_date": "2026-07-01",
+    "replacement_models": null,
+    "deprecation_context": "Fireworks",
+    "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
+    "content_hash": "773f34089d9a1de5",
+    "scraped_at": "2026-05-01T21:39:32.801836+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Azure",
+    "model_id": "FW-Kimi-K2.5",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-07-01",
+    "deprecation_date": "2026-07-01",
+    "replacement_models": null,
+    "deprecation_context": "Fireworks",
+    "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
+    "content_hash": "1a0b72abe90ea1ac",
+    "scraped_at": "2026-05-01T21:39:32.801894+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Azure",
+    "model_id": "FW-MiniMax-M2.5",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-07-01",
+    "deprecation_date": "2026-07-01",
+    "replacement_models": null,
+    "deprecation_context": "Fireworks",
+    "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
+    "content_hash": "06f1b846459620d9",
+    "scraped_at": "2026-05-01T21:39:32.801954+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Azure",
+    "model_id": "FW-Qwen3-14B",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-07-01",
+    "deprecation_date": "2026-07-01",
+    "replacement_models": null,
+    "deprecation_context": "Fireworks",
+    "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
+    "content_hash": "9569939a11856ce9",
+    "scraped_at": "2026-05-01T21:39:32.802011+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Azure",
+    "model_id": "FW-Qwen3.5-122B-A10B",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-08-01",
+    "deprecation_date": "2026-08-01",
+    "replacement_models": null,
+    "deprecation_context": "Fireworks",
+    "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
+    "content_hash": "cc6aadfb65addaa2",
+    "scraped_at": "2026-05-01T21:39:32.802070+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Azure",
+    "model_id": "FW-Qwen3.5-397B-A17B",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-08-01",
+    "deprecation_date": "2026-08-01",
+    "replacement_models": null,
+    "deprecation_context": "Fireworks",
+    "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
+    "content_hash": "41b70573625bb563",
+    "scraped_at": "2026-05-01T21:39:32.802131+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Azure",

--- a/docs/v1/deprecations.json
+++ b/docs/v1/deprecations.json
@@ -5,13 +5,31 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-07-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "5.4-mini"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "ef67ac992153d5f0",
-    "scraped_at": "2026-04-23T04:51:54.525170+00:00",
+    "scraped_at": "2026-05-01T21:39:21.868836+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "OpenAI",
+    "model_id": "computer-use-preview",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-07-23",
+    "deprecation_date": "2026-04-22",
+    "replacement_models": [
+      "5.4-mini"
+    ],
+    "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
+    "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
+    "content_hash": "bcf7d1748d204634",
+    "scraped_at": "2026-05-01T21:39:21.868877+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -19,13 +37,15 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-07-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-audio"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "6e559087aa9f66be",
-    "scraped_at": "2026-04-23T04:51:54.525206+00:00",
+    "scraped_at": "2026-05-01T21:39:21.868910+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -33,13 +53,15 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-07-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-audio"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "947035e404950459",
-    "scraped_at": "2026-04-23T04:51:54.525228+00:00",
+    "scraped_at": "2026-05-01T21:39:21.868932+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -47,13 +69,15 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-07-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-realtime-mini"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "90fd9b271351e489",
-    "scraped_at": "2026-04-23T04:51:54.525243+00:00",
+    "scraped_at": "2026-05-01T21:39:21.868951+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -61,13 +85,15 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-07-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "4.1-mini"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "54b1bd491d30bc72",
-    "scraped_at": "2026-04-23T04:51:54.525273+00:00",
+    "scraped_at": "2026-05-01T21:39:21.868968+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -75,13 +101,15 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-07-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-realtime"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "46f8ed5a5fd3c799",
-    "scraped_at": "2026-04-23T04:51:54.525284+00:00",
+    "scraped_at": "2026-05-01T21:39:21.868985+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -89,13 +117,15 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-07-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-4.1-mini"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "ab799d88d4bb3448",
-    "scraped_at": "2026-04-23T04:51:54.525295+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869000+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -103,13 +133,15 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-07-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-5.3-chat-latest"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "94b9bd980083e8ec",
-    "scraped_at": "2026-04-23T04:51:54.525314+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869016+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -117,13 +149,15 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-07-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-5.4"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "e1162ef1e18b042c",
-    "scraped_at": "2026-04-23T04:51:54.525329+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869031+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -131,13 +165,15 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-07-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-5.3-chat-latest"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "a02dc956835f75af",
-    "scraped_at": "2026-04-23T04:51:54.525340+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869046+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -145,13 +181,15 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-07-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-5"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "00f5c58b4da9ca88",
-    "scraped_at": "2026-04-23T04:51:54.525351+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869061+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -159,13 +197,15 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-07-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-5.4"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "395fbef9211a3706",
-    "scraped_at": "2026-04-23T04:51:54.525361+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869077+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -173,13 +213,15 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-07-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-5.4-mini"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "2c68ded2a590010e",
-    "scraped_at": "2026-04-23T04:51:54.525371+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869092+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -187,13 +229,15 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-07-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-audio"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "e902de424f32319a",
-    "scraped_at": "2026-04-23T04:51:54.525381+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869106+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -201,13 +245,15 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-07-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-realtime-mini"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "d94d349c7530e67c",
-    "scraped_at": "2026-04-23T04:51:54.525391+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869126+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -215,13 +261,31 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-07-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "5.4-Pro"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "3027ab0668ff7684",
-    "scraped_at": "2026-04-23T04:51:54.525400+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869144+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "OpenAI",
+    "model_id": "o3-deep-research",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-07-23",
+    "deprecation_date": "2026-04-22",
+    "replacement_models": [
+      "5.4-Pro"
+    ],
+    "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
+    "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
+    "content_hash": "2fb2f1948cb5f40c",
+    "scraped_at": "2026-05-01T21:39:21.869150+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -229,13 +293,31 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-07-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "5.4-Pro"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "d78cfac58c61f716",
-    "scraped_at": "2026-04-23T04:51:54.525409+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869166+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "OpenAI",
+    "model_id": "o4-mini-deep-research",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-07-23",
+    "deprecation_date": "2026-04-22",
+    "replacement_models": [
+      "5.4-Pro"
+    ],
+    "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
+    "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
+    "content_hash": "0935d48962005eb2",
+    "scraped_at": "2026-05-01T21:39:21.869172+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -243,13 +325,15 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-07-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-5.4"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "6bfc76fde10da4e4",
-    "scraped_at": "2026-04-23T04:51:54.525419+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869186+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -257,13 +341,47 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-10-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-4.1-mini"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "0dcdb171408e9370",
-    "scraped_at": "2026-04-23T04:51:54.525428+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869204+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "OpenAI",
+    "model_id": "gpt-3.5-turbo",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-10-23",
+    "deprecation_date": "2026-04-22",
+    "replacement_models": [
+      "gpt-4.1-mini"
+    ],
+    "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
+    "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
+    "content_hash": "f63778b2618b8631",
+    "scraped_at": "2026-05-01T21:39:21.869210+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "OpenAI",
+    "model_id": "gpt-3.5-turbo-completions",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-10-23",
+    "deprecation_date": "2026-04-22",
+    "replacement_models": [
+      "gpt-4.1-mini"
+    ],
+    "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
+    "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
+    "content_hash": "46bd24227d34b521",
+    "scraped_at": "2026-05-01T21:39:21.869214+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -271,13 +389,63 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-10-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-4.1"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "18a2fc1ab49d3146",
-    "scraped_at": "2026-04-23T04:51:54.525437+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869274+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "OpenAI",
+    "model_id": "gpt-4",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-10-23",
+    "deprecation_date": "2026-04-22",
+    "replacement_models": [
+      "gpt-4.1"
+    ],
+    "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
+    "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
+    "content_hash": "b1cf8fa52f11e1a8",
+    "scraped_at": "2026-05-01T21:39:21.869293+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "OpenAI",
+    "model_id": "gpt-4-0613-completions",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-10-23",
+    "deprecation_date": "2026-04-22",
+    "replacement_models": [
+      "gpt-4.1"
+    ],
+    "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
+    "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
+    "content_hash": "ba38613e6dede54f",
+    "scraped_at": "2026-05-01T21:39:21.869302+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "OpenAI",
+    "model_id": "gpt-4-completions",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-10-23",
+    "deprecation_date": "2026-04-22",
+    "replacement_models": [
+      "gpt-4.1"
+    ],
+    "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
+    "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
+    "content_hash": "09d420371810c007",
+    "scraped_at": "2026-05-01T21:39:21.869308+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -285,13 +453,15 @@
     "announcement_date": "2026-03-26",
     "shutdown_date": "2026-10-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-4.1"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "0cd83d946b9ac51a",
-    "scraped_at": "2026-04-23T04:51:54.525446+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869329+00:00",
     "first_observed": "2026-03-26",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -299,13 +469,47 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-10-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-4.1"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "3ec298b507c96fa1",
-    "scraped_at": "2026-04-23T04:51:54.525455+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869350+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "OpenAI",
+    "model_id": "gpt-4-turbo-2024-04-09",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-10-23",
+    "deprecation_date": "2026-04-22",
+    "replacement_models": [
+      "gpt-4.1"
+    ],
+    "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
+    "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
+    "content_hash": "13705242151f2e9d",
+    "scraped_at": "2026-05-01T21:39:21.869362+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "OpenAI",
+    "model_id": "gpt-4-turbo-completions",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-10-23",
+    "deprecation_date": "2026-04-22",
+    "replacement_models": [
+      "gpt-4.1"
+    ],
+    "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
+    "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
+    "content_hash": "c37dc59f9011d275",
+    "scraped_at": "2026-05-01T21:39:21.869450+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -313,13 +517,31 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-10-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-5-nano"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "3c4ce71e3a1d5d92",
-    "scraped_at": "2026-04-23T04:51:54.525464+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869494+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "OpenAI",
+    "model_id": "gpt-4.1-nano-2025-04-14",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-10-23",
+    "deprecation_date": "2026-04-22",
+    "replacement_models": [
+      "gpt-5-nano"
+    ],
+    "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
+    "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
+    "content_hash": "2a982d793b6b8f0c",
+    "scraped_at": "2026-05-01T21:39:21.869503+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -327,13 +549,15 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-10-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-4.1"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "7adaafff1d94c1f9",
-    "scraped_at": "2026-04-23T04:51:54.525473+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869524+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -341,13 +565,15 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-10-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-image-1.5"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "55a981c6faea7977",
-    "scraped_at": "2026-04-23T04:51:54.525487+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869547+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -355,13 +581,31 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-10-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "o3"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "6cce9cef09ff6992",
-    "scraped_at": "2026-04-23T04:51:54.525496+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869568+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "OpenAI",
+    "model_id": "o1",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-10-23",
+    "deprecation_date": "2026-04-22",
+    "replacement_models": [
+      "o3"
+    ],
+    "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
+    "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
+    "content_hash": "b822aec1c97a54fd",
+    "scraped_at": "2026-05-01T21:39:21.869574+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -369,13 +613,31 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-10-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "5.4-Pro"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "f9b5ac3f2401b58f",
-    "scraped_at": "2026-04-23T04:51:54.525506+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869591+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "OpenAI",
+    "model_id": "o1-pro",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-10-23",
+    "deprecation_date": "2026-04-22",
+    "replacement_models": [
+      "5.4-Pro"
+    ],
+    "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
+    "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
+    "content_hash": "8f44100a18b4417b",
+    "scraped_at": "2026-05-01T21:39:21.869596+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -383,13 +645,31 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-10-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "o3"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "8e25665c4346d538",
-    "scraped_at": "2026-04-23T04:51:54.525515+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869612+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "OpenAI",
+    "model_id": "o3-mini",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-10-23",
+    "deprecation_date": "2026-04-22",
+    "replacement_models": [
+      "o3"
+    ],
+    "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
+    "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
+    "content_hash": "776618f6972a36aa",
+    "scraped_at": "2026-05-01T21:39:21.869618+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -397,13 +677,15 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-10-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-5-mini"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "10e24c5e1850759e",
-    "scraped_at": "2026-04-23T04:51:54.525524+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869633+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -411,13 +693,31 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-10-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-5-mini"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "7ed63fc9f3f95dbc",
-    "scraped_at": "2026-04-23T04:51:54.525533+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869648+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "OpenAI",
+    "model_id": "o4-mini",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-10-23",
+    "deprecation_date": "2026-04-22",
+    "replacement_models": [
+      "gpt-5-mini"
+    ],
+    "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
+    "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
+    "content_hash": "2b348b0f1d565845",
+    "scraped_at": "2026-05-01T21:39:21.869654+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -425,13 +725,15 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-10-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-4.1-mini"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "56cccd7d42d33e7b",
-    "scraped_at": "2026-04-23T04:51:54.525557+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869737+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -439,13 +741,15 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-10-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-4.1"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "afeb72021dd9dfb9",
-    "scraped_at": "2026-04-23T04:51:54.525567+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869755+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -453,13 +757,15 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-10-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-5-nano"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "e0f4d75398046174",
-    "scraped_at": "2026-04-23T04:51:54.525577+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869771+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -467,13 +773,15 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-10-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-5-mini"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "875b4a305dc7e676",
-    "scraped_at": "2026-04-23T04:51:54.525586+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869786+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -481,93 +789,85 @@
     "announcement_date": "2026-04-23",
     "shutdown_date": "2026-10-23",
     "deprecation_date": "2026-04-22",
-    "replacement_models": null,
+    "replacement_models": [
+      "gpt-5-mini"
+    ],
     "deprecation_context": "To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.",
     "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
     "content_hash": "47779aff2ec07bfe",
-    "scraped_at": "2026-04-23T04:51:54.525595+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869800+00:00",
     "first_observed": "2026-04-23",
-    "last_observed": "2026-04-23"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
     "model_id": "sora-2",
     "announcement_date": "2026-03-27",
     "shutdown_date": "2026-09-24",
-    "replacement_models": [
-      "---"
-    ],
+    "deprecation_date": "2026-03-24",
+    "replacement_models": null,
     "deprecation_context": "On March 24th, 2026, we notified developers using the Videos API and Sora 2 video generation model aliases and snapshots of their deprecation and removal from the API on September 24, 2026.",
     "url": "https://platform.openai.com/docs/deprecations#2026-03-24-sora-2-video-generation-models-and-videos-api",
     "content_hash": "fe4030bdd7c7cacf",
-    "scraped_at": "2026-03-27T04:35:42.378612+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869964+00:00",
     "first_observed": "2026-03-27",
-    "last_observed": "2026-03-27",
-    "deprecation_date": "2026-03-24"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
     "model_id": "sora-2-pro",
     "announcement_date": "2026-03-27",
     "shutdown_date": "2026-09-24",
-    "replacement_models": [
-      "---"
-    ],
+    "deprecation_date": "2026-03-24",
+    "replacement_models": null,
     "deprecation_context": "On March 24th, 2026, we notified developers using the Videos API and Sora 2 video generation model aliases and snapshots of their deprecation and removal from the API on September 24, 2026.",
     "url": "https://platform.openai.com/docs/deprecations#2026-03-24-sora-2-video-generation-models-and-videos-api",
     "content_hash": "2b9043d1aa5d2a95",
-    "scraped_at": "2026-03-27T04:35:42.378649+00:00",
+    "scraped_at": "2026-05-01T21:39:21.869986+00:00",
     "first_observed": "2026-03-27",
-    "last_observed": "2026-03-27",
-    "deprecation_date": "2026-03-24"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
     "model_id": "sora-2-2025-10-06",
     "announcement_date": "2026-03-27",
     "shutdown_date": "2026-09-24",
-    "replacement_models": [
-      "---"
-    ],
+    "deprecation_date": "2026-03-24",
+    "replacement_models": null,
     "deprecation_context": "On March 24th, 2026, we notified developers using the Videos API and Sora 2 video generation model aliases and snapshots of their deprecation and removal from the API on September 24, 2026.",
     "url": "https://platform.openai.com/docs/deprecations#2026-03-24-sora-2-video-generation-models-and-videos-api",
     "content_hash": "1515760838a34125",
-    "scraped_at": "2026-03-27T04:35:42.378673+00:00",
+    "scraped_at": "2026-05-01T21:39:21.870005+00:00",
     "first_observed": "2026-03-27",
-    "last_observed": "2026-03-27",
-    "deprecation_date": "2026-03-24"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
     "model_id": "sora-2-2025-12-08",
     "announcement_date": "2026-03-27",
     "shutdown_date": "2026-09-24",
-    "replacement_models": [
-      "---"
-    ],
+    "deprecation_date": "2026-03-24",
+    "replacement_models": null,
     "deprecation_context": "On March 24th, 2026, we notified developers using the Videos API and Sora 2 video generation model aliases and snapshots of their deprecation and removal from the API on September 24, 2026.",
     "url": "https://platform.openai.com/docs/deprecations#2026-03-24-sora-2-video-generation-models-and-videos-api",
     "content_hash": "1d50d8b250da24a7",
-    "scraped_at": "2026-03-27T04:35:42.378692+00:00",
+    "scraped_at": "2026-05-01T21:39:21.870021+00:00",
     "first_observed": "2026-03-27",
-    "last_observed": "2026-03-27",
-    "deprecation_date": "2026-03-24"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
     "model_id": "sora-2-pro-2025-10-06",
     "announcement_date": "2026-03-27",
     "shutdown_date": "2026-09-24",
-    "replacement_models": [
-      "---"
-    ],
+    "deprecation_date": "2026-03-24",
+    "replacement_models": null,
     "deprecation_context": "On March 24th, 2026, we notified developers using the Videos API and Sora 2 video generation model aliases and snapshots of their deprecation and removal from the API on September 24, 2026.",
     "url": "https://platform.openai.com/docs/deprecations#2026-03-24-sora-2-video-generation-models-and-videos-api",
     "content_hash": "cc702b0e0fe4a5c5",
-    "scraped_at": "2026-03-27T04:35:42.378709+00:00",
+    "scraped_at": "2026-05-01T21:39:21.870035+00:00",
     "first_observed": "2026-03-27",
-    "last_observed": "2026-03-27",
-    "deprecation_date": "2026-03-24"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "OpenAI",
@@ -1925,646 +2225,818 @@
   },
   {
     "provider": "Google",
-    "model_id": "gemini-robotics-er-1.6-preview",
-    "announcement_date": "2026-04-15",
-    "shutdown_date": "",
-    "deprecation_date": "2026-04-14",
-    "replacement_models": null,
-    "deprecation_context": "Released gemini-robotics-er-1.6-preview , our updated robotics model.\nIt now has new capabilities like instrument reading, improved spatial and\nphysical reasoning capabilities. To learn more, see Gemini Robotics-ER page and the blog .",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20260414",
-    "content_hash": "8bd769e777bca254",
-    "scraped_at": "2026-04-15T04:47:23.808563+00:00",
-    "first_observed": "2026-04-15",
-    "last_observed": "2026-04-15"
-  },
-  {
-    "provider": "Google",
-    "model_id": "gemini-robotics-er-1.5-preview",
-    "announcement_date": "2026-04-15",
-    "shutdown_date": "",
-    "deprecation_date": "2026-04-14",
-    "replacement_models": null,
-    "deprecation_context": "Deprecation announcement: The gemini-robotics-er-1.5-preview model\nwill be shut down on April 30, 2026 at 9AM\nPST.",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20260414",
-    "content_hash": "0736e81a21067282",
-    "scraped_at": "2026-04-15T04:47:23.808648+00:00",
-    "first_observed": "2026-04-15",
-    "last_observed": "2026-04-15"
-  },
-  {
-    "provider": "Google",
-    "model_id": "gemini-embedding-2-preview",
-    "announcement_date": "2026-03-12",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "Released gemini-embedding-2-preview , our first multimodal embedding model.\nIt supports text, image, video, audio, and PDF inputs,\nmapping all modalities into a unified embedding space. To learn more, see Embeddings .",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20260310",
-    "content_hash": "604343c746f293f5",
-    "scraped_at": "2026-03-12T04:07:19.839599+00:00",
-    "first_observed": "2026-03-12",
-    "last_observed": "2026-03-12",
-    "deprecation_date": "2026-03-10"
-  },
-  {
-    "provider": "Google",
-    "model_id": "gemini-2.5-flash-lite-preview-09-2025",
-    "announcement_date": "2026-03-12",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "Deprecation announcement: The gemini-2.5-flash-lite-preview-09-2025 model\nwill be shut down on March 31, 2026.",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20260310",
-    "content_hash": "c2dcde220fb02fab",
-    "scraped_at": "2026-03-12T04:07:19.839689+00:00",
-    "first_observed": "2026-03-12",
-    "last_observed": "2026-03-12",
-    "deprecation_date": "2026-03-10"
-  },
-  {
-    "provider": "Google",
     "model_id": "gemini-3-pro-preview",
     "announcement_date": "2026-02-27",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "Deprecation announcement: Gemini 3 Pro Preview ( gemini-3-pro-preview )\nwill be shut down March 9, 2026.",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20260226",
-    "content_hash": "d3c4f9815f87ea3b",
-    "scraped_at": "2026-02-27T04:06:58.664291+00:00",
-    "first_observed": "2026-02-27",
-    "last_observed": "2026-02-27",
-    "deprecation_date": "2026-02-26"
-  },
-  {
-    "provider": "Google",
-    "model_id": "gemini-2.0-flash",
-    "announcement_date": "2026-02-20",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "Deprecation announcement: The following models will be shut down June 1, 2026: gemini-2.0-flash gemini-2.0-flash-001 gemini-2.0-flash-lite gemini-2.0-flash-lite-001",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20260218",
-    "content_hash": "889ed6ddbeaafb68",
-    "scraped_at": "2026-02-20T04:09:02.875598+00:00",
-    "first_observed": "2026-02-20",
-    "last_observed": "2026-02-20",
-    "deprecation_date": "2026-02-18"
-  },
-  {
-    "provider": "Google",
-    "model_id": "gemini-2.0-flash-001",
-    "announcement_date": "2026-02-20",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "Deprecation announcement: The following models will be shut down June 1, 2026: gemini-2.0-flash gemini-2.0-flash-001 gemini-2.0-flash-lite gemini-2.0-flash-lite-001",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20260218",
-    "content_hash": "2847532834f9d9e1",
-    "scraped_at": "2026-02-20T04:09:02.875718+00:00",
-    "first_observed": "2026-02-20",
-    "last_observed": "2026-02-20",
-    "deprecation_date": "2026-02-18"
-  },
-  {
-    "provider": "Google",
-    "model_id": "gemini-2.0-flash-lite",
-    "announcement_date": "2026-02-20",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "Deprecation announcement: The following models will be shut down June 1, 2026: gemini-2.0-flash gemini-2.0-flash-001 gemini-2.0-flash-lite gemini-2.0-flash-lite-001",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20260218",
-    "content_hash": "f2696084dbec3762",
-    "scraped_at": "2026-02-20T04:09:02.875804+00:00",
-    "first_observed": "2026-02-20",
-    "last_observed": "2026-02-20",
-    "deprecation_date": "2026-02-18"
-  },
-  {
-    "provider": "Google",
-    "model_id": "gemini-2.0-flash-lite-001",
-    "announcement_date": "2026-02-20",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "Deprecation announcement: The following models will be shut down June 1, 2026: gemini-2.0-flash gemini-2.0-flash-001 gemini-2.0-flash-lite gemini-2.0-flash-lite-001",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20260218",
-    "content_hash": "2351ca191e09f807",
-    "scraped_at": "2026-02-20T04:09:02.875883+00:00",
-    "first_observed": "2026-02-20",
-    "last_observed": "2026-02-20",
-    "deprecation_date": "2026-02-18"
-  },
-  {
-    "provider": "Google",
-    "model_id": "gemini-2.5-flash-preview-09-25",
-    "announcement_date": "2026-01-16",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "gemini-2.5-flash-preview-09-25",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20260115",
-    "content_hash": "fe1c89e97d73d1dd",
-    "scraped_at": "2026-01-16T03:24:29.958726+00:00",
-    "summary": "Insufficient information provided in the deprecation notice to complete analysis.",
-    "first_observed": "2026-01-16",
-    "last_observed": "2026-01-16",
-    "raw_content": "",
-    "content": "Insufficient information provided in the deprecation notice to complete analysis.",
-    "deprecation_date": "2026-01-15"
-  },
-  {
-    "provider": "Google",
-    "model_id": "imagen-4.0-generate-preview-06-06",
-    "announcement_date": "2026-01-16",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "imagen-4.0-generate-preview-06-06",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20260115",
-    "content_hash": "977571ca9e68cea8",
-    "scraped_at": "2026-01-16T03:24:29.958876+00:00",
-    "summary": "Insufficient information provided in the deprecation notice. Unable to extract specific details about model deprecation.",
-    "first_observed": "2026-01-16",
-    "last_observed": "2026-01-16",
-    "raw_content": "",
-    "content": "Insufficient information provided in the deprecation notice. Unable to extract specific details about model deprecation.",
-    "deprecation_date": "2026-01-15"
-  },
-  {
-    "provider": "Google",
-    "model_id": "imagen-4.0-ultra-generate-preview-06-06",
-    "announcement_date": "2026-01-16",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "imagen-4.0-ultra-generate-preview-06-06",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20260115",
-    "content_hash": "ef075c84f9cd6743",
-    "scraped_at": "2026-01-16T03:24:29.958925+00:00",
-    "summary": "Insufficient information provided in the deprecation notice to extract specific details.",
-    "first_observed": "2026-01-16",
-    "last_observed": "2026-01-16",
-    "raw_content": "",
-    "content": "Insufficient information provided in the deprecation notice to extract specific details.",
-    "deprecation_date": "2026-01-15"
-  },
-  {
-    "provider": "Google",
-    "model_id": "gemini-2.5-flash-image-preview",
-    "announcement_date": "2026-03-26",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "The gemini-2.5-flash-image-preview model has been shut down.",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20260115",
-    "content_hash": "46d302343637e255",
-    "scraped_at": "2026-03-26T13:07:23.859614+00:00",
-    "first_observed": "2026-03-26",
-    "last_observed": "2026-03-26",
-    "deprecation_date": "2026-01-15"
-  },
-  {
-    "provider": "Google",
-    "model_id": "veo-3.0-fast-generate-preview",
-    "announcement_date": "2025-12-05",
-    "shutdown_date": "2025-11-12",
-    "replacement_models": null,
-    "deprecation_context": "November 12: veo-3.0-fast-generate-preview veo-3.0-generate-preview",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251111",
-    "content_hash": "7477153d2249a270",
-    "scraped_at": "2025-12-05T16:52:41.232765+00:00",
-    "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-11-11"
-  },
-  {
-    "provider": "Google",
-    "model_id": "veo-3.0-generate-preview",
-    "announcement_date": "2025-12-05",
-    "shutdown_date": "2025-11-12",
-    "replacement_models": null,
-    "deprecation_context": "November 12: veo-3.0-fast-generate-preview veo-3.0-generate-preview",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251111",
-    "content_hash": "d74290d51e2b341e",
-    "scraped_at": "2025-12-05T16:52:41.232794+00:00",
-    "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-11-11"
-  },
-  {
-    "provider": "Google",
-    "model_id": "gemini-2.0-flash-exp-image-generation",
-    "announcement_date": "2025-12-05",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "gemini-2.0-flash-exp-image-generation",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251111",
-    "content_hash": "833d13ab0f88083b",
-    "scraped_at": "2025-12-05T16:52:41.232807+00:00",
-    "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-11-11"
-  },
-  {
-    "provider": "Google",
-    "model_id": "gemini-2.0-flash-preview-image-generation",
-    "announcement_date": "2025-12-05",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "gemini-2.0-flash-preview-image-generation",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251111",
-    "content_hash": "4a56ce13c77ab958",
-    "scraped_at": "2025-12-05T16:52:41.232818+00:00",
-    "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-11-11"
-  },
-  {
-    "provider": "Google",
-    "model_id": "imagen-3.0-generate-002",
-    "announcement_date": "2025-12-05",
-    "shutdown_date": "",
+    "shutdown_date": "2026-03-09",
+    "deprecation_date": "2026-03-09",
     "replacement_models": [
-      "imagen 4"
+      "gemini-3.1-pro-preview"
     ],
-    "deprecation_context": "The following model is shut down: imagen-3.0-generate-002 Use Imagen 4 instead. Refer to the Gemini deprecations table for more details.",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251110",
-    "content_hash": "428594f26fdaa768",
-    "scraped_at": "2025-12-05T16:52:41.232888+00:00",
-    "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-11-10"
+    "deprecation_context": "Gemini deprecations table: Gemini 3 models. Release date: 2025-11-18. Shutdown date: 2026-03-09. Recommended replacement: gemini-3.1-pro-preview.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-3-models",
+    "content_hash": "3f157fb9c4faef2d",
+    "scraped_at": "2026-05-01T21:43:36.810852+00:00",
+    "first_observed": "2026-02-27",
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Google",
-    "model_id": "gemini-2.5-flash-lite-preview-06-17",
+    "model_id": "gemini-2.5-pro",
     "announcement_date": "2025-12-05",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "gemini-2.5-flash-lite-preview-06-17",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
-    "content_hash": "f45c36e3fb9e800b",
-    "scraped_at": "2025-12-05T16:52:41.232941+00:00",
+    "shutdown_date": "2026-06-17",
+    "deprecation_date": "2026-06-17",
+    "replacement_models": [
+      "gemini-3.1-pro-preview"
+    ],
+    "deprecation_context": "Gemini deprecations table: Gemini 2.5 Pro models. Release date: 2025-06-17. Shutdown date: 2026-06-17. Recommended replacement: gemini-3.1-pro-preview.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.5-pro-models",
+    "content_hash": "05ef1fab10b274d9",
+    "scraped_at": "2026-05-01T21:43:36.811332+00:00",
     "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-11-04"
-  },
-  {
-    "provider": "Google",
-    "model_id": "gemini-2.5-flash-preview-05-20",
-    "announcement_date": "2025-12-05",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "gemini-2.5-flash-preview-05-20",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
-    "content_hash": "0bf60925c7f70027",
-    "scraped_at": "2025-12-05T16:52:41.232953+00:00",
-    "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-11-04"
-  },
-  {
-    "provider": "Google",
-    "model_id": "gemini-2.0-flash-thinking-exp",
-    "announcement_date": "2025-12-05",
-    "shutdown_date": "2025-12-02",
-    "replacement_models": null,
-    "deprecation_context": "December 2nd: gemini-2.0-flash-thinking-exp gemini-2.0-flash-thinking-exp-01-21 gemini-2.0-flash-thinking-exp-1219 gemini-2.5-pro-preview-03-25 gemini-2.5-pro-preview-05-06 gemini-2.5-pro-preview-06-05",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
-    "content_hash": "4999d7a107e2988a",
-    "scraped_at": "2025-12-05T16:52:41.232981+00:00",
-    "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-11-04"
-  },
-  {
-    "provider": "Google",
-    "model_id": "gemini-2.0-flash-thinking-exp-01-21",
-    "announcement_date": "2025-12-05",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "gemini-2.0-flash-thinking-exp-01-21",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
-    "content_hash": "09f03046955ec872",
-    "scraped_at": "2025-12-05T16:52:41.232993+00:00",
-    "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-11-04"
-  },
-  {
-    "provider": "Google",
-    "model_id": "gemini-2.0-flash-thinking-exp-1219",
-    "announcement_date": "2025-12-05",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "gemini-2.0-flash-thinking-exp-1219",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
-    "content_hash": "9b00e199081bdc1f",
-    "scraped_at": "2025-12-05T16:52:41.233003+00:00",
-    "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-11-04"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Google",
     "model_id": "gemini-2.5-pro-preview-03-25",
     "announcement_date": "2025-12-05",
     "shutdown_date": "2025-12-02",
-    "replacement_models": null,
-    "deprecation_context": "December 2nd: gemini-2.0-flash-thinking-exp gemini-2.0-flash-thinking-exp-01-21 gemini-2.0-flash-thinking-exp-1219 gemini-2.5-pro-preview-03-25 gemini-2.5-pro-preview-05-06 gemini-2.5-pro-preview-06-05",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
-    "content_hash": "942d02346fd8d63d",
-    "scraped_at": "2025-12-05T16:52:41.233029+00:00",
+    "deprecation_date": "2025-12-02",
+    "replacement_models": [
+      "gemini-3.1-pro-preview"
+    ],
+    "deprecation_context": "Gemini deprecations table: Gemini 2.5 Pro models. Release date: 2025-03-03. Shutdown date: 2025-12-02. Recommended replacement: gemini-3.1-pro-preview.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.5-pro-models",
+    "content_hash": "fcf9f4824ea77b2d",
+    "scraped_at": "2026-05-01T21:43:36.811516+00:00",
     "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-11-04"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Google",
     "model_id": "gemini-2.5-pro-preview-05-06",
     "announcement_date": "2025-12-05",
     "shutdown_date": "2025-12-02",
-    "replacement_models": null,
-    "deprecation_context": "December 2nd: gemini-2.0-flash-thinking-exp gemini-2.0-flash-thinking-exp-01-21 gemini-2.0-flash-thinking-exp-1219 gemini-2.5-pro-preview-03-25 gemini-2.5-pro-preview-05-06 gemini-2.5-pro-preview-06-05",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
-    "content_hash": "f3d8530a217ebf75",
-    "scraped_at": "2025-12-05T16:52:41.233055+00:00",
+    "deprecation_date": "2025-12-02",
+    "replacement_models": [
+      "gemini-3.1-pro-preview"
+    ],
+    "deprecation_context": "Gemini deprecations table: Gemini 2.5 Pro models. Release date: 2025-05-06. Shutdown date: 2025-12-02. Recommended replacement: gemini-3.1-pro-preview.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.5-pro-models",
+    "content_hash": "8354c3046da9f72f",
+    "scraped_at": "2026-05-01T21:43:36.811657+00:00",
     "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-11-04"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Google",
     "model_id": "gemini-2.5-pro-preview-06-05",
     "announcement_date": "2025-12-05",
     "shutdown_date": "2025-12-02",
-    "replacement_models": null,
-    "deprecation_context": "December 2nd: gemini-2.0-flash-thinking-exp gemini-2.0-flash-thinking-exp-01-21 gemini-2.0-flash-thinking-exp-1219 gemini-2.5-pro-preview-03-25 gemini-2.5-pro-preview-05-06 gemini-2.5-pro-preview-06-05",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
-    "content_hash": "7fa76fe7274e3106",
-    "scraped_at": "2025-12-05T16:52:41.233079+00:00",
+    "deprecation_date": "2025-12-02",
+    "replacement_models": [
+      "gemini-3.1-pro-preview"
+    ],
+    "deprecation_context": "Gemini deprecations table: Gemini 2.5 Pro models. Release date: 2025-06-05. Shutdown date: 2025-12-02. Recommended replacement: gemini-3.1-pro-preview.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.5-pro-models",
+    "content_hash": "25eef711a126c99f",
+    "scraped_at": "2026-05-01T21:43:36.811794+00:00",
     "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-11-04"
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-2.5-flash",
+    "announcement_date": "2025-12-05",
+    "shutdown_date": "2026-06-17",
+    "deprecation_date": "2026-06-17",
+    "replacement_models": [
+      "gemini-3-flash-preview"
+    ],
+    "deprecation_context": "Gemini deprecations table: Gemini 2.5 Flash models. Release date: 2025-06-17. Shutdown date: 2026-06-17. Recommended replacement: gemini-3-flash-preview.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.5-flash-models",
+    "content_hash": "0b1eb669860c5edf",
+    "scraped_at": "2026-05-01T21:43:36.812091+00:00",
+    "first_observed": "2025-12-05",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-2.5-flash-image",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-10-02",
+    "deprecation_date": "2026-10-02",
+    "replacement_models": [
+      "gemini-3.1-flash-image-preview"
+    ],
+    "deprecation_context": "Gemini deprecations table: Gemini 2.5 Flash models. Release date: 2025-10-02. Shutdown date: 2026-10-02. Recommended replacement: gemini-3.1-flash-image-preview.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.5-flash-models",
+    "content_hash": "da1b0e80f4ab45da",
+    "scraped_at": "2026-05-01T21:43:36.812255+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-2.5-flash-lite",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-07-22",
+    "deprecation_date": "2026-07-22",
+    "replacement_models": [
+      "gemini-3.1-flash-lite-preview"
+    ],
+    "deprecation_context": "Gemini deprecations table: Gemini 2.5 Flash models. Release date: 2025-07-22. Shutdown date: 2026-07-22. Recommended replacement: gemini-3.1-flash-lite-preview.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.5-flash-models",
+    "content_hash": "d505ac64b7fea2e1",
+    "scraped_at": "2026-05-01T21:43:36.812419+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-2.5-flash-lite-preview-09-2025",
+    "announcement_date": "2026-03-12",
+    "shutdown_date": "2026-03-31",
+    "deprecation_date": "2026-03-31",
+    "replacement_models": [
+      "gemini-3.1-flash-lite-preview"
+    ],
+    "deprecation_context": "Gemini deprecations table: Gemini 2.5 Flash models. Release date: 2025-09-25. Shutdown date: 2026-03-31. Recommended replacement: gemini-3.1-flash-lite-preview.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.5-flash-models",
+    "content_hash": "1e48a972a96a0345",
+    "scraped_at": "2026-05-01T21:43:36.812586+00:00",
+    "first_observed": "2026-03-12",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-2.5-flash-preview-05-20",
+    "announcement_date": "2025-12-05",
+    "shutdown_date": "2025-11-18",
+    "deprecation_date": "2025-11-18",
+    "replacement_models": [
+      "gemini-3-flash-preview"
+    ],
+    "deprecation_context": "Gemini deprecations table: Gemini 2.5 Flash models. Release date: 2025-05-20. Shutdown date: 2025-11-18. Recommended replacement: gemini-3-flash-preview.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.5-flash-models",
+    "content_hash": "b44520f661ca01b1",
+    "scraped_at": "2026-05-01T21:43:36.812719+00:00",
+    "first_observed": "2025-12-05",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-2.5-flash-image-preview",
+    "announcement_date": "2026-03-26",
+    "shutdown_date": "2026-01-15",
+    "deprecation_date": "2026-01-15",
+    "replacement_models": [
+      "gemini-2.5-flash-image"
+    ],
+    "deprecation_context": "Gemini deprecations table: Gemini 2.5 Flash models. Release date: 2025-05-07. Shutdown date: 2026-01-15. Recommended replacement: gemini-2.5-flash-image.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.5-flash-models",
+    "content_hash": "50ebd7c8c1faa535",
+    "scraped_at": "2026-05-01T21:39:32.402819+00:00",
+    "first_observed": "2026-03-26",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-2.5-flash-preview-09-25",
+    "announcement_date": "2026-01-16",
+    "shutdown_date": "2026-02-17",
+    "deprecation_date": "2026-02-17",
+    "replacement_models": [
+      "gemini-3-flash-preview"
+    ],
+    "deprecation_context": "Gemini deprecations table: Gemini 2.5 Flash models. Release date: 2025-09-25. Shutdown date: 2026-02-17. Recommended replacement: gemini-3-flash-preview.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.5-flash-models",
+    "content_hash": "f3d2383e375ba0c3",
+    "scraped_at": "2026-05-01T21:43:36.812991+00:00",
+    "first_observed": "2026-01-16",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-2.0-flash",
+    "announcement_date": "2026-02-20",
+    "shutdown_date": "2026-06-01",
+    "deprecation_date": "2026-06-01",
+    "replacement_models": [
+      "gemini-2.5-flash"
+    ],
+    "deprecation_context": "Gemini deprecations table: Gemini 2.0 models. Release date: 2025-02-05. Shutdown date: 2026-06-01. Recommended replacement: gemini-2.5-flash.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.0-models",
+    "content_hash": "37959faf4dadf47e",
+    "scraped_at": "2026-05-01T21:43:36.813281+00:00",
+    "first_observed": "2026-02-20",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-2.0-flash-001",
+    "announcement_date": "2026-02-20",
+    "shutdown_date": "2026-06-01",
+    "deprecation_date": "2026-06-01",
+    "replacement_models": [
+      "gemini-2.5-flash"
+    ],
+    "deprecation_context": "Gemini deprecations table: Gemini 2.0 models. Release date: 2025-02-05. Shutdown date: 2026-06-01. Recommended replacement: gemini-2.5-flash.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.0-models",
+    "content_hash": "4e70bbd684dd1268",
+    "scraped_at": "2026-05-01T21:43:36.813411+00:00",
+    "first_observed": "2026-02-20",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-2.0-flash-lite",
+    "announcement_date": "2026-02-20",
+    "shutdown_date": "2026-06-01",
+    "deprecation_date": "2026-06-01",
+    "replacement_models": [
+      "gemini-2.5-flash-lite"
+    ],
+    "deprecation_context": "Gemini deprecations table: Gemini 2.0 models. Release date: 2025-02-25. Shutdown date: 2026-06-01. Recommended replacement: gemini-2.5-flash-lite.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.0-models",
+    "content_hash": "3c27622388237fce",
+    "scraped_at": "2026-05-01T21:43:36.813544+00:00",
+    "first_observed": "2026-02-20",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-2.0-flash-lite-001",
+    "announcement_date": "2026-02-20",
+    "shutdown_date": "2026-06-01",
+    "deprecation_date": "2026-06-01",
+    "replacement_models": [
+      "gemini-2.5-flash-lite"
+    ],
+    "deprecation_context": "Gemini deprecations table: Gemini 2.0 models. Release date: 2025-02-25. Shutdown date: 2026-06-01. Recommended replacement: gemini-2.5-flash-lite.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.0-models",
+    "content_hash": "ced31dc8fffd254e",
+    "scraped_at": "2026-05-01T21:43:36.813674+00:00",
+    "first_observed": "2026-02-20",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-2.0-flash-preview-image-generation",
+    "announcement_date": "2025-12-05",
+    "shutdown_date": "2025-11-14",
+    "deprecation_date": "2025-11-14",
+    "replacement_models": [
+      "gemini-2.5-flash-image"
+    ],
+    "deprecation_context": "Gemini deprecations table: Gemini 2.0 models. Release date: 2025-05-07. Shutdown date: 2025-11-14. Recommended replacement: gemini-2.5-flash-image.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.0-models",
+    "content_hash": "f94b5ad701ee2c22",
+    "scraped_at": "2026-05-01T21:43:36.813829+00:00",
+    "first_observed": "2025-12-05",
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Google",
     "model_id": "gemini-2.0-flash-lite-preview",
     "announcement_date": "2026-03-26",
     "shutdown_date": "2025-12-09",
-    "replacement_models": null,
-    "deprecation_context": "December 9th: gemini-2.0-flash-lite-preview gemini-2.0-flash-lite-preview-02-05 gemini-2.0-flash-exp gemini-2.0-pro-exp gemini-2.0-pro-exp-02-05",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
-    "content_hash": "34626f312f5ab436",
-    "scraped_at": "2026-03-26T13:07:23.861760+00:00",
+    "deprecation_date": "2025-12-09",
+    "replacement_models": [
+      "gemini-2.5-flash-lite"
+    ],
+    "deprecation_context": "Gemini deprecations table: Gemini 2.0 models. Release date: 2025-02-05. Shutdown date: 2025-12-09. Recommended replacement: gemini-2.5-flash-lite.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.0-models",
+    "content_hash": "7d1bdcef07c402ae",
+    "scraped_at": "2026-05-01T21:43:36.813956+00:00",
     "first_observed": "2026-03-26",
-    "last_observed": "2026-03-26",
-    "deprecation_date": "2025-11-04"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Google",
     "model_id": "gemini-2.0-flash-lite-preview-02-05",
     "announcement_date": "2025-12-05",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "gemini-2.0-flash-lite-preview-02-05",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
-    "content_hash": "3362915ce2b590bd",
-    "scraped_at": "2025-12-05T16:52:41.233112+00:00",
-    "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-11-04"
-  },
-  {
-    "provider": "Google",
-    "model_id": "gemini-2.0-flash-exp",
-    "announcement_date": "2026-01-29",
     "shutdown_date": "2025-12-09",
-    "replacement_models": null,
-    "deprecation_context": "December 9th: gemini-2.0-flash-lite-preview gemini-2.0-flash-lite-preview-02-05 gemini-2.0-flash-exp gemini-2.0-pro-exp gemini-2.0-pro-exp-02-05",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
-    "content_hash": "ed83bc1c163356c0",
-    "scraped_at": "2026-01-29T04:02:00.403641+00:00",
-    "first_observed": "2026-01-29",
-    "last_observed": "2026-01-29",
-    "deprecation_date": "2025-11-04"
-  },
-  {
-    "provider": "Google",
-    "model_id": "gemini-2.0-pro-exp",
-    "announcement_date": "2026-01-29",
-    "shutdown_date": "2025-12-09",
-    "replacement_models": null,
-    "deprecation_context": "December 9th: gemini-2.0-flash-lite-preview gemini-2.0-flash-lite-preview-02-05 gemini-2.0-flash-exp gemini-2.0-pro-exp gemini-2.0-pro-exp-02-05",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
-    "content_hash": "f0f832b7736bdccd",
-    "scraped_at": "2026-01-29T04:02:00.403734+00:00",
-    "first_observed": "2026-01-29",
-    "last_observed": "2026-01-29",
-    "deprecation_date": "2025-11-04"
-  },
-  {
-    "provider": "Google",
-    "model_id": "gemini-2.0-pro-exp-02-05",
-    "announcement_date": "2026-01-29",
-    "shutdown_date": "2025-12-09",
-    "replacement_models": null,
-    "deprecation_context": "December 9th: gemini-2.0-flash-lite-preview gemini-2.0-flash-lite-preview-02-05 gemini-2.0-flash-exp gemini-2.0-pro-exp gemini-2.0-pro-exp-02-05",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
-    "content_hash": "28b9783352ec4a78",
-    "scraped_at": "2026-01-29T04:02:00.403817+00:00",
-    "first_observed": "2026-01-29",
-    "last_observed": "2026-01-29",
-    "deprecation_date": "2025-11-04"
-  },
-  {
-    "provider": "Google",
-    "model_id": "gemini-2.5-flash-preview-native-audio-dialog",
-    "announcement_date": "2025-12-05",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "gemini-2.5-flash-preview-native-audio-dialog",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251020",
-    "content_hash": "a6db09acf9586d17",
-    "scraped_at": "2025-12-05T16:52:41.233151+00:00",
-    "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-10-20"
-  },
-  {
-    "provider": "Google",
-    "model_id": "gemini-2.5-flash-exp-native-audio-thinking-dialog",
-    "announcement_date": "2025-12-05",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "gemini-2.5-flash-exp-native-audio-thinking-dialog",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251020",
-    "content_hash": "d653454cc95f2094",
-    "scraped_at": "2025-12-05T16:52:41.233162+00:00",
-    "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-10-20"
-  },
-  {
-    "provider": "Google",
-    "model_id": "gemini-2.5-flash-native-audio-preview-09-2025",
-    "announcement_date": "2025-12-05",
-    "shutdown_date": "",
+    "deprecation_date": "2025-12-09",
     "replacement_models": [
-      "gemini-2.5-flash-native-audio-preview-09-2025"
+      "gemini-2.5-flash-lite"
     ],
-    "deprecation_context": "You can use gemini-2.5-flash-native-audio-preview-09-2025 instead.",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251020",
-    "content_hash": "940f19fd10e7c46b",
-    "scraped_at": "2025-12-05T16:52:41.233176+00:00",
+    "deprecation_context": "Gemini deprecations table: Gemini 2.0 models. Release date: 2025-02-05. Shutdown date: 2025-12-09. Recommended replacement: gemini-2.5-flash-lite.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.0-models",
+    "content_hash": "8a725acd38d9859c",
+    "scraped_at": "2026-05-01T21:43:36.814091+00:00",
     "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-10-20"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Google",
     "model_id": "gemini-2.0-flash-live-001",
     "announcement_date": "2025-12-05",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "Deprecation announcement: Shut down for gemini-2.0-flash-live-001 and gemini-live-2.5-flash-preview coming December 09, 2025.",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251020",
-    "content_hash": "61cc267215361e67",
-    "scraped_at": "2025-12-05T16:52:41.233192+00:00",
+    "shutdown_date": "2025-12-09",
+    "deprecation_date": "2025-12-09",
+    "replacement_models": [
+      "gemini-3.1-flash-live-preview"
+    ],
+    "deprecation_context": "Gemini deprecations table: Live API models. Release date: 2025-04-09. Shutdown date: 2025-12-09. Recommended replacement: gemini-3.1-flash-live-preview.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#live-api-models",
+    "content_hash": "1281b430644aa797",
+    "scraped_at": "2026-05-01T21:43:36.814360+00:00",
     "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-10-20"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Google",
     "model_id": "gemini-live-2.5-flash-preview",
     "announcement_date": "2025-12-05",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "Deprecation announcement: Shut down for gemini-2.0-flash-live-001 and gemini-live-2.5-flash-preview coming December 09, 2025.",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251020",
-    "content_hash": "7348812caddd830f",
-    "scraped_at": "2025-12-05T16:52:41.233205+00:00",
+    "shutdown_date": "2025-12-09",
+    "deprecation_date": "2025-12-09",
+    "replacement_models": [
+      "gemini-3.1-flash-live-preview"
+    ],
+    "deprecation_context": "Gemini deprecations table: Live API models. Release date: 2025-06-17. Shutdown date: 2025-12-09. Recommended replacement: gemini-3.1-flash-live-preview.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#live-api-models",
+    "content_hash": "10a243f5fa902758",
+    "scraped_at": "2026-05-01T21:43:36.814597+00:00",
     "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-10-20"
-  },
-  {
-    "provider": "Google",
-    "model_id": "gemini-embedding-exp-03-07",
-    "announcement_date": "2025-12-05",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "gemini-embedding-exp-03-07 ( gemini-embedding-exp )",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20250916",
-    "content_hash": "f19ba4ca0f34fc6a",
-    "scraped_at": "2025-12-05T16:52:41.233344+00:00",
-    "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-09-16"
-  },
-  {
-    "provider": "Google",
-    "model_id": "gemini-embedding-exp",
-    "announcement_date": "2025-12-05",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "gemini-embedding-exp-03-07 ( gemini-embedding-exp )",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20250916",
-    "content_hash": "f2377e29f3dca6ba",
-    "scraped_at": "2025-12-05T16:52:41.233356+00:00",
-    "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-09-16"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Google",
     "model_id": "gemini-embedding-001",
     "announcement_date": "2025-12-05",
-    "shutdown_date": "",
+    "shutdown_date": "2026-07-14",
+    "deprecation_date": "2026-07-14",
     "replacement_models": null,
-    "deprecation_context": "Released gemini-embedding-001 , the stable version of our\ntext embedding model. To learn more, see embeddings . The gemini-embedding-exp-03-07 model will be deprecated on August 14, 2025.",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20250714",
-    "content_hash": "6e276cebfb8270f4",
-    "scraped_at": "2025-12-05T16:52:41.233467+00:00",
+    "deprecation_context": "Gemini deprecations table: Embedding models. Release date: 2025-07-14. Shutdown date: 2026-07-14.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#embedding-models",
+    "content_hash": "d5844c73290161b7",
+    "scraped_at": "2026-05-01T21:43:36.815121+00:00",
     "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-07-14"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Google",
-    "model_id": "gemini-2.5-pro",
-    "announcement_date": "2025-12-05",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "Released gemini-2.5-pro , the stable version of our most powerful\nmodel, now with adaptive thinking. To learn more, see Gemini 2.5 Pro and Thinking . gemini-2.5-pro-preview-05-06 will be redirected to gemini-2.5-pro on June 26, 2025.",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20250617",
-    "content_hash": "32d67caea6ef685e",
-    "scraped_at": "2025-12-05T16:52:41.233549+00:00",
-    "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-06-17"
+    "model_id": "text-embedding-004",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-01-14",
+    "deprecation_date": "2026-01-14",
+    "replacement_models": [
+      "gemini-embedding-001"
+    ],
+    "deprecation_context": "Gemini deprecations table: Embedding models. Release date: 2024-04-09. Shutdown date: 2026-01-14. Recommended replacement: gemini-embedding-001.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#embedding-models",
+    "content_hash": "0e9799854657595b",
+    "scraped_at": "2026-05-01T21:43:36.815257+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Google",
-    "model_id": "gemini-2.5-flash",
-    "announcement_date": "2025-12-05",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "Released gemini-2.5-flash , our first stable 2.5 Flash model. To learn\nmore, see Gemini 2.5 Flash . gemini-2.5-flash-preview-04-17 will be deprecated on July 15, 2025.",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20250617",
-    "content_hash": "b92463f415925e71",
-    "scraped_at": "2025-12-05T16:52:41.233598+00:00",
-    "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-06-17"
+    "model_id": "embedding-001",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2025-10-30",
+    "deprecation_date": "2025-10-30",
+    "replacement_models": [
+      "gemini-embedding-001"
+    ],
+    "deprecation_context": "Gemini deprecations table: Embedding models. Release date: 2024-04-09. Shutdown date: 2025-10-30. Recommended replacement: gemini-embedding-001.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#embedding-models",
+    "content_hash": "887ccfb53324069d",
+    "scraped_at": "2026-05-01T21:43:36.815415+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Google",
-    "model_id": "gemini-2.5-flash-preview-04-17",
+    "model_id": "embedding-gecko-001",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2025-10-30",
+    "deprecation_date": "2025-10-30",
+    "replacement_models": [
+      "gemini-embedding-001"
+    ],
+    "deprecation_context": "Gemini deprecations table: Embedding models. Shutdown date: 2025-10-30. Recommended replacement: gemini-embedding-001.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#embedding-models",
+    "content_hash": "62ad77277267c0a6",
+    "scraped_at": "2026-05-01T21:43:36.815516+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-embedding-exp",
     "announcement_date": "2025-12-05",
-    "shutdown_date": "",
-    "replacement_models": null,
-    "deprecation_context": "Released gemini-2.5-flash , our first stable 2.5 Flash model. To learn\nmore, see Gemini 2.5 Flash . gemini-2.5-flash-preview-04-17 will be deprecated on July 15, 2025.",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20250617",
-    "content_hash": "193dd2401fcb40e2",
-    "scraped_at": "2025-12-05T16:52:41.233613+00:00",
+    "shutdown_date": "2025-10-30",
+    "deprecation_date": "2025-10-30",
+    "replacement_models": [
+      "gemini-embedding-001"
+    ],
+    "deprecation_context": "Gemini deprecations table: Embedding models. Shutdown date: 2025-10-30. Recommended replacement: gemini-embedding-001.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#embedding-models",
+    "content_hash": "37a64c8f379d3e44",
+    "scraped_at": "2026-05-01T21:43:36.815615+00:00",
     "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-06-17"
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-embedding-exp-03-07",
+    "announcement_date": "2025-12-05",
+    "shutdown_date": "2025-10-30",
+    "deprecation_date": "2025-10-30",
+    "replacement_models": [
+      "gemini-embedding-001"
+    ],
+    "deprecation_context": "Gemini deprecations table: Embedding models. Shutdown date: 2025-10-30. Recommended replacement: gemini-embedding-001.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#embedding-models",
+    "content_hash": "d3ff4ac737be58ed",
+    "scraped_at": "2026-05-01T21:43:36.815714+00:00",
+    "first_observed": "2025-12-05",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "imagen-4.0-generate-001",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-06-24",
+    "deprecation_date": "2026-06-24",
+    "replacement_models": [
+      "gemini-3-pro-image-preview",
+      "gemini-2.5-flash-image"
+    ],
+    "deprecation_context": "Gemini deprecations table: Imagen models. Release date: 2025-06-24. Shutdown date: 2026-06-24. Recommended replacement: gemini-3-pro-image-preview, gemini-2.5-flash-image.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#imagen-models",
+    "content_hash": "0c7252b63e3ce811",
+    "scraped_at": "2026-05-01T21:43:36.815981+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "imagen-4.0-ultra-generate-001",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-06-24",
+    "deprecation_date": "2026-06-24",
+    "replacement_models": [
+      "gemini-3-pro-image-preview",
+      "gemini-2.5-flash-image"
+    ],
+    "deprecation_context": "Gemini deprecations table: Imagen models. Release date: 2025-06-24. Shutdown date: 2026-06-24. Recommended replacement: gemini-3-pro-image-preview, gemini-2.5-flash-image.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#imagen-models",
+    "content_hash": "0664f2cf2f1ba3b4",
+    "scraped_at": "2026-05-01T21:43:36.816114+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "imagen-4.0-fast-generate-001",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-06-24",
+    "deprecation_date": "2026-06-24",
+    "replacement_models": [
+      "gemini-3-pro-image-preview",
+      "gemini-2.5-flash-image"
+    ],
+    "deprecation_context": "Gemini deprecations table: Imagen models. Release date: 2025-06-24. Shutdown date: 2026-06-24. Recommended replacement: gemini-3-pro-image-preview, gemini-2.5-flash-image.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#imagen-models",
+    "content_hash": "2a9204b7421569a7",
+    "scraped_at": "2026-05-01T21:43:36.816246+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "imagen-3.0-generate-002",
+    "announcement_date": "2025-12-05",
+    "shutdown_date": "2025-11-10",
+    "deprecation_date": "2025-11-10",
+    "replacement_models": [
+      "imagen-4.0-generate-001"
+    ],
+    "deprecation_context": "Gemini deprecations table: Imagen models. Release date: 2025-02-06. Shutdown date: 2025-11-10. Recommended replacement: imagen-4.0-generate-001.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#imagen-models",
+    "content_hash": "490f9a42a3755b65",
+    "scraped_at": "2026-05-01T21:39:32.406953+00:00",
+    "first_observed": "2025-12-05",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "imagen-4.0-generate-preview-06-06",
+    "announcement_date": "2026-01-16",
+    "shutdown_date": "2026-02-17",
+    "deprecation_date": "2026-02-17",
+    "replacement_models": [
+      "imagen-4.0-generate-001"
+    ],
+    "deprecation_context": "Gemini deprecations table: Imagen models. Release date: 2025-06-24. Shutdown date: 2026-02-17. Recommended replacement: imagen-4.0-generate-001.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#imagen-models",
+    "content_hash": "971af8046555b5db",
+    "scraped_at": "2026-05-01T21:43:36.816629+00:00",
+    "first_observed": "2026-01-16",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "imagen-4.0-ultra-generate-preview-06-06",
+    "announcement_date": "2026-01-16",
+    "shutdown_date": "2026-02-17",
+    "deprecation_date": "2026-02-17",
+    "replacement_models": [
+      "imagen-4.0-ultra-generate-001"
+    ],
+    "deprecation_context": "Gemini deprecations table: Imagen models. Release date: 2025-06-24. Shutdown date: 2026-02-17. Recommended replacement: imagen-4.0-ultra-generate-001.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#imagen-models",
+    "content_hash": "daeac3d4e66242e9",
+    "scraped_at": "2026-05-01T21:43:36.816783+00:00",
+    "first_observed": "2026-01-16",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "veo-3.0-generate-preview",
+    "announcement_date": "2025-12-05",
+    "shutdown_date": "2025-11-12",
+    "deprecation_date": "2025-11-12",
+    "replacement_models": [
+      "veo-3.1-generate-preview"
+    ],
+    "deprecation_context": "Gemini deprecations table: Veo models. Release date: 2025-07-31. Shutdown date: 2025-11-12. Recommended replacement: veo-3.1-generate-preview.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#veo-models",
+    "content_hash": "d3699091e748d06c",
+    "scraped_at": "2026-05-01T21:43:36.817475+00:00",
+    "first_observed": "2025-12-05",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "veo-3.0-fast-generate-preview",
+    "announcement_date": "2025-12-05",
+    "shutdown_date": "2025-11-12",
+    "deprecation_date": "2025-11-12",
+    "replacement_models": [
+      "veo-3.1-fast-generate-preview"
+    ],
+    "deprecation_context": "Gemini deprecations table: Veo models. Release date: 2025-07-31. Shutdown date: 2025-11-12. Recommended replacement: veo-3.1-fast-generate-preview.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#veo-models",
+    "content_hash": "7a843bd1ead3ca19",
+    "scraped_at": "2026-05-01T21:43:36.817610+00:00",
+    "first_observed": "2025-12-05",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-robotics-er-1.5-preview",
+    "announcement_date": "2026-04-15",
+    "shutdown_date": "2026-04-30",
+    "deprecation_date": "2026-04-30",
+    "replacement_models": [
+      "gemini-robotics-er-1.6-preview"
+    ],
+    "deprecation_context": "Gemini deprecations table: Robotics models. Release date: 2025-09-25. Shutdown date: 2026-04-30. Recommended replacement: gemini-robotics-er-1.6-preview.",
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations#robotics-models",
+    "content_hash": "8572e476a6dc50b4",
+    "scraped_at": "2026-05-01T21:43:36.818151+00:00",
+    "first_observed": "2026-04-15",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-2.0-flash-exp-image-generation",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2025-11-14",
+    "deprecation_date": "2025-11-11",
+    "replacement_models": null,
+    "deprecation_context": "Deprecation announcement: The following models will be shut down: November 12: veo-3.0-fast-generate-preview veo-3.0-generate-preview November 14: gemini-2.0-flash-exp-image-generation gemini-2.0-flash-preview-image-generation",
+    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251111",
+    "content_hash": "f95fc122df4b57e4",
+    "scraped_at": "2026-05-01T21:41:37.792318+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-2.5-flash-lite-preview-06-17",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2025-11-18",
+    "deprecation_date": "2025-11-04",
+    "replacement_models": null,
+    "deprecation_context": "Deprecation announcement: The following models will be shut down: November 18th: gemini-2.5-flash-lite-preview-06-17 gemini-2.5-flash-preview-05-20 December 2nd: gemini-2.0-flash-thinking-exp gemini-2.0-flash-thinking-exp-01-21 gemini-2.0-flash-thinking-exp-1219 gemini-2.5-pro-preview-03-25 gemini-2.5-pro-preview-05-06 gemini-2.5-pro-preview-06-05 December 9th: gemini-2.0-flash-lite-preview gemini-2.0-flash-lite-preview-02-05 gemini-2.0-flash-exp gemini-2.0-pro-exp gemini-2.0-pro-exp-02-05",
+    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
+    "content_hash": "297d2d7799ed7266",
+    "scraped_at": "2026-05-01T21:41:37.792860+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-2.0-flash-thinking-exp",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2025-12-02",
+    "deprecation_date": "2025-11-04",
+    "replacement_models": null,
+    "deprecation_context": "Deprecation announcement: The following models will be shut down: November 18th: gemini-2.5-flash-lite-preview-06-17 gemini-2.5-flash-preview-05-20 December 2nd: gemini-2.0-flash-thinking-exp gemini-2.0-flash-thinking-exp-01-21 gemini-2.0-flash-thinking-exp-1219 gemini-2.5-pro-preview-03-25 gemini-2.5-pro-preview-05-06 gemini-2.5-pro-preview-06-05 December 9th: gemini-2.0-flash-lite-preview gemini-2.0-flash-lite-preview-02-05 gemini-2.0-flash-exp gemini-2.0-pro-exp gemini-2.0-pro-exp-02-05",
+    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
+    "content_hash": "4999d7a107e2988a",
+    "scraped_at": "2026-05-01T21:41:37.792942+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-2.0-flash-thinking-exp-01-21",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2025-12-02",
+    "deprecation_date": "2025-11-04",
+    "replacement_models": null,
+    "deprecation_context": "Deprecation announcement: The following models will be shut down: November 18th: gemini-2.5-flash-lite-preview-06-17 gemini-2.5-flash-preview-05-20 December 2nd: gemini-2.0-flash-thinking-exp gemini-2.0-flash-thinking-exp-01-21 gemini-2.0-flash-thinking-exp-1219 gemini-2.5-pro-preview-03-25 gemini-2.5-pro-preview-05-06 gemini-2.5-pro-preview-06-05 December 9th: gemini-2.0-flash-lite-preview gemini-2.0-flash-lite-preview-02-05 gemini-2.0-flash-exp gemini-2.0-pro-exp gemini-2.0-pro-exp-02-05",
+    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
+    "content_hash": "179f6530449831a2",
+    "scraped_at": "2026-05-01T21:41:37.792951+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-2.0-flash-thinking-exp-1219",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2025-12-02",
+    "deprecation_date": "2025-11-04",
+    "replacement_models": null,
+    "deprecation_context": "Deprecation announcement: The following models will be shut down: November 18th: gemini-2.5-flash-lite-preview-06-17 gemini-2.5-flash-preview-05-20 December 2nd: gemini-2.0-flash-thinking-exp gemini-2.0-flash-thinking-exp-01-21 gemini-2.0-flash-thinking-exp-1219 gemini-2.5-pro-preview-03-25 gemini-2.5-pro-preview-05-06 gemini-2.5-pro-preview-06-05 December 9th: gemini-2.0-flash-lite-preview gemini-2.0-flash-lite-preview-02-05 gemini-2.0-flash-exp gemini-2.0-pro-exp gemini-2.0-pro-exp-02-05",
+    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
+    "content_hash": "22cd13d98890bd2f",
+    "scraped_at": "2026-05-01T21:41:37.792957+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-2.0-flash-exp",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2025-12-09",
+    "deprecation_date": "2025-11-04",
+    "replacement_models": null,
+    "deprecation_context": "Deprecation announcement: The following models will be shut down: November 18th: gemini-2.5-flash-lite-preview-06-17 gemini-2.5-flash-preview-05-20 December 2nd: gemini-2.0-flash-thinking-exp gemini-2.0-flash-thinking-exp-01-21 gemini-2.0-flash-thinking-exp-1219 gemini-2.5-pro-preview-03-25 gemini-2.5-pro-preview-05-06 gemini-2.5-pro-preview-06-05 December 9th: gemini-2.0-flash-lite-preview gemini-2.0-flash-lite-preview-02-05 gemini-2.0-flash-exp gemini-2.0-pro-exp gemini-2.0-pro-exp-02-05",
+    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
+    "content_hash": "ed83bc1c163356c0",
+    "scraped_at": "2026-05-01T21:41:37.793047+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-2.0-pro-exp",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2025-12-09",
+    "deprecation_date": "2025-11-04",
+    "replacement_models": null,
+    "deprecation_context": "Deprecation announcement: The following models will be shut down: November 18th: gemini-2.5-flash-lite-preview-06-17 gemini-2.5-flash-preview-05-20 December 2nd: gemini-2.0-flash-thinking-exp gemini-2.0-flash-thinking-exp-01-21 gemini-2.0-flash-thinking-exp-1219 gemini-2.5-pro-preview-03-25 gemini-2.5-pro-preview-05-06 gemini-2.5-pro-preview-06-05 December 9th: gemini-2.0-flash-lite-preview gemini-2.0-flash-lite-preview-02-05 gemini-2.0-flash-exp gemini-2.0-pro-exp gemini-2.0-pro-exp-02-05",
+    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
+    "content_hash": "f0f832b7736bdccd",
+    "scraped_at": "2026-05-01T21:41:37.793052+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-2.0-pro-exp-02-05",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2025-12-09",
+    "deprecation_date": "2025-11-04",
+    "replacement_models": null,
+    "deprecation_context": "Deprecation announcement: The following models will be shut down: November 18th: gemini-2.5-flash-lite-preview-06-17 gemini-2.5-flash-preview-05-20 December 2nd: gemini-2.0-flash-thinking-exp gemini-2.0-flash-thinking-exp-01-21 gemini-2.0-flash-thinking-exp-1219 gemini-2.5-pro-preview-03-25 gemini-2.5-pro-preview-05-06 gemini-2.5-pro-preview-06-05 December 9th: gemini-2.0-flash-lite-preview gemini-2.0-flash-lite-preview-02-05 gemini-2.0-flash-exp gemini-2.0-pro-exp gemini-2.0-pro-exp-02-05",
+    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
+    "content_hash": "28b9783352ec4a78",
+    "scraped_at": "2026-05-01T21:41:37.793056+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-2.5-flash-preview-native-audio-dialog",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2025-10-20",
+    "deprecation_date": "2025-10-20",
+    "replacement_models": null,
+    "deprecation_context": "The following Gemini Live API models are now shut down: gemini-2.5-flash-preview-native-audio-dialog gemini-2.5-flash-exp-native-audio-thinking-dialog You can use gemini-2.5-flash-native-audio-preview-09-2025 instead.",
+    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251020",
+    "content_hash": "10ae2df8d53261a5",
+    "scraped_at": "2026-05-01T21:41:37.793796+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-2.5-flash-exp-native-audio-thinking-dialog",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2025-10-20",
+    "deprecation_date": "2025-10-20",
+    "replacement_models": null,
+    "deprecation_context": "The following Gemini Live API models are now shut down: gemini-2.5-flash-preview-native-audio-dialog gemini-2.5-flash-exp-native-audio-thinking-dialog You can use gemini-2.5-flash-native-audio-preview-09-2025 instead.",
+    "url": "https://ai.google.dev/gemini-api/docs/changelog#20251020",
+    "content_hash": "95fd5becec1923b7",
+    "scraped_at": "2026-05-01T21:41:37.793808+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-1.5-pro",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2025-09-29",
+    "deprecation_date": "2025-09-29",
+    "replacement_models": null,
+    "deprecation_context": "The following Gemini 1.5 models are now shut down: gemini-1.5-pro gemini-1.5-flash-8b gemini-1.5-flash",
+    "url": "https://ai.google.dev/gemini-api/docs/changelog#20250929",
+    "content_hash": "85398405d856fb29",
+    "scraped_at": "2026-05-01T21:41:37.794509+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-1.5-flash-8b",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2025-09-29",
+    "deprecation_date": "2025-09-29",
+    "replacement_models": null,
+    "deprecation_context": "The following Gemini 1.5 models are now shut down: gemini-1.5-pro gemini-1.5-flash-8b gemini-1.5-flash",
+    "url": "https://ai.google.dev/gemini-api/docs/changelog#20250929",
+    "content_hash": "aa0b855680cd8d0e",
+    "scraped_at": "2026-05-01T21:41:37.794521+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Google",
     "model_id": "gemini-1.5-flash",
-    "announcement_date": "2025-12-05",
-    "shutdown_date": "",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2025-09-29",
+    "deprecation_date": "2025-09-29",
     "replacement_models": null,
-    "deprecation_context": "The last available tuning model, Gemini 1.5 Flash 001, has been shut down.\nTuning is no longer supported on any models.\nSeeFine tuning with the Gemini API.",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog#20250527",
-    "content_hash": "8f9dc738c3dfd3cc",
-    "scraped_at": "2025-12-05T16:52:41.233724+00:00",
-    "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-05-27"
+    "deprecation_context": "The following Gemini 1.5 models are now shut down: gemini-1.5-pro gemini-1.5-flash-8b gemini-1.5-flash",
+    "url": "https://ai.google.dev/gemini-api/docs/changelog#20250929",
+    "content_hash": "6d3e7c4b7657ff7b",
+    "scraped_at": "2026-05-01T21:41:37.794527+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-2.5-pro-exp-03-25",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2025-06-26",
+    "deprecation_date": "2025-06-26",
+    "replacement_models": null,
+    "deprecation_context": "gemini-2.5-pro-exp-03-25 is shut down.",
+    "url": "https://ai.google.dev/gemini-api/docs/changelog#20250626",
+    "content_hash": "d49beed5b21cd203",
+    "scraped_at": "2026-05-01T21:41:37.795869+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Google",
+    "model_id": "gemini-2.5-flash-preview-04-17",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2025-07-15",
+    "deprecation_date": "2025-06-17",
+    "replacement_models": null,
+    "deprecation_context": "Released gemini-2.5-flash , our first stable 2.5 Flash model. To learn more, see Gemini 2.5 Flash . gemini-2.5-flash-preview-04-17 will be deprecated on July 15, 2025.",
+    "url": "https://ai.google.dev/gemini-api/docs/changelog#20250617",
+    "content_hash": "83a90cc20c75a1ad",
+    "scraped_at": "2026-05-01T21:41:37.796124+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Google",
     "model_id": "gemini-1.0-pro",
-    "announcement_date": "2025-12-05",
-    "shutdown_date": "",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2025-02-18",
+    "deprecation_date": "2025-02-18",
     "replacement_models": null,
-    "deprecation_context": "Gemini 1.0 Pro is no longer supported. For the list of supported models, seeGemini models.",
+    "deprecation_context": "Gemini 1.0 Pro is no longer supported. For the list of supported models, see Gemini models .",
     "url": "https://ai.google.dev/gemini-api/docs/changelog#20250218",
-    "content_hash": "f8f77fd5aa429cef",
-    "scraped_at": "2025-12-05T16:52:41.233930+00:00",
-    "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2025-02-18"
+    "content_hash": "128d0f8ecb13d754",
+    "scraped_at": "2026-05-01T21:41:37.797350+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Google",
     "model_id": "gemini-1.0-pro-vision",
-    "announcement_date": "2025-12-05",
-    "shutdown_date": "",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2024-07-12",
+    "deprecation_date": "2024-07-12",
     "replacement_models": null,
     "deprecation_context": "Support for Gemini 1.0 Pro Vision removed from Google AI services and tools.",
     "url": "https://ai.google.dev/gemini-api/docs/changelog#20240712",
-    "content_hash": "2531fc166d518039",
-    "scraped_at": "2025-12-05T16:52:41.234181+00:00",
-    "first_observed": "2025-12-05",
-    "last_observed": "2025-12-05",
-    "deprecation_date": "2024-07-12"
+    "content_hash": "3e1182c8c673612e",
+    "scraped_at": "2026-05-01T21:41:37.799166+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Google Vertex",
@@ -2987,6 +3459,236 @@
     "deprecation_date": "2026-01-07"
   },
   {
+    "provider": "Cohere",
+    "model_id": "embed-english-v2.0",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-04-04",
+    "deprecation_date": "2026-04-04",
+    "replacement_models": [
+      "embed-english-v3.0",
+      "embed-multilingual-v3.0",
+      "embed-v4.0"
+    ],
+    "deprecation_context": "Effective April 4th, 2026, the following models will be retired: * `embed-english-v2.0` * `embed-english-light-v2.0` * `embed-multilingual-v2.0` * `c4ai-aya-expanse-8b` * `c4ai-aya-vision-8b` We encourage you to migrate to our latest models, which offer enhanced performance, improved accuracy, and expanded capabilities: * Embedding tasks alternatives: * `embed-english-v3.0` * `embed-multilingual-v3.0` * `embed-v4.0` * Chat tasks alternatives: * `command-r7b-12-2024` * `command-a-03-2025` * `command-a-reasoning-08-2025` Our team is here to ensure a seamless transition. For questions or assistance, please don’t hesitate reaching out to us at [support@cohere.com](mailto:support@cohere.com). Thank you for your continued partnership. We look forward to powering your applications with our latest AI advancements.",
+    "url": "https://docs.cohere.com/docs/deprecations#2026-04-04-embed-v2-0-aya-expanse-8b",
+    "content_hash": "e22828ef84934124",
+    "scraped_at": "2026-05-01T21:39:32.667159+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Cohere",
+    "model_id": "embed-english-light-v2.0",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-04-04",
+    "deprecation_date": "2026-04-04",
+    "replacement_models": [
+      "embed-english-v3.0",
+      "embed-multilingual-v3.0",
+      "embed-v4.0"
+    ],
+    "deprecation_context": "Effective April 4th, 2026, the following models will be retired: * `embed-english-v2.0` * `embed-english-light-v2.0` * `embed-multilingual-v2.0` * `c4ai-aya-expanse-8b` * `c4ai-aya-vision-8b` We encourage you to migrate to our latest models, which offer enhanced performance, improved accuracy, and expanded capabilities: * Embedding tasks alternatives: * `embed-english-v3.0` * `embed-multilingual-v3.0` * `embed-v4.0` * Chat tasks alternatives: * `command-r7b-12-2024` * `command-a-03-2025` * `command-a-reasoning-08-2025` Our team is here to ensure a seamless transition. For questions or assistance, please don’t hesitate reaching out to us at [support@cohere.com](mailto:support@cohere.com). Thank you for your continued partnership. We look forward to powering your applications with our latest AI advancements.",
+    "url": "https://docs.cohere.com/docs/deprecations#2026-04-04-embed-v2-0-aya-expanse-8b",
+    "content_hash": "3a5d5641c008de6b",
+    "scraped_at": "2026-05-01T21:39:32.667216+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Cohere",
+    "model_id": "embed-multilingual-v2.0",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-04-04",
+    "deprecation_date": "2026-04-04",
+    "replacement_models": [
+      "embed-english-v3.0",
+      "embed-multilingual-v3.0",
+      "embed-v4.0"
+    ],
+    "deprecation_context": "Effective April 4th, 2026, the following models will be retired: * `embed-english-v2.0` * `embed-english-light-v2.0` * `embed-multilingual-v2.0` * `c4ai-aya-expanse-8b` * `c4ai-aya-vision-8b` We encourage you to migrate to our latest models, which offer enhanced performance, improved accuracy, and expanded capabilities: * Embedding tasks alternatives: * `embed-english-v3.0` * `embed-multilingual-v3.0` * `embed-v4.0` * Chat tasks alternatives: * `command-r7b-12-2024` * `command-a-03-2025` * `command-a-reasoning-08-2025` Our team is here to ensure a seamless transition. For questions or assistance, please don’t hesitate reaching out to us at [support@cohere.com](mailto:support@cohere.com). Thank you for your continued partnership. We look forward to powering your applications with our latest AI advancements.",
+    "url": "https://docs.cohere.com/docs/deprecations#2026-04-04-embed-v2-0-aya-expanse-8b",
+    "content_hash": "8fd92b457a3bcc95",
+    "scraped_at": "2026-05-01T21:39:32.667257+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Cohere",
+    "model_id": "c4ai-aya-expanse-8b",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-04-04",
+    "deprecation_date": "2026-04-04",
+    "replacement_models": [
+      "command-r7b-12-2024",
+      "command-a-03-2025",
+      "command-a-reasoning-08-2025"
+    ],
+    "deprecation_context": "Effective April 4th, 2026, the following models will be retired: * `embed-english-v2.0` * `embed-english-light-v2.0` * `embed-multilingual-v2.0` * `c4ai-aya-expanse-8b` * `c4ai-aya-vision-8b` We encourage you to migrate to our latest models, which offer enhanced performance, improved accuracy, and expanded capabilities: * Embedding tasks alternatives: * `embed-english-v3.0` * `embed-multilingual-v3.0` * `embed-v4.0` * Chat tasks alternatives: * `command-r7b-12-2024` * `command-a-03-2025` * `command-a-reasoning-08-2025` Our team is here to ensure a seamless transition. For questions or assistance, please don’t hesitate reaching out to us at [support@cohere.com](mailto:support@cohere.com). Thank you for your continued partnership. We look forward to powering your applications with our latest AI advancements.",
+    "url": "https://docs.cohere.com/docs/deprecations#2026-04-04-embed-v2-0-aya-expanse-8b",
+    "content_hash": "4042ca6f1e047813",
+    "scraped_at": "2026-05-01T21:39:32.667293+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Cohere",
+    "model_id": "c4ai-aya-vision-8b",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-04-04",
+    "deprecation_date": "2026-04-04",
+    "replacement_models": [
+      "command-r7b-12-2024",
+      "command-a-03-2025",
+      "command-a-reasoning-08-2025"
+    ],
+    "deprecation_context": "Effective April 4th, 2026, the following models will be retired: * `embed-english-v2.0` * `embed-english-light-v2.0` * `embed-multilingual-v2.0` * `c4ai-aya-expanse-8b` * `c4ai-aya-vision-8b` We encourage you to migrate to our latest models, which offer enhanced performance, improved accuracy, and expanded capabilities: * Embedding tasks alternatives: * `embed-english-v3.0` * `embed-multilingual-v3.0` * `embed-v4.0` * Chat tasks alternatives: * `command-r7b-12-2024` * `command-a-03-2025` * `command-a-reasoning-08-2025` Our team is here to ensure a seamless transition. For questions or assistance, please don’t hesitate reaching out to us at [support@cohere.com](mailto:support@cohere.com). Thank you for your continued partnership. We look forward to powering your applications with our latest AI advancements.",
+    "url": "https://docs.cohere.com/docs/deprecations#2026-04-04-embed-v2-0-aya-expanse-8b",
+    "content_hash": "ff93362baaf77425",
+    "scraped_at": "2026-05-01T21:39:32.667327+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Cohere",
+    "model_id": "command-r-03-2024",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "",
+    "deprecation_date": "2025-09-15",
+    "replacement_models": [
+      "command-r-08-2024",
+      "command-r-plus-08-2024",
+      "command-a-03-2025"
+    ],
+    "deprecation_context": "Effective September 15, 2025, the following deprecations will roll out. Deprecated Models: * `command-r-03-2024`  (and the alias `command-r`) * `command-r-plus-04-2024`  (and the alias `command-r-plus`) * `command-light` * `command` * `summarize` (Refer to [the migration guide](https://docs.cohere.com/docs/summarizing-text#migration-from-summarize-to-chat-endpoint) for alternatives). For command model replacements, we recommend you use `command-r-08-2024`, `command-r-plus-08-2024`, or `command-a-03-2025` (which is the strongest-performing model across domains) instead. Retired Fine-Tuning Capabilities: Fine-tuning for the `command-light`, `command`, `command-r`, `classify`, and `rerank` models is being retired. This covers both the Cohere dashboard and API. Previously fine-tuned models will no longer be accessible. Deprecated Features and API Endpoints: * `/v1/connectors` (Managed connectors for RAG) * `/v1/chat` parameters: `connectors`, `search_queries_only` * `/v1/generate` (Legacy generative endpoint) * `/v1/summarize` (Legacy summarization endpoint) * `/v1/classify` * Slack App integration * Coral Web UI (chat.cohere.com and coral.cohere.com) These changes reflect our commitment to innovation and performance optimization. We encourage users to assess their current implementations and migrate to recommended alternatives. Our support team is available at [support@cohere.com](mailto:support@cohere.com) to assist with the transition. For detailed guidance, please refer to our migration resources and technical documentation.",
+    "url": "https://docs.cohere.com/docs/deprecations#2025-09-15-various-older-command-models-a-number-of-endpoints-all-of-fine-tuning",
+    "content_hash": "c49e9808e9c2d9a4",
+    "scraped_at": "2026-05-01T21:39:32.667381+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Cohere",
+    "model_id": "command-r",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "",
+    "deprecation_date": "2025-09-15",
+    "replacement_models": [
+      "command-r-08-2024",
+      "command-r-plus-08-2024",
+      "command-a-03-2025"
+    ],
+    "deprecation_context": "Effective September 15, 2025, the following deprecations will roll out. Deprecated Models: * `command-r-03-2024`  (and the alias `command-r`) * `command-r-plus-04-2024`  (and the alias `command-r-plus`) * `command-light` * `command` * `summarize` (Refer to [the migration guide](https://docs.cohere.com/docs/summarizing-text#migration-from-summarize-to-chat-endpoint) for alternatives). For command model replacements, we recommend you use `command-r-08-2024`, `command-r-plus-08-2024`, or `command-a-03-2025` (which is the strongest-performing model across domains) instead. Retired Fine-Tuning Capabilities: Fine-tuning for the `command-light`, `command`, `command-r`, `classify`, and `rerank` models is being retired. This covers both the Cohere dashboard and API. Previously fine-tuned models will no longer be accessible. Deprecated Features and API Endpoints: * `/v1/connectors` (Managed connectors for RAG) * `/v1/chat` parameters: `connectors`, `search_queries_only` * `/v1/generate` (Legacy generative endpoint) * `/v1/summarize` (Legacy summarization endpoint) * `/v1/classify` * Slack App integration * Coral Web UI (chat.cohere.com and coral.cohere.com) These changes reflect our commitment to innovation and performance optimization. We encourage users to assess their current implementations and migrate to recommended alternatives. Our support team is available at [support@cohere.com](mailto:support@cohere.com) to assist with the transition. For detailed guidance, please refer to our migration resources and technical documentation.",
+    "url": "https://docs.cohere.com/docs/deprecations#2025-09-15-various-older-command-models-a-number-of-endpoints-all-of-fine-tuning",
+    "content_hash": "77f1c626c22a5fb8",
+    "scraped_at": "2026-05-01T21:39:32.667391+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Cohere",
+    "model_id": "command-r-plus-04-2024",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "",
+    "deprecation_date": "2025-09-15",
+    "replacement_models": [
+      "command-r-08-2024",
+      "command-r-plus-08-2024",
+      "command-a-03-2025"
+    ],
+    "deprecation_context": "Effective September 15, 2025, the following deprecations will roll out. Deprecated Models: * `command-r-03-2024`  (and the alias `command-r`) * `command-r-plus-04-2024`  (and the alias `command-r-plus`) * `command-light` * `command` * `summarize` (Refer to [the migration guide](https://docs.cohere.com/docs/summarizing-text#migration-from-summarize-to-chat-endpoint) for alternatives). For command model replacements, we recommend you use `command-r-08-2024`, `command-r-plus-08-2024`, or `command-a-03-2025` (which is the strongest-performing model across domains) instead. Retired Fine-Tuning Capabilities: Fine-tuning for the `command-light`, `command`, `command-r`, `classify`, and `rerank` models is being retired. This covers both the Cohere dashboard and API. Previously fine-tuned models will no longer be accessible. Deprecated Features and API Endpoints: * `/v1/connectors` (Managed connectors for RAG) * `/v1/chat` parameters: `connectors`, `search_queries_only` * `/v1/generate` (Legacy generative endpoint) * `/v1/summarize` (Legacy summarization endpoint) * `/v1/classify` * Slack App integration * Coral Web UI (chat.cohere.com and coral.cohere.com) These changes reflect our commitment to innovation and performance optimization. We encourage users to assess their current implementations and migrate to recommended alternatives. Our support team is available at [support@cohere.com](mailto:support@cohere.com) to assist with the transition. For detailed guidance, please refer to our migration resources and technical documentation.",
+    "url": "https://docs.cohere.com/docs/deprecations#2025-09-15-various-older-command-models-a-number-of-endpoints-all-of-fine-tuning",
+    "content_hash": "5fe9a262b5c7bfaa",
+    "scraped_at": "2026-05-01T21:39:32.667396+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Cohere",
+    "model_id": "command-r-plus",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "",
+    "deprecation_date": "2025-09-15",
+    "replacement_models": [
+      "command-r-08-2024",
+      "command-r-plus-08-2024",
+      "command-a-03-2025"
+    ],
+    "deprecation_context": "Effective September 15, 2025, the following deprecations will roll out. Deprecated Models: * `command-r-03-2024`  (and the alias `command-r`) * `command-r-plus-04-2024`  (and the alias `command-r-plus`) * `command-light` * `command` * `summarize` (Refer to [the migration guide](https://docs.cohere.com/docs/summarizing-text#migration-from-summarize-to-chat-endpoint) for alternatives). For command model replacements, we recommend you use `command-r-08-2024`, `command-r-plus-08-2024`, or `command-a-03-2025` (which is the strongest-performing model across domains) instead. Retired Fine-Tuning Capabilities: Fine-tuning for the `command-light`, `command`, `command-r`, `classify`, and `rerank` models is being retired. This covers both the Cohere dashboard and API. Previously fine-tuned models will no longer be accessible. Deprecated Features and API Endpoints: * `/v1/connectors` (Managed connectors for RAG) * `/v1/chat` parameters: `connectors`, `search_queries_only` * `/v1/generate` (Legacy generative endpoint) * `/v1/summarize` (Legacy summarization endpoint) * `/v1/classify` * Slack App integration * Coral Web UI (chat.cohere.com and coral.cohere.com) These changes reflect our commitment to innovation and performance optimization. We encourage users to assess their current implementations and migrate to recommended alternatives. Our support team is available at [support@cohere.com](mailto:support@cohere.com) to assist with the transition. For detailed guidance, please refer to our migration resources and technical documentation.",
+    "url": "https://docs.cohere.com/docs/deprecations#2025-09-15-various-older-command-models-a-number-of-endpoints-all-of-fine-tuning",
+    "content_hash": "fa8450ce908c56a3",
+    "scraped_at": "2026-05-01T21:39:32.667401+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Cohere",
+    "model_id": "command-light",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "",
+    "deprecation_date": "2025-09-15",
+    "replacement_models": [
+      "command-r-08-2024",
+      "command-r-plus-08-2024",
+      "command-a-03-2025"
+    ],
+    "deprecation_context": "Effective September 15, 2025, the following deprecations will roll out. Deprecated Models: * `command-r-03-2024`  (and the alias `command-r`) * `command-r-plus-04-2024`  (and the alias `command-r-plus`) * `command-light` * `command` * `summarize` (Refer to [the migration guide](https://docs.cohere.com/docs/summarizing-text#migration-from-summarize-to-chat-endpoint) for alternatives). For command model replacements, we recommend you use `command-r-08-2024`, `command-r-plus-08-2024`, or `command-a-03-2025` (which is the strongest-performing model across domains) instead. Retired Fine-Tuning Capabilities: Fine-tuning for the `command-light`, `command`, `command-r`, `classify`, and `rerank` models is being retired. This covers both the Cohere dashboard and API. Previously fine-tuned models will no longer be accessible. Deprecated Features and API Endpoints: * `/v1/connectors` (Managed connectors for RAG) * `/v1/chat` parameters: `connectors`, `search_queries_only` * `/v1/generate` (Legacy generative endpoint) * `/v1/summarize` (Legacy summarization endpoint) * `/v1/classify` * Slack App integration * Coral Web UI (chat.cohere.com and coral.cohere.com) These changes reflect our commitment to innovation and performance optimization. We encourage users to assess their current implementations and migrate to recommended alternatives. Our support team is available at [support@cohere.com](mailto:support@cohere.com) to assist with the transition. For detailed guidance, please refer to our migration resources and technical documentation.",
+    "url": "https://docs.cohere.com/docs/deprecations#2025-09-15-various-older-command-models-a-number-of-endpoints-all-of-fine-tuning",
+    "content_hash": "3dd7dfbe6e9b5f6c",
+    "scraped_at": "2026-05-01T21:39:32.667406+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Cohere",
+    "model_id": "command",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "",
+    "deprecation_date": "2025-09-15",
+    "replacement_models": [
+      "command-r-08-2024",
+      "command-r-plus-08-2024",
+      "command-a-03-2025"
+    ],
+    "deprecation_context": "Effective September 15, 2025, the following deprecations will roll out. Deprecated Models: * `command-r-03-2024`  (and the alias `command-r`) * `command-r-plus-04-2024`  (and the alias `command-r-plus`) * `command-light` * `command` * `summarize` (Refer to [the migration guide](https://docs.cohere.com/docs/summarizing-text#migration-from-summarize-to-chat-endpoint) for alternatives). For command model replacements, we recommend you use `command-r-08-2024`, `command-r-plus-08-2024`, or `command-a-03-2025` (which is the strongest-performing model across domains) instead. Retired Fine-Tuning Capabilities: Fine-tuning for the `command-light`, `command`, `command-r`, `classify`, and `rerank` models is being retired. This covers both the Cohere dashboard and API. Previously fine-tuned models will no longer be accessible. Deprecated Features and API Endpoints: * `/v1/connectors` (Managed connectors for RAG) * `/v1/chat` parameters: `connectors`, `search_queries_only` * `/v1/generate` (Legacy generative endpoint) * `/v1/summarize` (Legacy summarization endpoint) * `/v1/classify` * Slack App integration * Coral Web UI (chat.cohere.com and coral.cohere.com) These changes reflect our commitment to innovation and performance optimization. We encourage users to assess their current implementations and migrate to recommended alternatives. Our support team is available at [support@cohere.com](mailto:support@cohere.com) to assist with the transition. For detailed guidance, please refer to our migration resources and technical documentation.",
+    "url": "https://docs.cohere.com/docs/deprecations#2025-09-15-various-older-command-models-a-number-of-endpoints-all-of-fine-tuning",
+    "content_hash": "292d47b466348948",
+    "scraped_at": "2026-05-01T21:39:32.667410+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Cohere",
+    "model_id": "rerank-english-v2.0",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2025-04-30",
+    "deprecation_date": "2024-12-02",
+    "replacement_models": [
+      "rerank-v3.5"
+    ],
+    "deprecation_context": "On December 2nd, 2024, we announced the release of Rerank-v3.5 along with the deprecation of the Rerank-v2.0 model family. Fine-tuned models created from these base models are not affected by this deprecation. | Shutdown Date | Deprecated Model           | Deprecated Model Price | Recommended Replacement | | ------------- | -------------------------- | ---------------------- | ----------------------- | | 2025-04-30    | `rerank-english-v2.0`      | \\$1.00 / 1K searches   | `rerank-v3.5`           | | 2025-04-30    | `rerank-multilingual-v2.0` | \\$1.00 / 1K searches   | `rerank-v3.5`           | # Best Practices: 1. Regularly check our documentation for updates on announcements regarding the status of models. 2. Test applications with newer models well before the shutdown date of your current model. 3. Update any production code to use an active model as soon as possible. 4. Contact [support@cohere.ai](mailto:support@cohere.ai) if you need any assistance with migration or have any questions.",
+    "url": "https://docs.cohere.com/docs/deprecations#2024-12-02-rerank-v2-0",
+    "content_hash": "8514ec8565d5661f",
+    "scraped_at": "2026-05-01T21:39:32.667519+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Cohere",
+    "model_id": "rerank-multilingual-v2.0",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2025-04-30",
+    "deprecation_date": "2024-12-02",
+    "replacement_models": [
+      "rerank-v3.5"
+    ],
+    "deprecation_context": "On December 2nd, 2024, we announced the release of Rerank-v3.5 along with the deprecation of the Rerank-v2.0 model family. Fine-tuned models created from these base models are not affected by this deprecation. | Shutdown Date | Deprecated Model           | Deprecated Model Price | Recommended Replacement | | ------------- | -------------------------- | ---------------------- | ----------------------- | | 2025-04-30    | `rerank-english-v2.0`      | \\$1.00 / 1K searches   | `rerank-v3.5`           | | 2025-04-30    | `rerank-multilingual-v2.0` | \\$1.00 / 1K searches   | `rerank-v3.5`           | # Best Practices: 1. Regularly check our documentation for updates on announcements regarding the status of models. 2. Test applications with newer models well before the shutdown date of your current model. 3. Update any production code to use an active model as soon as possible. 4. Contact [support@cohere.ai](mailto:support@cohere.ai) if you need any assistance with migration or have any questions.",
+    "url": "https://docs.cohere.com/docs/deprecations#2024-12-02-rerank-v2-0",
+    "content_hash": "d6c535dc8fc536cb",
+    "scraped_at": "2026-05-01T21:39:32.667541+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
     "provider": "Azure",
     "model_id": "codex-mini",
     "announcement_date": "2026-04-25",
@@ -3120,15 +3822,15 @@
     "provider": "Azure",
     "model_id": "gpt-4o-transcribe-diarize",
     "announcement_date": "2026-04-25",
-    "shutdown_date": "2027-04-16",
-    "deprecation_date": "2027-04-16",
+    "shutdown_date": "2026-10-15",
+    "deprecation_date": "2026-10-15",
     "replacement_models": null,
     "deprecation_context": "Azure OpenAI",
     "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
-    "content_hash": "ae02ba4e5f42c80b",
-    "scraped_at": "2026-04-25T04:37:34.697793+00:00",
+    "content_hash": "b170b46eb302432c",
+    "scraped_at": "2026-05-01T21:39:32.794046+00:00",
     "first_observed": "2026-04-25",
-    "last_observed": "2026-04-25"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Azure",
@@ -3148,17 +3850,17 @@
     "provider": "Azure",
     "model_id": "gpt-5-chat",
     "announcement_date": "2026-04-25",
-    "shutdown_date": "2026-05-13",
-    "deprecation_date": "2026-05-13",
+    "shutdown_date": "2026-06-09",
+    "deprecation_date": "2026-06-09",
     "replacement_models": [
       "gpt-5.3-chat"
     ],
     "deprecation_context": "Azure OpenAI",
     "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
-    "content_hash": "accf6b6d5cb420b0",
-    "scraped_at": "2026-04-25T04:37:34.697899+00:00",
+    "content_hash": "6ade3ca1c8539bcc",
+    "scraped_at": "2026-05-01T21:39:32.794174+00:00",
     "first_observed": "2026-04-25",
-    "last_observed": "2026-04-25"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Azure",
@@ -3234,17 +3936,17 @@
     "provider": "Azure",
     "model_id": "gpt-5.1-chat",
     "announcement_date": "2026-04-25",
-    "shutdown_date": "2026-05-13",
-    "deprecation_date": "2026-05-13",
+    "shutdown_date": "2026-06-09",
+    "deprecation_date": "2026-06-09",
     "replacement_models": [
       "gpt-5.3-chat"
     ],
     "deprecation_context": "Azure OpenAI",
     "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
-    "content_hash": "e28d78c89b9e71b2",
-    "scraped_at": "2026-04-25T04:37:34.698274+00:00",
+    "content_hash": "ea6dd1af0ebbe8ee",
+    "scraped_at": "2026-05-01T21:39:32.794622+00:00",
     "first_observed": "2026-04-25",
-    "last_observed": "2026-04-25"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Azure",
@@ -3306,17 +4008,17 @@
     "provider": "Azure",
     "model_id": "gpt-5.2-chat",
     "announcement_date": "2026-04-25",
-    "shutdown_date": "2026-05-13",
-    "deprecation_date": "2026-05-13",
+    "shutdown_date": "2026-06-09",
+    "deprecation_date": "2026-06-09",
     "replacement_models": [
       "gpt-5.3-chat"
     ],
     "deprecation_context": "Azure OpenAI",
     "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
-    "content_hash": "c334c11ca689daeb",
-    "scraped_at": "2026-04-25T04:37:34.698534+00:00",
+    "content_hash": "e2c11ecce76c11fe",
+    "scraped_at": "2026-05-01T21:39:32.794939+00:00",
     "first_observed": "2026-04-25",
-    "last_observed": "2026-04-25"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Azure",
@@ -3336,15 +4038,15 @@
     "provider": "Azure",
     "model_id": "gpt-5.3-chat",
     "announcement_date": "2026-04-25",
-    "shutdown_date": "2026-06-03",
-    "deprecation_date": "2026-06-03",
+    "shutdown_date": "2026-06-09",
+    "deprecation_date": "2026-06-09",
     "replacement_models": null,
     "deprecation_context": "Azure OpenAI",
     "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
-    "content_hash": "6bd863f35eb4c576",
-    "scraped_at": "2026-04-25T04:37:34.698723+00:00",
+    "content_hash": "0c46900e355ddc84",
+    "scraped_at": "2026-05-01T21:39:32.795129+00:00",
     "first_observed": "2026-04-25",
-    "last_observed": "2026-04-25"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Azure",
@@ -3462,15 +4164,15 @@
     "provider": "Azure",
     "model_id": "gpt-audio-mini",
     "announcement_date": "2026-04-25",
-    "shutdown_date": "2027-04-07",
-    "deprecation_date": "2027-04-07",
+    "shutdown_date": "2026-07-23",
+    "deprecation_date": "2026-07-23",
     "replacement_models": null,
     "deprecation_context": "Azure OpenAI",
     "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
-    "content_hash": "70d512379d4d005b",
-    "scraped_at": "2026-04-25T04:37:34.699132+00:00",
+    "content_hash": "2edcfbcaf3436a25",
+    "scraped_at": "2026-05-01T21:39:32.795695+00:00",
     "first_observed": "2026-04-25",
-    "last_observed": "2026-04-25"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Azure",
@@ -3560,15 +4262,15 @@
     "provider": "Azure",
     "model_id": "gpt-realtime-mini",
     "announcement_date": "2026-04-25",
-    "shutdown_date": "2027-04-07",
-    "deprecation_date": "2027-04-07",
+    "shutdown_date": "2026-07-23",
+    "deprecation_date": "2026-07-23",
     "replacement_models": null,
     "deprecation_context": "Azure OpenAI",
     "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
-    "content_hash": "ccc7c5c25ea6d587",
-    "scraped_at": "2026-04-25T04:37:34.699510+00:00",
+    "content_hash": "1e5794106bddf9ef",
+    "scraped_at": "2026-05-01T21:39:32.796194+00:00",
     "first_observed": "2026-04-25",
-    "last_observed": "2026-04-25"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Azure",
@@ -3716,43 +4418,43 @@
     "provider": "Azure",
     "model_id": "tts",
     "announcement_date": "2026-04-25",
-    "shutdown_date": "2026-06-18",
-    "deprecation_date": "2026-06-18",
+    "shutdown_date": "2026-12-15",
+    "deprecation_date": "2026-12-15",
     "replacement_models": null,
     "deprecation_context": "Azure OpenAI",
     "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
-    "content_hash": "5d94bac6e93772dd",
-    "scraped_at": "2026-04-25T04:37:34.700273+00:00",
+    "content_hash": "d6ea8347c42ce73b",
+    "scraped_at": "2026-05-01T21:39:32.797034+00:00",
     "first_observed": "2026-04-25",
-    "last_observed": "2026-04-25"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Azure",
     "model_id": "tts-hd",
     "announcement_date": "2026-04-25",
-    "shutdown_date": "2026-06-18",
-    "deprecation_date": "2026-06-18",
+    "shutdown_date": "2026-12-15",
+    "deprecation_date": "2026-12-15",
     "replacement_models": null,
     "deprecation_context": "Azure OpenAI",
     "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
-    "content_hash": "a2d02a168c0318f5",
-    "scraped_at": "2026-04-25T04:37:34.700324+00:00",
+    "content_hash": "8624b76057618bb1",
+    "scraped_at": "2026-05-01T21:39:32.797099+00:00",
     "first_observed": "2026-04-25",
-    "last_observed": "2026-04-25"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Azure",
     "model_id": "whisper",
     "announcement_date": "2026-04-25",
-    "shutdown_date": "2026-06-18",
-    "deprecation_date": "2026-06-18",
+    "shutdown_date": "2026-12-15",
+    "deprecation_date": "2026-12-15",
     "replacement_models": null,
     "deprecation_context": "Azure OpenAI",
     "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
-    "content_hash": "9f9b4c57b0441f07",
-    "scraped_at": "2026-04-25T04:37:34.700376+00:00",
+    "content_hash": "84ed70b66ac134fe",
+    "scraped_at": "2026-05-01T21:39:32.797163+00:00",
     "first_observed": "2026-04-25",
-    "last_observed": "2026-04-25"
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Azure",
@@ -3932,6 +4634,20 @@
   },
   {
     "provider": "Azure",
+    "model_id": "claude-opus-4-7",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2027-04-06",
+    "deprecation_date": "2027-04-06",
+    "replacement_models": null,
+    "deprecation_context": "Anthropic",
+    "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
+    "content_hash": "fb8e0fdd4ec9403c",
+    "scraped_at": "2026-05-01T21:39:32.800598+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Azure",
     "model_id": "claude-sonnet-4-5",
     "announcement_date": "2026-04-28",
     "shutdown_date": "2026-10-19",
@@ -4002,6 +4718,188 @@
     "scraped_at": "2026-04-25T04:37:34.703256+00:00",
     "first_observed": "2026-01-14",
     "last_observed": "2026-04-25"
+  },
+  {
+    "provider": "Azure",
+    "model_id": "FW-DeepSeek-V3.1",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-07-01",
+    "deprecation_date": "2026-07-01",
+    "replacement_models": null,
+    "deprecation_context": "Fireworks",
+    "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
+    "content_hash": "47c61306de0f7c29",
+    "scraped_at": "2026-05-01T21:39:32.801413+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Azure",
+    "model_id": "FW-DeepSeek-V3.2",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-07-01",
+    "deprecation_date": "2026-07-01",
+    "replacement_models": null,
+    "deprecation_context": "Fireworks",
+    "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
+    "content_hash": "de3d993e0e491ef2",
+    "scraped_at": "2026-05-01T21:39:32.801476+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Azure",
+    "model_id": "FW-GLM-4.7",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-07-01",
+    "deprecation_date": "2026-07-01",
+    "replacement_models": null,
+    "deprecation_context": "Fireworks",
+    "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
+    "content_hash": "4674d6265f93c4d5",
+    "scraped_at": "2026-05-01T21:39:32.801536+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Azure",
+    "model_id": "FW-GLM-5",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-07-01",
+    "deprecation_date": "2026-07-01",
+    "replacement_models": null,
+    "deprecation_context": "Fireworks",
+    "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
+    "content_hash": "35ff79076ee598ae",
+    "scraped_at": "2026-05-01T21:39:32.801595+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Azure",
+    "model_id": "FW-GLM-5.1",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-08-01",
+    "deprecation_date": "2026-08-01",
+    "replacement_models": null,
+    "deprecation_context": "Fireworks",
+    "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
+    "content_hash": "d522400ec22c2de1",
+    "scraped_at": "2026-05-01T21:39:32.801653+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Azure",
+    "model_id": "FW-GPT-OSS-120B",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-07-01",
+    "deprecation_date": "2026-07-01",
+    "replacement_models": null,
+    "deprecation_context": "Fireworks",
+    "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
+    "content_hash": "d22c3645f6d920bd",
+    "scraped_at": "2026-05-01T21:39:32.801715+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Azure",
+    "model_id": "FW-Kimi-K2-Instruct-0905",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-07-01",
+    "deprecation_date": "2026-07-01",
+    "replacement_models": null,
+    "deprecation_context": "Fireworks",
+    "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
+    "content_hash": "59867fc88f0a8c64",
+    "scraped_at": "2026-05-01T21:39:32.801775+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Azure",
+    "model_id": "FW-Kimi-K2-Thinking",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-07-01",
+    "deprecation_date": "2026-07-01",
+    "replacement_models": null,
+    "deprecation_context": "Fireworks",
+    "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
+    "content_hash": "773f34089d9a1de5",
+    "scraped_at": "2026-05-01T21:39:32.801836+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Azure",
+    "model_id": "FW-Kimi-K2.5",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-07-01",
+    "deprecation_date": "2026-07-01",
+    "replacement_models": null,
+    "deprecation_context": "Fireworks",
+    "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
+    "content_hash": "1a0b72abe90ea1ac",
+    "scraped_at": "2026-05-01T21:39:32.801894+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Azure",
+    "model_id": "FW-MiniMax-M2.5",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-07-01",
+    "deprecation_date": "2026-07-01",
+    "replacement_models": null,
+    "deprecation_context": "Fireworks",
+    "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
+    "content_hash": "06f1b846459620d9",
+    "scraped_at": "2026-05-01T21:39:32.801954+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Azure",
+    "model_id": "FW-Qwen3-14B",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-07-01",
+    "deprecation_date": "2026-07-01",
+    "replacement_models": null,
+    "deprecation_context": "Fireworks",
+    "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
+    "content_hash": "9569939a11856ce9",
+    "scraped_at": "2026-05-01T21:39:32.802011+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Azure",
+    "model_id": "FW-Qwen3.5-122B-A10B",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-08-01",
+    "deprecation_date": "2026-08-01",
+    "replacement_models": null,
+    "deprecation_context": "Fireworks",
+    "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
+    "content_hash": "cc6aadfb65addaa2",
+    "scraped_at": "2026-05-01T21:39:32.802070+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
+  },
+  {
+    "provider": "Azure",
+    "model_id": "FW-Qwen3.5-397B-A17B",
+    "announcement_date": "2026-05-01",
+    "shutdown_date": "2026-08-01",
+    "deprecation_date": "2026-08-01",
+    "replacement_models": null,
+    "deprecation_context": "Fireworks",
+    "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
+    "content_hash": "41b70573625bb563",
+    "scraped_at": "2026-05-01T21:39:32.802131+00:00",
+    "first_observed": "2026-05-01",
+    "last_observed": "2026-05-01"
   },
   {
     "provider": "Azure",

--- a/docs/v1/feed.json
+++ b/docs/v1/feed.json
@@ -17,16 +17,41 @@
       "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
       "title": "OpenAI: computer-use-preview-2025-03-11",
       "content_text": "",
-      "date_published": "2026-04-23T04:51:54.525170+00:00",
+      "date_published": "2026-05-01T21:39:21.868836+00:00",
       "_deprecation": {
         "provider": "OpenAI",
         "model_id": "computer-use-preview-2025-03-11",
         "shutdown_date": "2026-07-23",
         "deprecation_date": "2026-04-22",
         "announcement_date": "2026-04-23",
-        "replacement_models": null,
+        "replacement_models": [
+          "5.4-mini"
+        ],
         "first_observed": "2026-04-23",
-        "last_observed": "2026-04-23"
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "OpenAI",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "openai-computer-use-preview",
+      "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
+      "title": "OpenAI: computer-use-preview",
+      "content_text": "",
+      "date_published": "2026-05-01T21:39:21.868877+00:00",
+      "_deprecation": {
+        "provider": "OpenAI",
+        "model_id": "computer-use-preview",
+        "shutdown_date": "2026-07-23",
+        "deprecation_date": "2026-04-22",
+        "announcement_date": "2026-05-01",
+        "replacement_models": [
+          "5.4-mini"
+        ],
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "OpenAI",
@@ -38,16 +63,18 @@
       "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
       "title": "OpenAI: gpt-4o-audio-preview-2024-12-17",
       "content_text": "",
-      "date_published": "2026-04-23T04:51:54.525206+00:00",
+      "date_published": "2026-05-01T21:39:21.868910+00:00",
       "_deprecation": {
         "provider": "OpenAI",
         "model_id": "gpt-4o-audio-preview-2024-12-17",
         "shutdown_date": "2026-07-23",
         "deprecation_date": "2026-04-22",
         "announcement_date": "2026-04-23",
-        "replacement_models": null,
+        "replacement_models": [
+          "gpt-audio"
+        ],
         "first_observed": "2026-04-23",
-        "last_observed": "2026-04-23"
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "OpenAI",
@@ -59,16 +86,18 @@
       "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
       "title": "OpenAI: gpt-4o-mini-audio-preview-2024-12-17",
       "content_text": "",
-      "date_published": "2026-04-23T04:51:54.525228+00:00",
+      "date_published": "2026-05-01T21:39:21.868932+00:00",
       "_deprecation": {
         "provider": "OpenAI",
         "model_id": "gpt-4o-mini-audio-preview-2024-12-17",
         "shutdown_date": "2026-07-23",
         "deprecation_date": "2026-04-22",
         "announcement_date": "2026-04-23",
-        "replacement_models": null,
+        "replacement_models": [
+          "gpt-audio"
+        ],
         "first_observed": "2026-04-23",
-        "last_observed": "2026-04-23"
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "OpenAI",
@@ -80,16 +109,18 @@
       "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
       "title": "OpenAI: gpt-4o-mini-realtime-preview-2024-12-17",
       "content_text": "",
-      "date_published": "2026-04-23T04:51:54.525243+00:00",
+      "date_published": "2026-05-01T21:39:21.868951+00:00",
       "_deprecation": {
         "provider": "OpenAI",
         "model_id": "gpt-4o-mini-realtime-preview-2024-12-17",
         "shutdown_date": "2026-07-23",
         "deprecation_date": "2026-04-22",
         "announcement_date": "2026-04-23",
-        "replacement_models": null,
+        "replacement_models": [
+          "gpt-realtime-mini"
+        ],
         "first_observed": "2026-04-23",
-        "last_observed": "2026-04-23"
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "OpenAI",
@@ -101,16 +132,18 @@
       "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
       "title": "OpenAI: gpt-4o-mini-search-preview-2025-03-11",
       "content_text": "",
-      "date_published": "2026-04-23T04:51:54.525273+00:00",
+      "date_published": "2026-05-01T21:39:21.868968+00:00",
       "_deprecation": {
         "provider": "OpenAI",
         "model_id": "gpt-4o-mini-search-preview-2025-03-11",
         "shutdown_date": "2026-07-23",
         "deprecation_date": "2026-04-22",
         "announcement_date": "2026-04-23",
-        "replacement_models": null,
+        "replacement_models": [
+          "4.1-mini"
+        ],
         "first_observed": "2026-04-23",
-        "last_observed": "2026-04-23"
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "OpenAI",
@@ -122,16 +155,18 @@
       "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
       "title": "OpenAI: gpt-4o-mini-tts-2025-03-20",
       "content_text": "",
-      "date_published": "2026-04-23T04:51:54.525284+00:00",
+      "date_published": "2026-05-01T21:39:21.868985+00:00",
       "_deprecation": {
         "provider": "OpenAI",
         "model_id": "gpt-4o-mini-tts-2025-03-20",
         "shutdown_date": "2026-07-23",
         "deprecation_date": "2026-04-22",
         "announcement_date": "2026-04-23",
-        "replacement_models": null,
+        "replacement_models": [
+          "gpt-realtime"
+        ],
         "first_observed": "2026-04-23",
-        "last_observed": "2026-04-23"
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "OpenAI",
@@ -143,16 +178,18 @@
       "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
       "title": "OpenAI: gpt-4o-search-preview-2025-03-11",
       "content_text": "",
-      "date_published": "2026-04-23T04:51:54.525295+00:00",
+      "date_published": "2026-05-01T21:39:21.869000+00:00",
       "_deprecation": {
         "provider": "OpenAI",
         "model_id": "gpt-4o-search-preview-2025-03-11",
         "shutdown_date": "2026-07-23",
         "deprecation_date": "2026-04-22",
         "announcement_date": "2026-04-23",
-        "replacement_models": null,
+        "replacement_models": [
+          "gpt-4.1-mini"
+        ],
         "first_observed": "2026-04-23",
-        "last_observed": "2026-04-23"
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "OpenAI",
@@ -164,16 +201,18 @@
       "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
       "title": "OpenAI: gpt-5-chat-latest",
       "content_text": "",
-      "date_published": "2026-04-23T04:51:54.525314+00:00",
+      "date_published": "2026-05-01T21:39:21.869016+00:00",
       "_deprecation": {
         "provider": "OpenAI",
         "model_id": "gpt-5-chat-latest",
         "shutdown_date": "2026-07-23",
         "deprecation_date": "2026-04-22",
         "announcement_date": "2026-04-23",
-        "replacement_models": null,
+        "replacement_models": [
+          "gpt-5.3-chat-latest"
+        ],
         "first_observed": "2026-04-23",
-        "last_observed": "2026-04-23"
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "OpenAI",
@@ -185,16 +224,18 @@
       "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
       "title": "OpenAI: gpt-5-codex",
       "content_text": "",
-      "date_published": "2026-04-23T04:51:54.525329+00:00",
+      "date_published": "2026-05-01T21:39:21.869031+00:00",
       "_deprecation": {
         "provider": "OpenAI",
         "model_id": "gpt-5-codex",
         "shutdown_date": "2026-07-23",
         "deprecation_date": "2026-04-22",
         "announcement_date": "2026-04-23",
-        "replacement_models": null,
+        "replacement_models": [
+          "gpt-5.4"
+        ],
         "first_observed": "2026-04-23",
-        "last_observed": "2026-04-23"
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "OpenAI",
@@ -206,16 +247,18 @@
       "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
       "title": "OpenAI: gpt-5.1-chat-latest",
       "content_text": "",
-      "date_published": "2026-04-23T04:51:54.525340+00:00",
+      "date_published": "2026-05-01T21:39:21.869046+00:00",
       "_deprecation": {
         "provider": "OpenAI",
         "model_id": "gpt-5.1-chat-latest",
         "shutdown_date": "2026-07-23",
         "deprecation_date": "2026-04-22",
         "announcement_date": "2026-04-23",
-        "replacement_models": null,
+        "replacement_models": [
+          "gpt-5.3-chat-latest"
+        ],
         "first_observed": "2026-04-23",
-        "last_observed": "2026-04-23"
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "OpenAI",
@@ -227,16 +270,18 @@
       "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
       "title": "OpenAI: gpt-5.1-codex",
       "content_text": "",
-      "date_published": "2026-04-23T04:51:54.525351+00:00",
+      "date_published": "2026-05-01T21:39:21.869061+00:00",
       "_deprecation": {
         "provider": "OpenAI",
         "model_id": "gpt-5.1-codex",
         "shutdown_date": "2026-07-23",
         "deprecation_date": "2026-04-22",
         "announcement_date": "2026-04-23",
-        "replacement_models": null,
+        "replacement_models": [
+          "gpt-5"
+        ],
         "first_observed": "2026-04-23",
-        "last_observed": "2026-04-23"
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "OpenAI",
@@ -248,16 +293,18 @@
       "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
       "title": "OpenAI: gpt-5.1-codex-max",
       "content_text": "",
-      "date_published": "2026-04-23T04:51:54.525361+00:00",
+      "date_published": "2026-05-01T21:39:21.869077+00:00",
       "_deprecation": {
         "provider": "OpenAI",
         "model_id": "gpt-5.1-codex-max",
         "shutdown_date": "2026-07-23",
         "deprecation_date": "2026-04-22",
         "announcement_date": "2026-04-23",
-        "replacement_models": null,
+        "replacement_models": [
+          "gpt-5.4"
+        ],
         "first_observed": "2026-04-23",
-        "last_observed": "2026-04-23"
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "OpenAI",
@@ -269,16 +316,18 @@
       "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
       "title": "OpenAI: gpt-5.1-codex-mini",
       "content_text": "",
-      "date_published": "2026-04-23T04:51:54.525371+00:00",
+      "date_published": "2026-05-01T21:39:21.869092+00:00",
       "_deprecation": {
         "provider": "OpenAI",
         "model_id": "gpt-5.1-codex-mini",
         "shutdown_date": "2026-07-23",
         "deprecation_date": "2026-04-22",
         "announcement_date": "2026-04-23",
-        "replacement_models": null,
+        "replacement_models": [
+          "gpt-5.4-mini"
+        ],
         "first_observed": "2026-04-23",
-        "last_observed": "2026-04-23"
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "OpenAI",
@@ -290,16 +339,18 @@
       "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
       "title": "OpenAI: gpt-audio-mini-2025-10-06",
       "content_text": "",
-      "date_published": "2026-04-23T04:51:54.525381+00:00",
+      "date_published": "2026-05-01T21:39:21.869106+00:00",
       "_deprecation": {
         "provider": "OpenAI",
         "model_id": "gpt-audio-mini-2025-10-06",
         "shutdown_date": "2026-07-23",
         "deprecation_date": "2026-04-22",
         "announcement_date": "2026-04-23",
-        "replacement_models": null,
+        "replacement_models": [
+          "gpt-audio"
+        ],
         "first_observed": "2026-04-23",
-        "last_observed": "2026-04-23"
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "OpenAI",
@@ -311,16 +362,18 @@
       "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
       "title": "OpenAI: gpt-realtime-mini-2025-10-06",
       "content_text": "",
-      "date_published": "2026-04-23T04:51:54.525391+00:00",
+      "date_published": "2026-05-01T21:39:21.869126+00:00",
       "_deprecation": {
         "provider": "OpenAI",
         "model_id": "gpt-realtime-mini-2025-10-06",
         "shutdown_date": "2026-07-23",
         "deprecation_date": "2026-04-22",
         "announcement_date": "2026-04-23",
-        "replacement_models": null,
+        "replacement_models": [
+          "gpt-realtime-mini"
+        ],
         "first_observed": "2026-04-23",
-        "last_observed": "2026-04-23"
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "OpenAI",
@@ -332,16 +385,41 @@
       "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
       "title": "OpenAI: o3-deep-research-2025-06-26",
       "content_text": "",
-      "date_published": "2026-04-23T04:51:54.525400+00:00",
+      "date_published": "2026-05-01T21:39:21.869144+00:00",
       "_deprecation": {
         "provider": "OpenAI",
         "model_id": "o3-deep-research-2025-06-26",
         "shutdown_date": "2026-07-23",
         "deprecation_date": "2026-04-22",
         "announcement_date": "2026-04-23",
-        "replacement_models": null,
+        "replacement_models": [
+          "5.4-Pro"
+        ],
         "first_observed": "2026-04-23",
-        "last_observed": "2026-04-23"
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "OpenAI",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "openai-o3-deep-research",
+      "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
+      "title": "OpenAI: o3-deep-research",
+      "content_text": "",
+      "date_published": "2026-05-01T21:39:21.869150+00:00",
+      "_deprecation": {
+        "provider": "OpenAI",
+        "model_id": "o3-deep-research",
+        "shutdown_date": "2026-07-23",
+        "deprecation_date": "2026-04-22",
+        "announcement_date": "2026-05-01",
+        "replacement_models": [
+          "5.4-Pro"
+        ],
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "OpenAI",
@@ -353,16 +431,41 @@
       "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
       "title": "OpenAI: o4-mini-deep-research-2025-06-26",
       "content_text": "",
-      "date_published": "2026-04-23T04:51:54.525409+00:00",
+      "date_published": "2026-05-01T21:39:21.869166+00:00",
       "_deprecation": {
         "provider": "OpenAI",
         "model_id": "o4-mini-deep-research-2025-06-26",
         "shutdown_date": "2026-07-23",
         "deprecation_date": "2026-04-22",
         "announcement_date": "2026-04-23",
-        "replacement_models": null,
+        "replacement_models": [
+          "5.4-Pro"
+        ],
         "first_observed": "2026-04-23",
-        "last_observed": "2026-04-23"
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "OpenAI",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "openai-o4-mini-deep-research",
+      "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
+      "title": "OpenAI: o4-mini-deep-research",
+      "content_text": "",
+      "date_published": "2026-05-01T21:39:21.869172+00:00",
+      "_deprecation": {
+        "provider": "OpenAI",
+        "model_id": "o4-mini-deep-research",
+        "shutdown_date": "2026-07-23",
+        "deprecation_date": "2026-04-22",
+        "announcement_date": "2026-05-01",
+        "replacement_models": [
+          "5.4-Pro"
+        ],
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "OpenAI",
@@ -374,16 +477,18 @@
       "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
       "title": "OpenAI: gpt-5.2-codex",
       "content_text": "",
-      "date_published": "2026-04-23T04:51:54.525419+00:00",
+      "date_published": "2026-05-01T21:39:21.869186+00:00",
       "_deprecation": {
         "provider": "OpenAI",
         "model_id": "gpt-5.2-codex",
         "shutdown_date": "2026-07-23",
         "deprecation_date": "2026-04-22",
         "announcement_date": "2026-04-23",
-        "replacement_models": null,
+        "replacement_models": [
+          "gpt-5.4"
+        ],
         "first_observed": "2026-04-23",
-        "last_observed": "2026-04-23"
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "OpenAI",
@@ -395,16 +500,64 @@
       "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
       "title": "OpenAI: gpt-3.5-turbo-0125",
       "content_text": "",
-      "date_published": "2026-04-23T04:51:54.525428+00:00",
+      "date_published": "2026-05-01T21:39:21.869204+00:00",
       "_deprecation": {
         "provider": "OpenAI",
         "model_id": "gpt-3.5-turbo-0125",
         "shutdown_date": "2026-10-23",
         "deprecation_date": "2026-04-22",
         "announcement_date": "2026-04-23",
-        "replacement_models": null,
+        "replacement_models": [
+          "gpt-4.1-mini"
+        ],
         "first_observed": "2026-04-23",
-        "last_observed": "2026-04-23"
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "OpenAI",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "openai-gpt-3.5-turbo",
+      "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
+      "title": "OpenAI: gpt-3.5-turbo",
+      "content_text": "",
+      "date_published": "2026-05-01T21:39:21.869210+00:00",
+      "_deprecation": {
+        "provider": "OpenAI",
+        "model_id": "gpt-3.5-turbo",
+        "shutdown_date": "2026-10-23",
+        "deprecation_date": "2026-04-22",
+        "announcement_date": "2026-05-01",
+        "replacement_models": [
+          "gpt-4.1-mini"
+        ],
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "OpenAI",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "openai-gpt-3.5-turbo-completions",
+      "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
+      "title": "OpenAI: gpt-3.5-turbo-completions",
+      "content_text": "",
+      "date_published": "2026-05-01T21:39:21.869214+00:00",
+      "_deprecation": {
+        "provider": "OpenAI",
+        "model_id": "gpt-3.5-turbo-completions",
+        "shutdown_date": "2026-10-23",
+        "deprecation_date": "2026-04-22",
+        "announcement_date": "2026-05-01",
+        "replacement_models": [
+          "gpt-4.1-mini"
+        ],
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "OpenAI",
@@ -416,16 +569,87 @@
       "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
       "title": "OpenAI: gpt-4-0613",
       "content_text": "",
-      "date_published": "2026-04-23T04:51:54.525437+00:00",
+      "date_published": "2026-05-01T21:39:21.869274+00:00",
       "_deprecation": {
         "provider": "OpenAI",
         "model_id": "gpt-4-0613",
         "shutdown_date": "2026-10-23",
         "deprecation_date": "2026-04-22",
         "announcement_date": "2026-04-23",
-        "replacement_models": null,
+        "replacement_models": [
+          "gpt-4.1"
+        ],
         "first_observed": "2026-04-23",
-        "last_observed": "2026-04-23"
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "OpenAI",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "openai-gpt-4",
+      "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
+      "title": "OpenAI: gpt-4",
+      "content_text": "",
+      "date_published": "2026-05-01T21:39:21.869293+00:00",
+      "_deprecation": {
+        "provider": "OpenAI",
+        "model_id": "gpt-4",
+        "shutdown_date": "2026-10-23",
+        "deprecation_date": "2026-04-22",
+        "announcement_date": "2026-05-01",
+        "replacement_models": [
+          "gpt-4.1"
+        ],
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "OpenAI",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "openai-gpt-4-0613-completions",
+      "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
+      "title": "OpenAI: gpt-4-0613-completions",
+      "content_text": "",
+      "date_published": "2026-05-01T21:39:21.869302+00:00",
+      "_deprecation": {
+        "provider": "OpenAI",
+        "model_id": "gpt-4-0613-completions",
+        "shutdown_date": "2026-10-23",
+        "deprecation_date": "2026-04-22",
+        "announcement_date": "2026-05-01",
+        "replacement_models": [
+          "gpt-4.1"
+        ],
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "OpenAI",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "openai-gpt-4-completions",
+      "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
+      "title": "OpenAI: gpt-4-completions",
+      "content_text": "",
+      "date_published": "2026-05-01T21:39:21.869308+00:00",
+      "_deprecation": {
+        "provider": "OpenAI",
+        "model_id": "gpt-4-completions",
+        "shutdown_date": "2026-10-23",
+        "deprecation_date": "2026-04-22",
+        "announcement_date": "2026-05-01",
+        "replacement_models": [
+          "gpt-4.1"
+        ],
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "OpenAI",
@@ -437,16 +661,18 @@
       "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
       "title": "OpenAI: gpt-4-1106-preview",
       "content_text": "",
-      "date_published": "2026-04-23T04:51:54.525446+00:00",
+      "date_published": "2026-05-01T21:39:21.869329+00:00",
       "_deprecation": {
         "provider": "OpenAI",
         "model_id": "gpt-4-1106-preview",
         "shutdown_date": "2026-10-23",
         "deprecation_date": "2026-04-22",
         "announcement_date": "2026-03-26",
-        "replacement_models": null,
+        "replacement_models": [
+          "gpt-4.1"
+        ],
         "first_observed": "2026-03-26",
-        "last_observed": "2026-04-23"
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "OpenAI",
@@ -458,16 +684,64 @@
       "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
       "title": "OpenAI: gpt-4-turbo",
       "content_text": "",
-      "date_published": "2026-04-23T04:51:54.525455+00:00",
+      "date_published": "2026-05-01T21:39:21.869350+00:00",
       "_deprecation": {
         "provider": "OpenAI",
         "model_id": "gpt-4-turbo",
         "shutdown_date": "2026-10-23",
         "deprecation_date": "2026-04-22",
         "announcement_date": "2026-04-23",
-        "replacement_models": null,
+        "replacement_models": [
+          "gpt-4.1"
+        ],
         "first_observed": "2026-04-23",
-        "last_observed": "2026-04-23"
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "OpenAI",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "openai-gpt-4-turbo-2024-04-09",
+      "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
+      "title": "OpenAI: gpt-4-turbo-2024-04-09",
+      "content_text": "",
+      "date_published": "2026-05-01T21:39:21.869362+00:00",
+      "_deprecation": {
+        "provider": "OpenAI",
+        "model_id": "gpt-4-turbo-2024-04-09",
+        "shutdown_date": "2026-10-23",
+        "deprecation_date": "2026-04-22",
+        "announcement_date": "2026-05-01",
+        "replacement_models": [
+          "gpt-4.1"
+        ],
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "OpenAI",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "openai-gpt-4-turbo-completions",
+      "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
+      "title": "OpenAI: gpt-4-turbo-completions",
+      "content_text": "",
+      "date_published": "2026-05-01T21:39:21.869450+00:00",
+      "_deprecation": {
+        "provider": "OpenAI",
+        "model_id": "gpt-4-turbo-completions",
+        "shutdown_date": "2026-10-23",
+        "deprecation_date": "2026-04-22",
+        "announcement_date": "2026-05-01",
+        "replacement_models": [
+          "gpt-4.1"
+        ],
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "OpenAI",
@@ -479,16 +753,41 @@
       "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
       "title": "OpenAI: gpt-4.1-nano",
       "content_text": "",
-      "date_published": "2026-04-23T04:51:54.525464+00:00",
+      "date_published": "2026-05-01T21:39:21.869494+00:00",
       "_deprecation": {
         "provider": "OpenAI",
         "model_id": "gpt-4.1-nano",
         "shutdown_date": "2026-10-23",
         "deprecation_date": "2026-04-22",
         "announcement_date": "2026-04-23",
-        "replacement_models": null,
+        "replacement_models": [
+          "gpt-5-nano"
+        ],
         "first_observed": "2026-04-23",
-        "last_observed": "2026-04-23"
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "OpenAI",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "openai-gpt-4.1-nano-2025-04-14",
+      "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
+      "title": "OpenAI: gpt-4.1-nano-2025-04-14",
+      "content_text": "",
+      "date_published": "2026-05-01T21:39:21.869503+00:00",
+      "_deprecation": {
+        "provider": "OpenAI",
+        "model_id": "gpt-4.1-nano-2025-04-14",
+        "shutdown_date": "2026-10-23",
+        "deprecation_date": "2026-04-22",
+        "announcement_date": "2026-05-01",
+        "replacement_models": [
+          "gpt-5-nano"
+        ],
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "OpenAI",
@@ -500,16 +799,18 @@
       "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
       "title": "OpenAI: gpt-4o-2024-05-13",
       "content_text": "",
-      "date_published": "2026-04-23T04:51:54.525473+00:00",
+      "date_published": "2026-05-01T21:39:21.869524+00:00",
       "_deprecation": {
         "provider": "OpenAI",
         "model_id": "gpt-4o-2024-05-13",
         "shutdown_date": "2026-10-23",
         "deprecation_date": "2026-04-22",
         "announcement_date": "2026-04-23",
-        "replacement_models": null,
+        "replacement_models": [
+          "gpt-4.1"
+        ],
         "first_observed": "2026-04-23",
-        "last_observed": "2026-04-23"
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "OpenAI",
@@ -521,16 +822,18 @@
       "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
       "title": "OpenAI: gpt-image-1",
       "content_text": "",
-      "date_published": "2026-04-23T04:51:54.525487+00:00",
+      "date_published": "2026-05-01T21:39:21.869547+00:00",
       "_deprecation": {
         "provider": "OpenAI",
         "model_id": "gpt-image-1",
         "shutdown_date": "2026-10-23",
         "deprecation_date": "2026-04-22",
         "announcement_date": "2026-04-23",
-        "replacement_models": null,
+        "replacement_models": [
+          "gpt-image-1.5"
+        ],
         "first_observed": "2026-04-23",
-        "last_observed": "2026-04-23"
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "OpenAI",
@@ -542,16 +845,41 @@
       "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
       "title": "OpenAI: o1-2024-12-17",
       "content_text": "",
-      "date_published": "2026-04-23T04:51:54.525496+00:00",
+      "date_published": "2026-05-01T21:39:21.869568+00:00",
       "_deprecation": {
         "provider": "OpenAI",
         "model_id": "o1-2024-12-17",
         "shutdown_date": "2026-10-23",
         "deprecation_date": "2026-04-22",
         "announcement_date": "2026-04-23",
-        "replacement_models": null,
+        "replacement_models": [
+          "o3"
+        ],
         "first_observed": "2026-04-23",
-        "last_observed": "2026-04-23"
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "OpenAI",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "openai-o1",
+      "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
+      "title": "OpenAI: o1",
+      "content_text": "",
+      "date_published": "2026-05-01T21:39:21.869574+00:00",
+      "_deprecation": {
+        "provider": "OpenAI",
+        "model_id": "o1",
+        "shutdown_date": "2026-10-23",
+        "deprecation_date": "2026-04-22",
+        "announcement_date": "2026-05-01",
+        "replacement_models": [
+          "o3"
+        ],
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "OpenAI",
@@ -563,16 +891,41 @@
       "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
       "title": "OpenAI: o1-pro-2025-03-19",
       "content_text": "",
-      "date_published": "2026-04-23T04:51:54.525506+00:00",
+      "date_published": "2026-05-01T21:39:21.869591+00:00",
       "_deprecation": {
         "provider": "OpenAI",
         "model_id": "o1-pro-2025-03-19",
         "shutdown_date": "2026-10-23",
         "deprecation_date": "2026-04-22",
         "announcement_date": "2026-04-23",
-        "replacement_models": null,
+        "replacement_models": [
+          "5.4-Pro"
+        ],
         "first_observed": "2026-04-23",
-        "last_observed": "2026-04-23"
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "OpenAI",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "openai-o1-pro",
+      "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
+      "title": "OpenAI: o1-pro",
+      "content_text": "",
+      "date_published": "2026-05-01T21:39:21.869596+00:00",
+      "_deprecation": {
+        "provider": "OpenAI",
+        "model_id": "o1-pro",
+        "shutdown_date": "2026-10-23",
+        "deprecation_date": "2026-04-22",
+        "announcement_date": "2026-05-01",
+        "replacement_models": [
+          "5.4-Pro"
+        ],
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "OpenAI",
@@ -584,16 +937,41 @@
       "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
       "title": "OpenAI: o3-mini-2025-01-31",
       "content_text": "",
-      "date_published": "2026-04-23T04:51:54.525515+00:00",
+      "date_published": "2026-05-01T21:39:21.869612+00:00",
       "_deprecation": {
         "provider": "OpenAI",
         "model_id": "o3-mini-2025-01-31",
         "shutdown_date": "2026-10-23",
         "deprecation_date": "2026-04-22",
         "announcement_date": "2026-04-23",
-        "replacement_models": null,
+        "replacement_models": [
+          "o3"
+        ],
         "first_observed": "2026-04-23",
-        "last_observed": "2026-04-23"
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "OpenAI",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "openai-o3-mini",
+      "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
+      "title": "OpenAI: o3-mini",
+      "content_text": "",
+      "date_published": "2026-05-01T21:39:21.869618+00:00",
+      "_deprecation": {
+        "provider": "OpenAI",
+        "model_id": "o3-mini",
+        "shutdown_date": "2026-10-23",
+        "deprecation_date": "2026-04-22",
+        "announcement_date": "2026-05-01",
+        "replacement_models": [
+          "o3"
+        ],
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "OpenAI",
@@ -605,16 +983,18 @@
       "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
       "title": "OpenAI: ft-o4-mini-2025-04-16",
       "content_text": "",
-      "date_published": "2026-04-23T04:51:54.525524+00:00",
+      "date_published": "2026-05-01T21:39:21.869633+00:00",
       "_deprecation": {
         "provider": "OpenAI",
         "model_id": "ft-o4-mini-2025-04-16",
         "shutdown_date": "2026-10-23",
         "deprecation_date": "2026-04-22",
         "announcement_date": "2026-04-23",
-        "replacement_models": null,
+        "replacement_models": [
+          "gpt-5-mini"
+        ],
         "first_observed": "2026-04-23",
-        "last_observed": "2026-04-23"
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "OpenAI",
@@ -626,16 +1006,41 @@
       "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
       "title": "OpenAI: o4-mini-2025-04-16",
       "content_text": "",
-      "date_published": "2026-04-23T04:51:54.525533+00:00",
+      "date_published": "2026-05-01T21:39:21.869648+00:00",
       "_deprecation": {
         "provider": "OpenAI",
         "model_id": "o4-mini-2025-04-16",
         "shutdown_date": "2026-10-23",
         "deprecation_date": "2026-04-22",
         "announcement_date": "2026-04-23",
-        "replacement_models": null,
+        "replacement_models": [
+          "gpt-5-mini"
+        ],
         "first_observed": "2026-04-23",
-        "last_observed": "2026-04-23"
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "OpenAI",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "openai-o4-mini",
+      "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
+      "title": "OpenAI: o4-mini",
+      "content_text": "",
+      "date_published": "2026-05-01T21:39:21.869654+00:00",
+      "_deprecation": {
+        "provider": "OpenAI",
+        "model_id": "o4-mini",
+        "shutdown_date": "2026-10-23",
+        "deprecation_date": "2026-04-22",
+        "announcement_date": "2026-05-01",
+        "replacement_models": [
+          "gpt-5-mini"
+        ],
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "OpenAI",
@@ -647,16 +1052,18 @@
       "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
       "title": "OpenAI: ft-gpt-3.5-turbo",
       "content_text": "",
-      "date_published": "2026-04-23T04:51:54.525557+00:00",
+      "date_published": "2026-05-01T21:39:21.869737+00:00",
       "_deprecation": {
         "provider": "OpenAI",
         "model_id": "ft-gpt-3.5-turbo",
         "shutdown_date": "2026-10-23",
         "deprecation_date": "2026-04-22",
         "announcement_date": "2026-04-23",
-        "replacement_models": null,
+        "replacement_models": [
+          "gpt-4.1-mini"
+        ],
         "first_observed": "2026-04-23",
-        "last_observed": "2026-04-23"
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "OpenAI",
@@ -668,16 +1075,18 @@
       "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
       "title": "OpenAI: ft-gpt-4",
       "content_text": "",
-      "date_published": "2026-04-23T04:51:54.525567+00:00",
+      "date_published": "2026-05-01T21:39:21.869755+00:00",
       "_deprecation": {
         "provider": "OpenAI",
         "model_id": "ft-gpt-4",
         "shutdown_date": "2026-10-23",
         "deprecation_date": "2026-04-22",
         "announcement_date": "2026-04-23",
-        "replacement_models": null,
+        "replacement_models": [
+          "gpt-4.1"
+        ],
         "first_observed": "2026-04-23",
-        "last_observed": "2026-04-23"
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "OpenAI",
@@ -689,16 +1098,18 @@
       "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
       "title": "OpenAI: ft-gpt-4.1-nano-2025-04-14",
       "content_text": "",
-      "date_published": "2026-04-23T04:51:54.525577+00:00",
+      "date_published": "2026-05-01T21:39:21.869771+00:00",
       "_deprecation": {
         "provider": "OpenAI",
         "model_id": "ft-gpt-4.1-nano-2025-04-14",
         "shutdown_date": "2026-10-23",
         "deprecation_date": "2026-04-22",
         "announcement_date": "2026-04-23",
-        "replacement_models": null,
+        "replacement_models": [
+          "gpt-5-nano"
+        ],
         "first_observed": "2026-04-23",
-        "last_observed": "2026-04-23"
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "OpenAI",
@@ -710,16 +1121,18 @@
       "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
       "title": "OpenAI: ft-babbage-002",
       "content_text": "",
-      "date_published": "2026-04-23T04:51:54.525586+00:00",
+      "date_published": "2026-05-01T21:39:21.869786+00:00",
       "_deprecation": {
         "provider": "OpenAI",
         "model_id": "ft-babbage-002",
         "shutdown_date": "2026-10-23",
         "deprecation_date": "2026-04-22",
         "announcement_date": "2026-04-23",
-        "replacement_models": null,
+        "replacement_models": [
+          "gpt-5-mini"
+        ],
         "first_observed": "2026-04-23",
-        "last_observed": "2026-04-23"
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "OpenAI",
@@ -731,16 +1144,18 @@
       "url": "https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots",
       "title": "OpenAI: ft-davinci-002",
       "content_text": "",
-      "date_published": "2026-04-23T04:51:54.525595+00:00",
+      "date_published": "2026-05-01T21:39:21.869800+00:00",
       "_deprecation": {
         "provider": "OpenAI",
         "model_id": "ft-davinci-002",
         "shutdown_date": "2026-10-23",
         "deprecation_date": "2026-04-22",
         "announcement_date": "2026-04-23",
-        "replacement_models": null,
+        "replacement_models": [
+          "gpt-5-mini"
+        ],
         "first_observed": "2026-04-23",
-        "last_observed": "2026-04-23"
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "OpenAI",
@@ -752,18 +1167,16 @@
       "url": "https://platform.openai.com/docs/deprecations#2026-03-24-sora-2-video-generation-models-and-videos-api",
       "title": "OpenAI: sora-2",
       "content_text": "",
-      "date_published": "2026-03-27T04:35:42.378612+00:00",
+      "date_published": "2026-05-01T21:39:21.869964+00:00",
       "_deprecation": {
         "provider": "OpenAI",
         "model_id": "sora-2",
         "shutdown_date": "2026-09-24",
         "deprecation_date": "2026-03-24",
         "announcement_date": "2026-03-27",
-        "replacement_models": [
-          "---"
-        ],
+        "replacement_models": null,
         "first_observed": "2026-03-27",
-        "last_observed": "2026-03-27"
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "OpenAI",
@@ -775,18 +1188,16 @@
       "url": "https://platform.openai.com/docs/deprecations#2026-03-24-sora-2-video-generation-models-and-videos-api",
       "title": "OpenAI: sora-2-pro",
       "content_text": "",
-      "date_published": "2026-03-27T04:35:42.378649+00:00",
+      "date_published": "2026-05-01T21:39:21.869986+00:00",
       "_deprecation": {
         "provider": "OpenAI",
         "model_id": "sora-2-pro",
         "shutdown_date": "2026-09-24",
         "deprecation_date": "2026-03-24",
         "announcement_date": "2026-03-27",
-        "replacement_models": [
-          "---"
-        ],
+        "replacement_models": null,
         "first_observed": "2026-03-27",
-        "last_observed": "2026-03-27"
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "OpenAI",
@@ -798,18 +1209,16 @@
       "url": "https://platform.openai.com/docs/deprecations#2026-03-24-sora-2-video-generation-models-and-videos-api",
       "title": "OpenAI: sora-2-2025-10-06",
       "content_text": "",
-      "date_published": "2026-03-27T04:35:42.378673+00:00",
+      "date_published": "2026-05-01T21:39:21.870005+00:00",
       "_deprecation": {
         "provider": "OpenAI",
         "model_id": "sora-2-2025-10-06",
         "shutdown_date": "2026-09-24",
         "deprecation_date": "2026-03-24",
         "announcement_date": "2026-03-27",
-        "replacement_models": [
-          "---"
-        ],
+        "replacement_models": null,
         "first_observed": "2026-03-27",
-        "last_observed": "2026-03-27"
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "OpenAI",
@@ -821,18 +1230,16 @@
       "url": "https://platform.openai.com/docs/deprecations#2026-03-24-sora-2-video-generation-models-and-videos-api",
       "title": "OpenAI: sora-2-2025-12-08",
       "content_text": "",
-      "date_published": "2026-03-27T04:35:42.378692+00:00",
+      "date_published": "2026-05-01T21:39:21.870021+00:00",
       "_deprecation": {
         "provider": "OpenAI",
         "model_id": "sora-2-2025-12-08",
         "shutdown_date": "2026-09-24",
         "deprecation_date": "2026-03-24",
         "announcement_date": "2026-03-27",
-        "replacement_models": [
-          "---"
-        ],
+        "replacement_models": null,
         "first_observed": "2026-03-27",
-        "last_observed": "2026-03-27"
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "OpenAI",
@@ -844,18 +1251,16 @@
       "url": "https://platform.openai.com/docs/deprecations#2026-03-24-sora-2-video-generation-models-and-videos-api",
       "title": "OpenAI: sora-2-pro-2025-10-06",
       "content_text": "",
-      "date_published": "2026-03-27T04:35:42.378709+00:00",
+      "date_published": "2026-05-01T21:39:21.870035+00:00",
       "_deprecation": {
         "provider": "OpenAI",
         "model_id": "sora-2-pro-2025-10-06",
         "shutdown_date": "2026-09-24",
         "deprecation_date": "2026-03-24",
         "announcement_date": "2026-03-27",
-        "replacement_models": [
-          "---"
-        ],
+        "replacement_models": null,
         "first_observed": "2026-03-27",
-        "last_observed": "2026-03-27"
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "OpenAI",
@@ -2805,308 +3210,832 @@
       ]
     },
     {
-      "id": "google-gemini-robotics-er-1.6-preview",
-      "url": "https://ai.google.dev/gemini-api/docs/changelog#20260414",
-      "title": "Google: gemini-robotics-er-1.6-preview",
+      "id": "google-gemini-3-pro-preview",
+      "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-3-models",
+      "title": "Google: gemini-3-pro-preview",
       "content_text": "",
-      "date_published": "2026-04-15T04:47:23.808563+00:00",
+      "date_published": "2026-05-01T21:43:36.810852+00:00",
       "_deprecation": {
         "provider": "Google",
-        "model_id": "gemini-robotics-er-1.6-preview",
-        "shutdown_date": "",
-        "deprecation_date": "2026-04-14",
-        "announcement_date": "2026-04-15",
-        "replacement_models": null,
-        "first_observed": "2026-04-15",
-        "last_observed": "2026-04-15"
+        "model_id": "gemini-3-pro-preview",
+        "shutdown_date": "2026-03-09",
+        "deprecation_date": "2026-03-09",
+        "announcement_date": "2026-02-27",
+        "replacement_models": [
+          "gemini-3.1-pro-preview"
+        ],
+        "first_observed": "2026-02-27",
+        "last_observed": "2026-05-01"
       },
       "tags": [
-        "Google"
+        "Google",
+        "shutdown-2026"
       ]
     },
     {
-      "id": "google-gemini-robotics-er-1.5-preview",
-      "url": "https://ai.google.dev/gemini-api/docs/changelog#20260414",
-      "title": "Google: gemini-robotics-er-1.5-preview",
+      "id": "google-gemini-2.5-pro",
+      "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.5-pro-models",
+      "title": "Google: gemini-2.5-pro",
       "content_text": "",
-      "date_published": "2026-04-15T04:47:23.808648+00:00",
+      "date_published": "2026-05-01T21:43:36.811332+00:00",
       "_deprecation": {
         "provider": "Google",
-        "model_id": "gemini-robotics-er-1.5-preview",
-        "shutdown_date": "",
-        "deprecation_date": "2026-04-14",
-        "announcement_date": "2026-04-15",
-        "replacement_models": null,
-        "first_observed": "2026-04-15",
-        "last_observed": "2026-04-15"
+        "model_id": "gemini-2.5-pro",
+        "shutdown_date": "2026-06-17",
+        "deprecation_date": "2026-06-17",
+        "announcement_date": "2025-12-05",
+        "replacement_models": [
+          "gemini-3.1-pro-preview"
+        ],
+        "first_observed": "2025-12-05",
+        "last_observed": "2026-05-01"
       },
       "tags": [
-        "Google"
+        "Google",
+        "shutdown-2026"
       ]
     },
     {
-      "id": "google-gemini-embedding-2-preview",
-      "url": "https://ai.google.dev/gemini-api/docs/changelog#20260310",
-      "title": "Google: gemini-embedding-2-preview",
+      "id": "google-gemini-2.5-pro-preview-03-25",
+      "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.5-pro-models",
+      "title": "Google: gemini-2.5-pro-preview-03-25",
       "content_text": "",
-      "date_published": "2026-03-12T04:07:19.839599+00:00",
+      "date_published": "2026-05-01T21:43:36.811516+00:00",
       "_deprecation": {
         "provider": "Google",
-        "model_id": "gemini-embedding-2-preview",
-        "shutdown_date": "",
-        "deprecation_date": "2026-03-10",
-        "announcement_date": "2026-03-12",
-        "replacement_models": null,
-        "first_observed": "2026-03-12",
-        "last_observed": "2026-03-12"
+        "model_id": "gemini-2.5-pro-preview-03-25",
+        "shutdown_date": "2025-12-02",
+        "deprecation_date": "2025-12-02",
+        "announcement_date": "2025-12-05",
+        "replacement_models": [
+          "gemini-3.1-pro-preview"
+        ],
+        "first_observed": "2025-12-05",
+        "last_observed": "2026-05-01"
       },
       "tags": [
-        "Google"
+        "Google",
+        "shutdown-2025"
+      ]
+    },
+    {
+      "id": "google-gemini-2.5-pro-preview-05-06",
+      "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.5-pro-models",
+      "title": "Google: gemini-2.5-pro-preview-05-06",
+      "content_text": "",
+      "date_published": "2026-05-01T21:43:36.811657+00:00",
+      "_deprecation": {
+        "provider": "Google",
+        "model_id": "gemini-2.5-pro-preview-05-06",
+        "shutdown_date": "2025-12-02",
+        "deprecation_date": "2025-12-02",
+        "announcement_date": "2025-12-05",
+        "replacement_models": [
+          "gemini-3.1-pro-preview"
+        ],
+        "first_observed": "2025-12-05",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Google",
+        "shutdown-2025"
+      ]
+    },
+    {
+      "id": "google-gemini-2.5-pro-preview-06-05",
+      "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.5-pro-models",
+      "title": "Google: gemini-2.5-pro-preview-06-05",
+      "content_text": "",
+      "date_published": "2026-05-01T21:43:36.811794+00:00",
+      "_deprecation": {
+        "provider": "Google",
+        "model_id": "gemini-2.5-pro-preview-06-05",
+        "shutdown_date": "2025-12-02",
+        "deprecation_date": "2025-12-02",
+        "announcement_date": "2025-12-05",
+        "replacement_models": [
+          "gemini-3.1-pro-preview"
+        ],
+        "first_observed": "2025-12-05",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Google",
+        "shutdown-2025"
+      ]
+    },
+    {
+      "id": "google-gemini-2.5-flash",
+      "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.5-flash-models",
+      "title": "Google: gemini-2.5-flash",
+      "content_text": "",
+      "date_published": "2026-05-01T21:43:36.812091+00:00",
+      "_deprecation": {
+        "provider": "Google",
+        "model_id": "gemini-2.5-flash",
+        "shutdown_date": "2026-06-17",
+        "deprecation_date": "2026-06-17",
+        "announcement_date": "2025-12-05",
+        "replacement_models": [
+          "gemini-3-flash-preview"
+        ],
+        "first_observed": "2025-12-05",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Google",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "google-gemini-2.5-flash-image",
+      "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.5-flash-models",
+      "title": "Google: gemini-2.5-flash-image",
+      "content_text": "",
+      "date_published": "2026-05-01T21:43:36.812255+00:00",
+      "_deprecation": {
+        "provider": "Google",
+        "model_id": "gemini-2.5-flash-image",
+        "shutdown_date": "2026-10-02",
+        "deprecation_date": "2026-10-02",
+        "announcement_date": "2026-05-01",
+        "replacement_models": [
+          "gemini-3.1-flash-image-preview"
+        ],
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Google",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "google-gemini-2.5-flash-lite",
+      "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.5-flash-models",
+      "title": "Google: gemini-2.5-flash-lite",
+      "content_text": "",
+      "date_published": "2026-05-01T21:43:36.812419+00:00",
+      "_deprecation": {
+        "provider": "Google",
+        "model_id": "gemini-2.5-flash-lite",
+        "shutdown_date": "2026-07-22",
+        "deprecation_date": "2026-07-22",
+        "announcement_date": "2026-05-01",
+        "replacement_models": [
+          "gemini-3.1-flash-lite-preview"
+        ],
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Google",
+        "shutdown-2026"
       ]
     },
     {
       "id": "google-gemini-2.5-flash-lite-preview-09-2025",
-      "url": "https://ai.google.dev/gemini-api/docs/changelog#20260310",
+      "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.5-flash-models",
       "title": "Google: gemini-2.5-flash-lite-preview-09-2025",
       "content_text": "",
-      "date_published": "2026-03-12T04:07:19.839689+00:00",
+      "date_published": "2026-05-01T21:43:36.812586+00:00",
       "_deprecation": {
         "provider": "Google",
         "model_id": "gemini-2.5-flash-lite-preview-09-2025",
-        "shutdown_date": "",
-        "deprecation_date": "2026-03-10",
+        "shutdown_date": "2026-03-31",
+        "deprecation_date": "2026-03-31",
         "announcement_date": "2026-03-12",
-        "replacement_models": null,
+        "replacement_models": [
+          "gemini-3.1-flash-lite-preview"
+        ],
         "first_observed": "2026-03-12",
-        "last_observed": "2026-03-12"
+        "last_observed": "2026-05-01"
       },
       "tags": [
-        "Google"
+        "Google",
+        "shutdown-2026"
       ]
     },
     {
-      "id": "google-gemini-3-pro-preview",
-      "url": "https://ai.google.dev/gemini-api/docs/changelog#20260226",
-      "title": "Google: gemini-3-pro-preview",
+      "id": "google-gemini-2.5-flash-preview-05-20",
+      "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.5-flash-models",
+      "title": "Google: gemini-2.5-flash-preview-05-20",
       "content_text": "",
-      "date_published": "2026-02-27T04:06:58.664291+00:00",
+      "date_published": "2026-05-01T21:43:36.812719+00:00",
       "_deprecation": {
         "provider": "Google",
-        "model_id": "gemini-3-pro-preview",
-        "shutdown_date": "",
-        "deprecation_date": "2026-02-26",
-        "announcement_date": "2026-02-27",
-        "replacement_models": null,
-        "first_observed": "2026-02-27",
-        "last_observed": "2026-02-27"
+        "model_id": "gemini-2.5-flash-preview-05-20",
+        "shutdown_date": "2025-11-18",
+        "deprecation_date": "2025-11-18",
+        "announcement_date": "2025-12-05",
+        "replacement_models": [
+          "gemini-3-flash-preview"
+        ],
+        "first_observed": "2025-12-05",
+        "last_observed": "2026-05-01"
       },
       "tags": [
-        "Google"
-      ]
-    },
-    {
-      "id": "google-gemini-2.0-flash",
-      "url": "https://ai.google.dev/gemini-api/docs/changelog#20260218",
-      "title": "Google: gemini-2.0-flash",
-      "content_text": "",
-      "date_published": "2026-02-20T04:09:02.875598+00:00",
-      "_deprecation": {
-        "provider": "Google",
-        "model_id": "gemini-2.0-flash",
-        "shutdown_date": "",
-        "deprecation_date": "2026-02-18",
-        "announcement_date": "2026-02-20",
-        "replacement_models": null,
-        "first_observed": "2026-02-20",
-        "last_observed": "2026-02-20"
-      },
-      "tags": [
-        "Google"
-      ]
-    },
-    {
-      "id": "google-gemini-2.0-flash-001",
-      "url": "https://ai.google.dev/gemini-api/docs/changelog#20260218",
-      "title": "Google: gemini-2.0-flash-001",
-      "content_text": "",
-      "date_published": "2026-02-20T04:09:02.875718+00:00",
-      "_deprecation": {
-        "provider": "Google",
-        "model_id": "gemini-2.0-flash-001",
-        "shutdown_date": "",
-        "deprecation_date": "2026-02-18",
-        "announcement_date": "2026-02-20",
-        "replacement_models": null,
-        "first_observed": "2026-02-20",
-        "last_observed": "2026-02-20"
-      },
-      "tags": [
-        "Google"
-      ]
-    },
-    {
-      "id": "google-gemini-2.0-flash-lite",
-      "url": "https://ai.google.dev/gemini-api/docs/changelog#20260218",
-      "title": "Google: gemini-2.0-flash-lite",
-      "content_text": "",
-      "date_published": "2026-02-20T04:09:02.875804+00:00",
-      "_deprecation": {
-        "provider": "Google",
-        "model_id": "gemini-2.0-flash-lite",
-        "shutdown_date": "",
-        "deprecation_date": "2026-02-18",
-        "announcement_date": "2026-02-20",
-        "replacement_models": null,
-        "first_observed": "2026-02-20",
-        "last_observed": "2026-02-20"
-      },
-      "tags": [
-        "Google"
-      ]
-    },
-    {
-      "id": "google-gemini-2.0-flash-lite-001",
-      "url": "https://ai.google.dev/gemini-api/docs/changelog#20260218",
-      "title": "Google: gemini-2.0-flash-lite-001",
-      "content_text": "",
-      "date_published": "2026-02-20T04:09:02.875883+00:00",
-      "_deprecation": {
-        "provider": "Google",
-        "model_id": "gemini-2.0-flash-lite-001",
-        "shutdown_date": "",
-        "deprecation_date": "2026-02-18",
-        "announcement_date": "2026-02-20",
-        "replacement_models": null,
-        "first_observed": "2026-02-20",
-        "last_observed": "2026-02-20"
-      },
-      "tags": [
-        "Google"
-      ]
-    },
-    {
-      "id": "google-gemini-2.5-flash-preview-09-25",
-      "url": "https://ai.google.dev/gemini-api/docs/changelog#20260115",
-      "title": "Google: gemini-2.5-flash-preview-09-25",
-      "content_text": "Insufficient information provided in the deprecation notice to complete analysis.",
-      "date_published": "2026-01-16T03:24:29.958726+00:00",
-      "_deprecation": {
-        "provider": "Google",
-        "model_id": "gemini-2.5-flash-preview-09-25",
-        "shutdown_date": "",
-        "deprecation_date": "2026-01-15",
-        "announcement_date": "2026-01-16",
-        "replacement_models": null,
-        "first_observed": "2026-01-16",
-        "last_observed": "2026-01-16",
-        "summary": "Insufficient information provided in the deprecation notice to complete analysis."
-      },
-      "tags": [
-        "Google"
-      ]
-    },
-    {
-      "id": "google-imagen-4.0-generate-preview-06-06",
-      "url": "https://ai.google.dev/gemini-api/docs/changelog#20260115",
-      "title": "Google: imagen-4.0-generate-preview-06-06",
-      "content_text": "Insufficient information provided in the deprecation notice. Unable to extract specific details about model deprecation.",
-      "date_published": "2026-01-16T03:24:29.958876+00:00",
-      "_deprecation": {
-        "provider": "Google",
-        "model_id": "imagen-4.0-generate-preview-06-06",
-        "shutdown_date": "",
-        "deprecation_date": "2026-01-15",
-        "announcement_date": "2026-01-16",
-        "replacement_models": null,
-        "first_observed": "2026-01-16",
-        "last_observed": "2026-01-16",
-        "summary": "Insufficient information provided in the deprecation notice. Unable to extract specific details about model deprecation."
-      },
-      "tags": [
-        "Google"
-      ]
-    },
-    {
-      "id": "google-imagen-4.0-ultra-generate-preview-06-06",
-      "url": "https://ai.google.dev/gemini-api/docs/changelog#20260115",
-      "title": "Google: imagen-4.0-ultra-generate-preview-06-06",
-      "content_text": "Insufficient information provided in the deprecation notice to extract specific details.",
-      "date_published": "2026-01-16T03:24:29.958925+00:00",
-      "_deprecation": {
-        "provider": "Google",
-        "model_id": "imagen-4.0-ultra-generate-preview-06-06",
-        "shutdown_date": "",
-        "deprecation_date": "2026-01-15",
-        "announcement_date": "2026-01-16",
-        "replacement_models": null,
-        "first_observed": "2026-01-16",
-        "last_observed": "2026-01-16",
-        "summary": "Insufficient information provided in the deprecation notice to extract specific details."
-      },
-      "tags": [
-        "Google"
+        "Google",
+        "shutdown-2025"
       ]
     },
     {
       "id": "google-gemini-2.5-flash-image-preview",
-      "url": "https://ai.google.dev/gemini-api/docs/changelog#20260115",
+      "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.5-flash-models",
       "title": "Google: gemini-2.5-flash-image-preview",
       "content_text": "",
-      "date_published": "2026-03-26T13:07:23.859614+00:00",
+      "date_published": "2026-05-01T21:39:32.402819+00:00",
       "_deprecation": {
         "provider": "Google",
         "model_id": "gemini-2.5-flash-image-preview",
-        "shutdown_date": "",
+        "shutdown_date": "2026-01-15",
         "deprecation_date": "2026-01-15",
         "announcement_date": "2026-03-26",
-        "replacement_models": null,
+        "replacement_models": [
+          "gemini-2.5-flash-image"
+        ],
         "first_observed": "2026-03-26",
-        "last_observed": "2026-03-26"
+        "last_observed": "2026-05-01"
       },
       "tags": [
-        "Google"
+        "Google",
+        "shutdown-2026"
       ]
     },
     {
-      "id": "google-veo-3.0-fast-generate-preview",
-      "url": "https://ai.google.dev/gemini-api/docs/changelog#20251111",
-      "title": "Google: veo-3.0-fast-generate-preview",
+      "id": "google-gemini-2.5-flash-preview-09-25",
+      "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.5-flash-models",
+      "title": "Google: gemini-2.5-flash-preview-09-25",
       "content_text": "",
-      "date_published": "2025-12-05T16:52:41.232765+00:00",
+      "date_published": "2026-05-01T21:43:36.812991+00:00",
       "_deprecation": {
         "provider": "Google",
-        "model_id": "veo-3.0-fast-generate-preview",
-        "shutdown_date": "2025-11-12",
-        "deprecation_date": "2025-11-11",
+        "model_id": "gemini-2.5-flash-preview-09-25",
+        "shutdown_date": "2026-02-17",
+        "deprecation_date": "2026-02-17",
+        "announcement_date": "2026-01-16",
+        "replacement_models": [
+          "gemini-3-flash-preview"
+        ],
+        "first_observed": "2026-01-16",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Google",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "google-gemini-2.0-flash",
+      "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.0-models",
+      "title": "Google: gemini-2.0-flash",
+      "content_text": "",
+      "date_published": "2026-05-01T21:43:36.813281+00:00",
+      "_deprecation": {
+        "provider": "Google",
+        "model_id": "gemini-2.0-flash",
+        "shutdown_date": "2026-06-01",
+        "deprecation_date": "2026-06-01",
+        "announcement_date": "2026-02-20",
+        "replacement_models": [
+          "gemini-2.5-flash"
+        ],
+        "first_observed": "2026-02-20",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Google",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "google-gemini-2.0-flash-001",
+      "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.0-models",
+      "title": "Google: gemini-2.0-flash-001",
+      "content_text": "",
+      "date_published": "2026-05-01T21:43:36.813411+00:00",
+      "_deprecation": {
+        "provider": "Google",
+        "model_id": "gemini-2.0-flash-001",
+        "shutdown_date": "2026-06-01",
+        "deprecation_date": "2026-06-01",
+        "announcement_date": "2026-02-20",
+        "replacement_models": [
+          "gemini-2.5-flash"
+        ],
+        "first_observed": "2026-02-20",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Google",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "google-gemini-2.0-flash-lite",
+      "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.0-models",
+      "title": "Google: gemini-2.0-flash-lite",
+      "content_text": "",
+      "date_published": "2026-05-01T21:43:36.813544+00:00",
+      "_deprecation": {
+        "provider": "Google",
+        "model_id": "gemini-2.0-flash-lite",
+        "shutdown_date": "2026-06-01",
+        "deprecation_date": "2026-06-01",
+        "announcement_date": "2026-02-20",
+        "replacement_models": [
+          "gemini-2.5-flash-lite"
+        ],
+        "first_observed": "2026-02-20",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Google",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "google-gemini-2.0-flash-lite-001",
+      "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.0-models",
+      "title": "Google: gemini-2.0-flash-lite-001",
+      "content_text": "",
+      "date_published": "2026-05-01T21:43:36.813674+00:00",
+      "_deprecation": {
+        "provider": "Google",
+        "model_id": "gemini-2.0-flash-lite-001",
+        "shutdown_date": "2026-06-01",
+        "deprecation_date": "2026-06-01",
+        "announcement_date": "2026-02-20",
+        "replacement_models": [
+          "gemini-2.5-flash-lite"
+        ],
+        "first_observed": "2026-02-20",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Google",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "google-gemini-2.0-flash-preview-image-generation",
+      "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.0-models",
+      "title": "Google: gemini-2.0-flash-preview-image-generation",
+      "content_text": "",
+      "date_published": "2026-05-01T21:43:36.813829+00:00",
+      "_deprecation": {
+        "provider": "Google",
+        "model_id": "gemini-2.0-flash-preview-image-generation",
+        "shutdown_date": "2025-11-14",
+        "deprecation_date": "2025-11-14",
         "announcement_date": "2025-12-05",
-        "replacement_models": null,
+        "replacement_models": [
+          "gemini-2.5-flash-image"
+        ],
         "first_observed": "2025-12-05",
-        "last_observed": "2025-12-05"
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "Google",
         "shutdown-2025"
+      ]
+    },
+    {
+      "id": "google-gemini-2.0-flash-lite-preview",
+      "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.0-models",
+      "title": "Google: gemini-2.0-flash-lite-preview",
+      "content_text": "",
+      "date_published": "2026-05-01T21:43:36.813956+00:00",
+      "_deprecation": {
+        "provider": "Google",
+        "model_id": "gemini-2.0-flash-lite-preview",
+        "shutdown_date": "2025-12-09",
+        "deprecation_date": "2025-12-09",
+        "announcement_date": "2026-03-26",
+        "replacement_models": [
+          "gemini-2.5-flash-lite"
+        ],
+        "first_observed": "2026-03-26",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Google",
+        "shutdown-2025"
+      ]
+    },
+    {
+      "id": "google-gemini-2.0-flash-lite-preview-02-05",
+      "url": "https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.0-models",
+      "title": "Google: gemini-2.0-flash-lite-preview-02-05",
+      "content_text": "",
+      "date_published": "2026-05-01T21:43:36.814091+00:00",
+      "_deprecation": {
+        "provider": "Google",
+        "model_id": "gemini-2.0-flash-lite-preview-02-05",
+        "shutdown_date": "2025-12-09",
+        "deprecation_date": "2025-12-09",
+        "announcement_date": "2025-12-05",
+        "replacement_models": [
+          "gemini-2.5-flash-lite"
+        ],
+        "first_observed": "2025-12-05",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Google",
+        "shutdown-2025"
+      ]
+    },
+    {
+      "id": "google-gemini-2.0-flash-live-001",
+      "url": "https://ai.google.dev/gemini-api/docs/deprecations#live-api-models",
+      "title": "Google: gemini-2.0-flash-live-001",
+      "content_text": "",
+      "date_published": "2026-05-01T21:43:36.814360+00:00",
+      "_deprecation": {
+        "provider": "Google",
+        "model_id": "gemini-2.0-flash-live-001",
+        "shutdown_date": "2025-12-09",
+        "deprecation_date": "2025-12-09",
+        "announcement_date": "2025-12-05",
+        "replacement_models": [
+          "gemini-3.1-flash-live-preview"
+        ],
+        "first_observed": "2025-12-05",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Google",
+        "shutdown-2025"
+      ]
+    },
+    {
+      "id": "google-gemini-live-2.5-flash-preview",
+      "url": "https://ai.google.dev/gemini-api/docs/deprecations#live-api-models",
+      "title": "Google: gemini-live-2.5-flash-preview",
+      "content_text": "",
+      "date_published": "2026-05-01T21:43:36.814597+00:00",
+      "_deprecation": {
+        "provider": "Google",
+        "model_id": "gemini-live-2.5-flash-preview",
+        "shutdown_date": "2025-12-09",
+        "deprecation_date": "2025-12-09",
+        "announcement_date": "2025-12-05",
+        "replacement_models": [
+          "gemini-3.1-flash-live-preview"
+        ],
+        "first_observed": "2025-12-05",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Google",
+        "shutdown-2025"
+      ]
+    },
+    {
+      "id": "google-gemini-embedding-001",
+      "url": "https://ai.google.dev/gemini-api/docs/deprecations#embedding-models",
+      "title": "Google: gemini-embedding-001",
+      "content_text": "",
+      "date_published": "2026-05-01T21:43:36.815121+00:00",
+      "_deprecation": {
+        "provider": "Google",
+        "model_id": "gemini-embedding-001",
+        "shutdown_date": "2026-07-14",
+        "deprecation_date": "2026-07-14",
+        "announcement_date": "2025-12-05",
+        "replacement_models": null,
+        "first_observed": "2025-12-05",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Google",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "google-text-embedding-004",
+      "url": "https://ai.google.dev/gemini-api/docs/deprecations#embedding-models",
+      "title": "Google: text-embedding-004",
+      "content_text": "",
+      "date_published": "2026-05-01T21:43:36.815257+00:00",
+      "_deprecation": {
+        "provider": "Google",
+        "model_id": "text-embedding-004",
+        "shutdown_date": "2026-01-14",
+        "deprecation_date": "2026-01-14",
+        "announcement_date": "2026-05-01",
+        "replacement_models": [
+          "gemini-embedding-001"
+        ],
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Google",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "google-embedding-001",
+      "url": "https://ai.google.dev/gemini-api/docs/deprecations#embedding-models",
+      "title": "Google: embedding-001",
+      "content_text": "",
+      "date_published": "2026-05-01T21:43:36.815415+00:00",
+      "_deprecation": {
+        "provider": "Google",
+        "model_id": "embedding-001",
+        "shutdown_date": "2025-10-30",
+        "deprecation_date": "2025-10-30",
+        "announcement_date": "2026-05-01",
+        "replacement_models": [
+          "gemini-embedding-001"
+        ],
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Google",
+        "shutdown-2025"
+      ]
+    },
+    {
+      "id": "google-embedding-gecko-001",
+      "url": "https://ai.google.dev/gemini-api/docs/deprecations#embedding-models",
+      "title": "Google: embedding-gecko-001",
+      "content_text": "",
+      "date_published": "2026-05-01T21:43:36.815516+00:00",
+      "_deprecation": {
+        "provider": "Google",
+        "model_id": "embedding-gecko-001",
+        "shutdown_date": "2025-10-30",
+        "deprecation_date": "2025-10-30",
+        "announcement_date": "2026-05-01",
+        "replacement_models": [
+          "gemini-embedding-001"
+        ],
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Google",
+        "shutdown-2025"
+      ]
+    },
+    {
+      "id": "google-gemini-embedding-exp",
+      "url": "https://ai.google.dev/gemini-api/docs/deprecations#embedding-models",
+      "title": "Google: gemini-embedding-exp",
+      "content_text": "",
+      "date_published": "2026-05-01T21:43:36.815615+00:00",
+      "_deprecation": {
+        "provider": "Google",
+        "model_id": "gemini-embedding-exp",
+        "shutdown_date": "2025-10-30",
+        "deprecation_date": "2025-10-30",
+        "announcement_date": "2025-12-05",
+        "replacement_models": [
+          "gemini-embedding-001"
+        ],
+        "first_observed": "2025-12-05",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Google",
+        "shutdown-2025"
+      ]
+    },
+    {
+      "id": "google-gemini-embedding-exp-03-07",
+      "url": "https://ai.google.dev/gemini-api/docs/deprecations#embedding-models",
+      "title": "Google: gemini-embedding-exp-03-07",
+      "content_text": "",
+      "date_published": "2026-05-01T21:43:36.815714+00:00",
+      "_deprecation": {
+        "provider": "Google",
+        "model_id": "gemini-embedding-exp-03-07",
+        "shutdown_date": "2025-10-30",
+        "deprecation_date": "2025-10-30",
+        "announcement_date": "2025-12-05",
+        "replacement_models": [
+          "gemini-embedding-001"
+        ],
+        "first_observed": "2025-12-05",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Google",
+        "shutdown-2025"
+      ]
+    },
+    {
+      "id": "google-imagen-4.0-generate-001",
+      "url": "https://ai.google.dev/gemini-api/docs/deprecations#imagen-models",
+      "title": "Google: imagen-4.0-generate-001",
+      "content_text": "",
+      "date_published": "2026-05-01T21:43:36.815981+00:00",
+      "_deprecation": {
+        "provider": "Google",
+        "model_id": "imagen-4.0-generate-001",
+        "shutdown_date": "2026-06-24",
+        "deprecation_date": "2026-06-24",
+        "announcement_date": "2026-05-01",
+        "replacement_models": [
+          "gemini-3-pro-image-preview",
+          "gemini-2.5-flash-image"
+        ],
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Google",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "google-imagen-4.0-ultra-generate-001",
+      "url": "https://ai.google.dev/gemini-api/docs/deprecations#imagen-models",
+      "title": "Google: imagen-4.0-ultra-generate-001",
+      "content_text": "",
+      "date_published": "2026-05-01T21:43:36.816114+00:00",
+      "_deprecation": {
+        "provider": "Google",
+        "model_id": "imagen-4.0-ultra-generate-001",
+        "shutdown_date": "2026-06-24",
+        "deprecation_date": "2026-06-24",
+        "announcement_date": "2026-05-01",
+        "replacement_models": [
+          "gemini-3-pro-image-preview",
+          "gemini-2.5-flash-image"
+        ],
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Google",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "google-imagen-4.0-fast-generate-001",
+      "url": "https://ai.google.dev/gemini-api/docs/deprecations#imagen-models",
+      "title": "Google: imagen-4.0-fast-generate-001",
+      "content_text": "",
+      "date_published": "2026-05-01T21:43:36.816246+00:00",
+      "_deprecation": {
+        "provider": "Google",
+        "model_id": "imagen-4.0-fast-generate-001",
+        "shutdown_date": "2026-06-24",
+        "deprecation_date": "2026-06-24",
+        "announcement_date": "2026-05-01",
+        "replacement_models": [
+          "gemini-3-pro-image-preview",
+          "gemini-2.5-flash-image"
+        ],
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Google",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "google-imagen-3.0-generate-002",
+      "url": "https://ai.google.dev/gemini-api/docs/deprecations#imagen-models",
+      "title": "Google: imagen-3.0-generate-002",
+      "content_text": "",
+      "date_published": "2026-05-01T21:39:32.406953+00:00",
+      "_deprecation": {
+        "provider": "Google",
+        "model_id": "imagen-3.0-generate-002",
+        "shutdown_date": "2025-11-10",
+        "deprecation_date": "2025-11-10",
+        "announcement_date": "2025-12-05",
+        "replacement_models": [
+          "imagen-4.0-generate-001"
+        ],
+        "first_observed": "2025-12-05",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Google",
+        "shutdown-2025"
+      ]
+    },
+    {
+      "id": "google-imagen-4.0-generate-preview-06-06",
+      "url": "https://ai.google.dev/gemini-api/docs/deprecations#imagen-models",
+      "title": "Google: imagen-4.0-generate-preview-06-06",
+      "content_text": "",
+      "date_published": "2026-05-01T21:43:36.816629+00:00",
+      "_deprecation": {
+        "provider": "Google",
+        "model_id": "imagen-4.0-generate-preview-06-06",
+        "shutdown_date": "2026-02-17",
+        "deprecation_date": "2026-02-17",
+        "announcement_date": "2026-01-16",
+        "replacement_models": [
+          "imagen-4.0-generate-001"
+        ],
+        "first_observed": "2026-01-16",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Google",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "google-imagen-4.0-ultra-generate-preview-06-06",
+      "url": "https://ai.google.dev/gemini-api/docs/deprecations#imagen-models",
+      "title": "Google: imagen-4.0-ultra-generate-preview-06-06",
+      "content_text": "",
+      "date_published": "2026-05-01T21:43:36.816783+00:00",
+      "_deprecation": {
+        "provider": "Google",
+        "model_id": "imagen-4.0-ultra-generate-preview-06-06",
+        "shutdown_date": "2026-02-17",
+        "deprecation_date": "2026-02-17",
+        "announcement_date": "2026-01-16",
+        "replacement_models": [
+          "imagen-4.0-ultra-generate-001"
+        ],
+        "first_observed": "2026-01-16",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Google",
+        "shutdown-2026"
       ]
     },
     {
       "id": "google-veo-3.0-generate-preview",
-      "url": "https://ai.google.dev/gemini-api/docs/changelog#20251111",
+      "url": "https://ai.google.dev/gemini-api/docs/deprecations#veo-models",
       "title": "Google: veo-3.0-generate-preview",
       "content_text": "",
-      "date_published": "2025-12-05T16:52:41.232794+00:00",
+      "date_published": "2026-05-01T21:43:36.817475+00:00",
       "_deprecation": {
         "provider": "Google",
         "model_id": "veo-3.0-generate-preview",
         "shutdown_date": "2025-11-12",
-        "deprecation_date": "2025-11-11",
+        "deprecation_date": "2025-11-12",
         "announcement_date": "2025-12-05",
-        "replacement_models": null,
+        "replacement_models": [
+          "veo-3.1-generate-preview"
+        ],
         "first_observed": "2025-12-05",
-        "last_observed": "2025-12-05"
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "Google",
         "shutdown-2025"
+      ]
+    },
+    {
+      "id": "google-veo-3.0-fast-generate-preview",
+      "url": "https://ai.google.dev/gemini-api/docs/deprecations#veo-models",
+      "title": "Google: veo-3.0-fast-generate-preview",
+      "content_text": "",
+      "date_published": "2026-05-01T21:43:36.817610+00:00",
+      "_deprecation": {
+        "provider": "Google",
+        "model_id": "veo-3.0-fast-generate-preview",
+        "shutdown_date": "2025-11-12",
+        "deprecation_date": "2025-11-12",
+        "announcement_date": "2025-12-05",
+        "replacement_models": [
+          "veo-3.1-fast-generate-preview"
+        ],
+        "first_observed": "2025-12-05",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Google",
+        "shutdown-2025"
+      ]
+    },
+    {
+      "id": "google-gemini-robotics-er-1.5-preview",
+      "url": "https://ai.google.dev/gemini-api/docs/deprecations#robotics-models",
+      "title": "Google: gemini-robotics-er-1.5-preview",
+      "content_text": "",
+      "date_published": "2026-05-01T21:43:36.818151+00:00",
+      "_deprecation": {
+        "provider": "Google",
+        "model_id": "gemini-robotics-er-1.5-preview",
+        "shutdown_date": "2026-04-30",
+        "deprecation_date": "2026-04-30",
+        "announcement_date": "2026-04-15",
+        "replacement_models": [
+          "gemini-robotics-er-1.6-preview"
+        ],
+        "first_observed": "2026-04-15",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Google",
+        "shutdown-2026"
       ]
     },
     {
@@ -3114,61 +4043,20 @@
       "url": "https://ai.google.dev/gemini-api/docs/changelog#20251111",
       "title": "Google: gemini-2.0-flash-exp-image-generation",
       "content_text": "",
-      "date_published": "2025-12-05T16:52:41.232807+00:00",
+      "date_published": "2026-05-01T21:41:37.792318+00:00",
       "_deprecation": {
         "provider": "Google",
         "model_id": "gemini-2.0-flash-exp-image-generation",
-        "shutdown_date": "",
+        "shutdown_date": "2025-11-14",
         "deprecation_date": "2025-11-11",
-        "announcement_date": "2025-12-05",
+        "announcement_date": "2026-05-01",
         "replacement_models": null,
-        "first_observed": "2025-12-05",
-        "last_observed": "2025-12-05"
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
       },
       "tags": [
-        "Google"
-      ]
-    },
-    {
-      "id": "google-gemini-2.0-flash-preview-image-generation",
-      "url": "https://ai.google.dev/gemini-api/docs/changelog#20251111",
-      "title": "Google: gemini-2.0-flash-preview-image-generation",
-      "content_text": "",
-      "date_published": "2025-12-05T16:52:41.232818+00:00",
-      "_deprecation": {
-        "provider": "Google",
-        "model_id": "gemini-2.0-flash-preview-image-generation",
-        "shutdown_date": "",
-        "deprecation_date": "2025-11-11",
-        "announcement_date": "2025-12-05",
-        "replacement_models": null,
-        "first_observed": "2025-12-05",
-        "last_observed": "2025-12-05"
-      },
-      "tags": [
-        "Google"
-      ]
-    },
-    {
-      "id": "google-imagen-3.0-generate-002",
-      "url": "https://ai.google.dev/gemini-api/docs/changelog#20251110",
-      "title": "Google: imagen-3.0-generate-002",
-      "content_text": "",
-      "date_published": "2025-12-05T16:52:41.232888+00:00",
-      "_deprecation": {
-        "provider": "Google",
-        "model_id": "imagen-3.0-generate-002",
-        "shutdown_date": "",
-        "deprecation_date": "2025-11-10",
-        "announcement_date": "2025-12-05",
-        "replacement_models": [
-          "imagen 4"
-        ],
-        "first_observed": "2025-12-05",
-        "last_observed": "2025-12-05"
-      },
-      "tags": [
-        "Google"
+        "Google",
+        "shutdown-2025"
       ]
     },
     {
@@ -3176,39 +4064,20 @@
       "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
       "title": "Google: gemini-2.5-flash-lite-preview-06-17",
       "content_text": "",
-      "date_published": "2025-12-05T16:52:41.232941+00:00",
+      "date_published": "2026-05-01T21:41:37.792860+00:00",
       "_deprecation": {
         "provider": "Google",
         "model_id": "gemini-2.5-flash-lite-preview-06-17",
-        "shutdown_date": "",
+        "shutdown_date": "2025-11-18",
         "deprecation_date": "2025-11-04",
-        "announcement_date": "2025-12-05",
+        "announcement_date": "2026-05-01",
         "replacement_models": null,
-        "first_observed": "2025-12-05",
-        "last_observed": "2025-12-05"
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
       },
       "tags": [
-        "Google"
-      ]
-    },
-    {
-      "id": "google-gemini-2.5-flash-preview-05-20",
-      "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
-      "title": "Google: gemini-2.5-flash-preview-05-20",
-      "content_text": "",
-      "date_published": "2025-12-05T16:52:41.232953+00:00",
-      "_deprecation": {
-        "provider": "Google",
-        "model_id": "gemini-2.5-flash-preview-05-20",
-        "shutdown_date": "",
-        "deprecation_date": "2025-11-04",
-        "announcement_date": "2025-12-05",
-        "replacement_models": null,
-        "first_observed": "2025-12-05",
-        "last_observed": "2025-12-05"
-      },
-      "tags": [
-        "Google"
+        "Google",
+        "shutdown-2025"
       ]
     },
     {
@@ -3216,16 +4085,16 @@
       "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
       "title": "Google: gemini-2.0-flash-thinking-exp",
       "content_text": "",
-      "date_published": "2025-12-05T16:52:41.232981+00:00",
+      "date_published": "2026-05-01T21:41:37.792942+00:00",
       "_deprecation": {
         "provider": "Google",
         "model_id": "gemini-2.0-flash-thinking-exp",
         "shutdown_date": "2025-12-02",
         "deprecation_date": "2025-11-04",
-        "announcement_date": "2025-12-05",
+        "announcement_date": "2026-05-01",
         "replacement_models": null,
-        "first_observed": "2025-12-05",
-        "last_observed": "2025-12-05"
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "Google",
@@ -3237,19 +4106,20 @@
       "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
       "title": "Google: gemini-2.0-flash-thinking-exp-01-21",
       "content_text": "",
-      "date_published": "2025-12-05T16:52:41.232993+00:00",
+      "date_published": "2026-05-01T21:41:37.792951+00:00",
       "_deprecation": {
         "provider": "Google",
         "model_id": "gemini-2.0-flash-thinking-exp-01-21",
-        "shutdown_date": "",
+        "shutdown_date": "2025-12-02",
         "deprecation_date": "2025-11-04",
-        "announcement_date": "2025-12-05",
+        "announcement_date": "2026-05-01",
         "replacement_models": null,
-        "first_observed": "2025-12-05",
-        "last_observed": "2025-12-05"
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
       },
       "tags": [
-        "Google"
+        "Google",
+        "shutdown-2025"
       ]
     },
     {
@@ -3257,123 +4127,20 @@
       "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
       "title": "Google: gemini-2.0-flash-thinking-exp-1219",
       "content_text": "",
-      "date_published": "2025-12-05T16:52:41.233003+00:00",
+      "date_published": "2026-05-01T21:41:37.792957+00:00",
       "_deprecation": {
         "provider": "Google",
         "model_id": "gemini-2.0-flash-thinking-exp-1219",
-        "shutdown_date": "",
-        "deprecation_date": "2025-11-04",
-        "announcement_date": "2025-12-05",
-        "replacement_models": null,
-        "first_observed": "2025-12-05",
-        "last_observed": "2025-12-05"
-      },
-      "tags": [
-        "Google"
-      ]
-    },
-    {
-      "id": "google-gemini-2.5-pro-preview-03-25",
-      "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
-      "title": "Google: gemini-2.5-pro-preview-03-25",
-      "content_text": "",
-      "date_published": "2025-12-05T16:52:41.233029+00:00",
-      "_deprecation": {
-        "provider": "Google",
-        "model_id": "gemini-2.5-pro-preview-03-25",
         "shutdown_date": "2025-12-02",
         "deprecation_date": "2025-11-04",
-        "announcement_date": "2025-12-05",
+        "announcement_date": "2026-05-01",
         "replacement_models": null,
-        "first_observed": "2025-12-05",
-        "last_observed": "2025-12-05"
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "Google",
         "shutdown-2025"
-      ]
-    },
-    {
-      "id": "google-gemini-2.5-pro-preview-05-06",
-      "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
-      "title": "Google: gemini-2.5-pro-preview-05-06",
-      "content_text": "",
-      "date_published": "2025-12-05T16:52:41.233055+00:00",
-      "_deprecation": {
-        "provider": "Google",
-        "model_id": "gemini-2.5-pro-preview-05-06",
-        "shutdown_date": "2025-12-02",
-        "deprecation_date": "2025-11-04",
-        "announcement_date": "2025-12-05",
-        "replacement_models": null,
-        "first_observed": "2025-12-05",
-        "last_observed": "2025-12-05"
-      },
-      "tags": [
-        "Google",
-        "shutdown-2025"
-      ]
-    },
-    {
-      "id": "google-gemini-2.5-pro-preview-06-05",
-      "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
-      "title": "Google: gemini-2.5-pro-preview-06-05",
-      "content_text": "",
-      "date_published": "2025-12-05T16:52:41.233079+00:00",
-      "_deprecation": {
-        "provider": "Google",
-        "model_id": "gemini-2.5-pro-preview-06-05",
-        "shutdown_date": "2025-12-02",
-        "deprecation_date": "2025-11-04",
-        "announcement_date": "2025-12-05",
-        "replacement_models": null,
-        "first_observed": "2025-12-05",
-        "last_observed": "2025-12-05"
-      },
-      "tags": [
-        "Google",
-        "shutdown-2025"
-      ]
-    },
-    {
-      "id": "google-gemini-2.0-flash-lite-preview",
-      "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
-      "title": "Google: gemini-2.0-flash-lite-preview",
-      "content_text": "",
-      "date_published": "2026-03-26T13:07:23.861760+00:00",
-      "_deprecation": {
-        "provider": "Google",
-        "model_id": "gemini-2.0-flash-lite-preview",
-        "shutdown_date": "2025-12-09",
-        "deprecation_date": "2025-11-04",
-        "announcement_date": "2026-03-26",
-        "replacement_models": null,
-        "first_observed": "2026-03-26",
-        "last_observed": "2026-03-26"
-      },
-      "tags": [
-        "Google",
-        "shutdown-2025"
-      ]
-    },
-    {
-      "id": "google-gemini-2.0-flash-lite-preview-02-05",
-      "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
-      "title": "Google: gemini-2.0-flash-lite-preview-02-05",
-      "content_text": "",
-      "date_published": "2025-12-05T16:52:41.233112+00:00",
-      "_deprecation": {
-        "provider": "Google",
-        "model_id": "gemini-2.0-flash-lite-preview-02-05",
-        "shutdown_date": "",
-        "deprecation_date": "2025-11-04",
-        "announcement_date": "2025-12-05",
-        "replacement_models": null,
-        "first_observed": "2025-12-05",
-        "last_observed": "2025-12-05"
-      },
-      "tags": [
-        "Google"
       ]
     },
     {
@@ -3381,16 +4148,16 @@
       "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
       "title": "Google: gemini-2.0-flash-exp",
       "content_text": "",
-      "date_published": "2026-01-29T04:02:00.403641+00:00",
+      "date_published": "2026-05-01T21:41:37.793047+00:00",
       "_deprecation": {
         "provider": "Google",
         "model_id": "gemini-2.0-flash-exp",
         "shutdown_date": "2025-12-09",
         "deprecation_date": "2025-11-04",
-        "announcement_date": "2026-01-29",
+        "announcement_date": "2026-05-01",
         "replacement_models": null,
-        "first_observed": "2026-01-29",
-        "last_observed": "2026-01-29"
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "Google",
@@ -3402,16 +4169,16 @@
       "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
       "title": "Google: gemini-2.0-pro-exp",
       "content_text": "",
-      "date_published": "2026-01-29T04:02:00.403734+00:00",
+      "date_published": "2026-05-01T21:41:37.793052+00:00",
       "_deprecation": {
         "provider": "Google",
         "model_id": "gemini-2.0-pro-exp",
         "shutdown_date": "2025-12-09",
         "deprecation_date": "2025-11-04",
-        "announcement_date": "2026-01-29",
+        "announcement_date": "2026-05-01",
         "replacement_models": null,
-        "first_observed": "2026-01-29",
-        "last_observed": "2026-01-29"
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "Google",
@@ -3423,16 +4190,16 @@
       "url": "https://ai.google.dev/gemini-api/docs/changelog#20251104",
       "title": "Google: gemini-2.0-pro-exp-02-05",
       "content_text": "",
-      "date_published": "2026-01-29T04:02:00.403817+00:00",
+      "date_published": "2026-05-01T21:41:37.793056+00:00",
       "_deprecation": {
         "provider": "Google",
         "model_id": "gemini-2.0-pro-exp-02-05",
         "shutdown_date": "2025-12-09",
         "deprecation_date": "2025-11-04",
-        "announcement_date": "2026-01-29",
+        "announcement_date": "2026-05-01",
         "replacement_models": null,
-        "first_observed": "2026-01-29",
-        "last_observed": "2026-01-29"
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "Google",
@@ -3444,19 +4211,20 @@
       "url": "https://ai.google.dev/gemini-api/docs/changelog#20251020",
       "title": "Google: gemini-2.5-flash-preview-native-audio-dialog",
       "content_text": "",
-      "date_published": "2025-12-05T16:52:41.233151+00:00",
+      "date_published": "2026-05-01T21:41:37.793796+00:00",
       "_deprecation": {
         "provider": "Google",
         "model_id": "gemini-2.5-flash-preview-native-audio-dialog",
-        "shutdown_date": "",
+        "shutdown_date": "2025-10-20",
         "deprecation_date": "2025-10-20",
-        "announcement_date": "2025-12-05",
+        "announcement_date": "2026-05-01",
         "replacement_models": null,
-        "first_observed": "2025-12-05",
-        "last_observed": "2025-12-05"
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
       },
       "tags": [
-        "Google"
+        "Google",
+        "shutdown-2025"
       ]
     },
     {
@@ -3464,181 +4232,104 @@
       "url": "https://ai.google.dev/gemini-api/docs/changelog#20251020",
       "title": "Google: gemini-2.5-flash-exp-native-audio-thinking-dialog",
       "content_text": "",
-      "date_published": "2025-12-05T16:52:41.233162+00:00",
+      "date_published": "2026-05-01T21:41:37.793808+00:00",
       "_deprecation": {
         "provider": "Google",
         "model_id": "gemini-2.5-flash-exp-native-audio-thinking-dialog",
-        "shutdown_date": "",
+        "shutdown_date": "2025-10-20",
         "deprecation_date": "2025-10-20",
-        "announcement_date": "2025-12-05",
+        "announcement_date": "2026-05-01",
         "replacement_models": null,
-        "first_observed": "2025-12-05",
-        "last_observed": "2025-12-05"
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
       },
       "tags": [
-        "Google"
+        "Google",
+        "shutdown-2025"
       ]
     },
     {
-      "id": "google-gemini-2.5-flash-native-audio-preview-09-2025",
-      "url": "https://ai.google.dev/gemini-api/docs/changelog#20251020",
-      "title": "Google: gemini-2.5-flash-native-audio-preview-09-2025",
+      "id": "google-gemini-1.5-pro",
+      "url": "https://ai.google.dev/gemini-api/docs/changelog#20250929",
+      "title": "Google: gemini-1.5-pro",
       "content_text": "",
-      "date_published": "2025-12-05T16:52:41.233176+00:00",
+      "date_published": "2026-05-01T21:41:37.794509+00:00",
       "_deprecation": {
         "provider": "Google",
-        "model_id": "gemini-2.5-flash-native-audio-preview-09-2025",
-        "shutdown_date": "",
-        "deprecation_date": "2025-10-20",
-        "announcement_date": "2025-12-05",
-        "replacement_models": [
-          "gemini-2.5-flash-native-audio-preview-09-2025"
-        ],
-        "first_observed": "2025-12-05",
-        "last_observed": "2025-12-05"
+        "model_id": "gemini-1.5-pro",
+        "shutdown_date": "2025-09-29",
+        "deprecation_date": "2025-09-29",
+        "announcement_date": "2026-05-01",
+        "replacement_models": null,
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
       },
       "tags": [
-        "Google"
+        "Google",
+        "shutdown-2025"
       ]
     },
     {
-      "id": "google-gemini-2.0-flash-live-001",
-      "url": "https://ai.google.dev/gemini-api/docs/changelog#20251020",
-      "title": "Google: gemini-2.0-flash-live-001",
+      "id": "google-gemini-1.5-flash-8b",
+      "url": "https://ai.google.dev/gemini-api/docs/changelog#20250929",
+      "title": "Google: gemini-1.5-flash-8b",
       "content_text": "",
-      "date_published": "2025-12-05T16:52:41.233192+00:00",
+      "date_published": "2026-05-01T21:41:37.794521+00:00",
       "_deprecation": {
         "provider": "Google",
-        "model_id": "gemini-2.0-flash-live-001",
-        "shutdown_date": "",
-        "deprecation_date": "2025-10-20",
-        "announcement_date": "2025-12-05",
+        "model_id": "gemini-1.5-flash-8b",
+        "shutdown_date": "2025-09-29",
+        "deprecation_date": "2025-09-29",
+        "announcement_date": "2026-05-01",
         "replacement_models": null,
-        "first_observed": "2025-12-05",
-        "last_observed": "2025-12-05"
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
       },
       "tags": [
-        "Google"
+        "Google",
+        "shutdown-2025"
       ]
     },
     {
-      "id": "google-gemini-live-2.5-flash-preview",
-      "url": "https://ai.google.dev/gemini-api/docs/changelog#20251020",
-      "title": "Google: gemini-live-2.5-flash-preview",
+      "id": "google-gemini-1.5-flash",
+      "url": "https://ai.google.dev/gemini-api/docs/changelog#20250929",
+      "title": "Google: gemini-1.5-flash",
       "content_text": "",
-      "date_published": "2025-12-05T16:52:41.233205+00:00",
+      "date_published": "2026-05-01T21:41:37.794527+00:00",
       "_deprecation": {
         "provider": "Google",
-        "model_id": "gemini-live-2.5-flash-preview",
-        "shutdown_date": "",
-        "deprecation_date": "2025-10-20",
-        "announcement_date": "2025-12-05",
+        "model_id": "gemini-1.5-flash",
+        "shutdown_date": "2025-09-29",
+        "deprecation_date": "2025-09-29",
+        "announcement_date": "2026-05-01",
         "replacement_models": null,
-        "first_observed": "2025-12-05",
-        "last_observed": "2025-12-05"
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
       },
       "tags": [
-        "Google"
+        "Google",
+        "shutdown-2025"
       ]
     },
     {
-      "id": "google-gemini-embedding-exp-03-07",
-      "url": "https://ai.google.dev/gemini-api/docs/changelog#20250916",
-      "title": "Google: gemini-embedding-exp-03-07",
+      "id": "google-gemini-2.5-pro-exp-03-25",
+      "url": "https://ai.google.dev/gemini-api/docs/changelog#20250626",
+      "title": "Google: gemini-2.5-pro-exp-03-25",
       "content_text": "",
-      "date_published": "2025-12-05T16:52:41.233344+00:00",
+      "date_published": "2026-05-01T21:41:37.795869+00:00",
       "_deprecation": {
         "provider": "Google",
-        "model_id": "gemini-embedding-exp-03-07",
-        "shutdown_date": "",
-        "deprecation_date": "2025-09-16",
-        "announcement_date": "2025-12-05",
+        "model_id": "gemini-2.5-pro-exp-03-25",
+        "shutdown_date": "2025-06-26",
+        "deprecation_date": "2025-06-26",
+        "announcement_date": "2026-05-01",
         "replacement_models": null,
-        "first_observed": "2025-12-05",
-        "last_observed": "2025-12-05"
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
       },
       "tags": [
-        "Google"
-      ]
-    },
-    {
-      "id": "google-gemini-embedding-exp",
-      "url": "https://ai.google.dev/gemini-api/docs/changelog#20250916",
-      "title": "Google: gemini-embedding-exp",
-      "content_text": "",
-      "date_published": "2025-12-05T16:52:41.233356+00:00",
-      "_deprecation": {
-        "provider": "Google",
-        "model_id": "gemini-embedding-exp",
-        "shutdown_date": "",
-        "deprecation_date": "2025-09-16",
-        "announcement_date": "2025-12-05",
-        "replacement_models": null,
-        "first_observed": "2025-12-05",
-        "last_observed": "2025-12-05"
-      },
-      "tags": [
-        "Google"
-      ]
-    },
-    {
-      "id": "google-gemini-embedding-001",
-      "url": "https://ai.google.dev/gemini-api/docs/changelog#20250714",
-      "title": "Google: gemini-embedding-001",
-      "content_text": "",
-      "date_published": "2025-12-05T16:52:41.233467+00:00",
-      "_deprecation": {
-        "provider": "Google",
-        "model_id": "gemini-embedding-001",
-        "shutdown_date": "",
-        "deprecation_date": "2025-07-14",
-        "announcement_date": "2025-12-05",
-        "replacement_models": null,
-        "first_observed": "2025-12-05",
-        "last_observed": "2025-12-05"
-      },
-      "tags": [
-        "Google"
-      ]
-    },
-    {
-      "id": "google-gemini-2.5-pro",
-      "url": "https://ai.google.dev/gemini-api/docs/changelog#20250617",
-      "title": "Google: gemini-2.5-pro",
-      "content_text": "",
-      "date_published": "2025-12-05T16:52:41.233549+00:00",
-      "_deprecation": {
-        "provider": "Google",
-        "model_id": "gemini-2.5-pro",
-        "shutdown_date": "",
-        "deprecation_date": "2025-06-17",
-        "announcement_date": "2025-12-05",
-        "replacement_models": null,
-        "first_observed": "2025-12-05",
-        "last_observed": "2025-12-05"
-      },
-      "tags": [
-        "Google"
-      ]
-    },
-    {
-      "id": "google-gemini-2.5-flash",
-      "url": "https://ai.google.dev/gemini-api/docs/changelog#20250617",
-      "title": "Google: gemini-2.5-flash",
-      "content_text": "",
-      "date_published": "2025-12-05T16:52:41.233598+00:00",
-      "_deprecation": {
-        "provider": "Google",
-        "model_id": "gemini-2.5-flash",
-        "shutdown_date": "",
-        "deprecation_date": "2025-06-17",
-        "announcement_date": "2025-12-05",
-        "replacement_models": null,
-        "first_observed": "2025-12-05",
-        "last_observed": "2025-12-05"
-      },
-      "tags": [
-        "Google"
+        "Google",
+        "shutdown-2025"
       ]
     },
     {
@@ -3646,39 +4337,20 @@
       "url": "https://ai.google.dev/gemini-api/docs/changelog#20250617",
       "title": "Google: gemini-2.5-flash-preview-04-17",
       "content_text": "",
-      "date_published": "2025-12-05T16:52:41.233613+00:00",
+      "date_published": "2026-05-01T21:41:37.796124+00:00",
       "_deprecation": {
         "provider": "Google",
         "model_id": "gemini-2.5-flash-preview-04-17",
-        "shutdown_date": "",
+        "shutdown_date": "2025-07-15",
         "deprecation_date": "2025-06-17",
-        "announcement_date": "2025-12-05",
+        "announcement_date": "2026-05-01",
         "replacement_models": null,
-        "first_observed": "2025-12-05",
-        "last_observed": "2025-12-05"
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
       },
       "tags": [
-        "Google"
-      ]
-    },
-    {
-      "id": "google-gemini-1.5-flash",
-      "url": "https://ai.google.dev/gemini-api/docs/changelog#20250527",
-      "title": "Google: gemini-1.5-flash",
-      "content_text": "",
-      "date_published": "2025-12-05T16:52:41.233724+00:00",
-      "_deprecation": {
-        "provider": "Google",
-        "model_id": "gemini-1.5-flash",
-        "shutdown_date": "",
-        "deprecation_date": "2025-05-27",
-        "announcement_date": "2025-12-05",
-        "replacement_models": null,
-        "first_observed": "2025-12-05",
-        "last_observed": "2025-12-05"
-      },
-      "tags": [
-        "Google"
+        "Google",
+        "shutdown-2025"
       ]
     },
     {
@@ -3686,19 +4358,20 @@
       "url": "https://ai.google.dev/gemini-api/docs/changelog#20250218",
       "title": "Google: gemini-1.0-pro",
       "content_text": "",
-      "date_published": "2025-12-05T16:52:41.233930+00:00",
+      "date_published": "2026-05-01T21:41:37.797350+00:00",
       "_deprecation": {
         "provider": "Google",
         "model_id": "gemini-1.0-pro",
-        "shutdown_date": "",
+        "shutdown_date": "2025-02-18",
         "deprecation_date": "2025-02-18",
-        "announcement_date": "2025-12-05",
+        "announcement_date": "2026-05-01",
         "replacement_models": null,
-        "first_observed": "2025-12-05",
-        "last_observed": "2025-12-05"
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
       },
       "tags": [
-        "Google"
+        "Google",
+        "shutdown-2025"
       ]
     },
     {
@@ -3706,19 +4379,20 @@
       "url": "https://ai.google.dev/gemini-api/docs/changelog#20240712",
       "title": "Google: gemini-1.0-pro-vision",
       "content_text": "",
-      "date_published": "2025-12-05T16:52:41.234181+00:00",
+      "date_published": "2026-05-01T21:41:37.799166+00:00",
       "_deprecation": {
         "provider": "Google",
         "model_id": "gemini-1.0-pro-vision",
-        "shutdown_date": "",
+        "shutdown_date": "2024-07-12",
         "deprecation_date": "2024-07-12",
-        "announcement_date": "2025-12-05",
+        "announcement_date": "2026-05-01",
         "replacement_models": null,
-        "first_observed": "2025-12-05",
-        "last_observed": "2025-12-05"
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
       },
       "tags": [
-        "Google"
+        "Google",
+        "shutdown-2024"
       ]
     },
     {
@@ -4352,6 +5026,321 @@
       ]
     },
     {
+      "id": "cohere-embed-english-v2.0",
+      "url": "https://docs.cohere.com/docs/deprecations#2026-04-04-embed-v2-0-aya-expanse-8b",
+      "title": "Cohere: embed-english-v2.0",
+      "content_text": "",
+      "date_published": "2026-05-01T21:39:32.667159+00:00",
+      "_deprecation": {
+        "provider": "Cohere",
+        "model_id": "embed-english-v2.0",
+        "shutdown_date": "2026-04-04",
+        "deprecation_date": "2026-04-04",
+        "announcement_date": "2026-05-01",
+        "replacement_models": [
+          "embed-english-v3.0",
+          "embed-multilingual-v3.0",
+          "embed-v4.0"
+        ],
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Cohere",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "cohere-embed-english-light-v2.0",
+      "url": "https://docs.cohere.com/docs/deprecations#2026-04-04-embed-v2-0-aya-expanse-8b",
+      "title": "Cohere: embed-english-light-v2.0",
+      "content_text": "",
+      "date_published": "2026-05-01T21:39:32.667216+00:00",
+      "_deprecation": {
+        "provider": "Cohere",
+        "model_id": "embed-english-light-v2.0",
+        "shutdown_date": "2026-04-04",
+        "deprecation_date": "2026-04-04",
+        "announcement_date": "2026-05-01",
+        "replacement_models": [
+          "embed-english-v3.0",
+          "embed-multilingual-v3.0",
+          "embed-v4.0"
+        ],
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Cohere",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "cohere-embed-multilingual-v2.0",
+      "url": "https://docs.cohere.com/docs/deprecations#2026-04-04-embed-v2-0-aya-expanse-8b",
+      "title": "Cohere: embed-multilingual-v2.0",
+      "content_text": "",
+      "date_published": "2026-05-01T21:39:32.667257+00:00",
+      "_deprecation": {
+        "provider": "Cohere",
+        "model_id": "embed-multilingual-v2.0",
+        "shutdown_date": "2026-04-04",
+        "deprecation_date": "2026-04-04",
+        "announcement_date": "2026-05-01",
+        "replacement_models": [
+          "embed-english-v3.0",
+          "embed-multilingual-v3.0",
+          "embed-v4.0"
+        ],
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Cohere",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "cohere-c4ai-aya-expanse-8b",
+      "url": "https://docs.cohere.com/docs/deprecations#2026-04-04-embed-v2-0-aya-expanse-8b",
+      "title": "Cohere: c4ai-aya-expanse-8b",
+      "content_text": "",
+      "date_published": "2026-05-01T21:39:32.667293+00:00",
+      "_deprecation": {
+        "provider": "Cohere",
+        "model_id": "c4ai-aya-expanse-8b",
+        "shutdown_date": "2026-04-04",
+        "deprecation_date": "2026-04-04",
+        "announcement_date": "2026-05-01",
+        "replacement_models": [
+          "command-r7b-12-2024",
+          "command-a-03-2025",
+          "command-a-reasoning-08-2025"
+        ],
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Cohere",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "cohere-c4ai-aya-vision-8b",
+      "url": "https://docs.cohere.com/docs/deprecations#2026-04-04-embed-v2-0-aya-expanse-8b",
+      "title": "Cohere: c4ai-aya-vision-8b",
+      "content_text": "",
+      "date_published": "2026-05-01T21:39:32.667327+00:00",
+      "_deprecation": {
+        "provider": "Cohere",
+        "model_id": "c4ai-aya-vision-8b",
+        "shutdown_date": "2026-04-04",
+        "deprecation_date": "2026-04-04",
+        "announcement_date": "2026-05-01",
+        "replacement_models": [
+          "command-r7b-12-2024",
+          "command-a-03-2025",
+          "command-a-reasoning-08-2025"
+        ],
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Cohere",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "cohere-command-r-03-2024",
+      "url": "https://docs.cohere.com/docs/deprecations#2025-09-15-various-older-command-models-a-number-of-endpoints-all-of-fine-tuning",
+      "title": "Cohere: command-r-03-2024",
+      "content_text": "",
+      "date_published": "2026-05-01T21:39:32.667381+00:00",
+      "_deprecation": {
+        "provider": "Cohere",
+        "model_id": "command-r-03-2024",
+        "shutdown_date": "",
+        "deprecation_date": "2025-09-15",
+        "announcement_date": "2026-05-01",
+        "replacement_models": [
+          "command-r-08-2024",
+          "command-r-plus-08-2024",
+          "command-a-03-2025"
+        ],
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Cohere"
+      ]
+    },
+    {
+      "id": "cohere-command-r",
+      "url": "https://docs.cohere.com/docs/deprecations#2025-09-15-various-older-command-models-a-number-of-endpoints-all-of-fine-tuning",
+      "title": "Cohere: command-r",
+      "content_text": "",
+      "date_published": "2026-05-01T21:39:32.667391+00:00",
+      "_deprecation": {
+        "provider": "Cohere",
+        "model_id": "command-r",
+        "shutdown_date": "",
+        "deprecation_date": "2025-09-15",
+        "announcement_date": "2026-05-01",
+        "replacement_models": [
+          "command-r-08-2024",
+          "command-r-plus-08-2024",
+          "command-a-03-2025"
+        ],
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Cohere"
+      ]
+    },
+    {
+      "id": "cohere-command-r-plus-04-2024",
+      "url": "https://docs.cohere.com/docs/deprecations#2025-09-15-various-older-command-models-a-number-of-endpoints-all-of-fine-tuning",
+      "title": "Cohere: command-r-plus-04-2024",
+      "content_text": "",
+      "date_published": "2026-05-01T21:39:32.667396+00:00",
+      "_deprecation": {
+        "provider": "Cohere",
+        "model_id": "command-r-plus-04-2024",
+        "shutdown_date": "",
+        "deprecation_date": "2025-09-15",
+        "announcement_date": "2026-05-01",
+        "replacement_models": [
+          "command-r-08-2024",
+          "command-r-plus-08-2024",
+          "command-a-03-2025"
+        ],
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Cohere"
+      ]
+    },
+    {
+      "id": "cohere-command-r-plus",
+      "url": "https://docs.cohere.com/docs/deprecations#2025-09-15-various-older-command-models-a-number-of-endpoints-all-of-fine-tuning",
+      "title": "Cohere: command-r-plus",
+      "content_text": "",
+      "date_published": "2026-05-01T21:39:32.667401+00:00",
+      "_deprecation": {
+        "provider": "Cohere",
+        "model_id": "command-r-plus",
+        "shutdown_date": "",
+        "deprecation_date": "2025-09-15",
+        "announcement_date": "2026-05-01",
+        "replacement_models": [
+          "command-r-08-2024",
+          "command-r-plus-08-2024",
+          "command-a-03-2025"
+        ],
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Cohere"
+      ]
+    },
+    {
+      "id": "cohere-command-light",
+      "url": "https://docs.cohere.com/docs/deprecations#2025-09-15-various-older-command-models-a-number-of-endpoints-all-of-fine-tuning",
+      "title": "Cohere: command-light",
+      "content_text": "",
+      "date_published": "2026-05-01T21:39:32.667406+00:00",
+      "_deprecation": {
+        "provider": "Cohere",
+        "model_id": "command-light",
+        "shutdown_date": "",
+        "deprecation_date": "2025-09-15",
+        "announcement_date": "2026-05-01",
+        "replacement_models": [
+          "command-r-08-2024",
+          "command-r-plus-08-2024",
+          "command-a-03-2025"
+        ],
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Cohere"
+      ]
+    },
+    {
+      "id": "cohere-command",
+      "url": "https://docs.cohere.com/docs/deprecations#2025-09-15-various-older-command-models-a-number-of-endpoints-all-of-fine-tuning",
+      "title": "Cohere: command",
+      "content_text": "",
+      "date_published": "2026-05-01T21:39:32.667410+00:00",
+      "_deprecation": {
+        "provider": "Cohere",
+        "model_id": "command",
+        "shutdown_date": "",
+        "deprecation_date": "2025-09-15",
+        "announcement_date": "2026-05-01",
+        "replacement_models": [
+          "command-r-08-2024",
+          "command-r-plus-08-2024",
+          "command-a-03-2025"
+        ],
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Cohere"
+      ]
+    },
+    {
+      "id": "cohere-rerank-english-v2.0",
+      "url": "https://docs.cohere.com/docs/deprecations#2024-12-02-rerank-v2-0",
+      "title": "Cohere: rerank-english-v2.0",
+      "content_text": "",
+      "date_published": "2026-05-01T21:39:32.667519+00:00",
+      "_deprecation": {
+        "provider": "Cohere",
+        "model_id": "rerank-english-v2.0",
+        "shutdown_date": "2025-04-30",
+        "deprecation_date": "2024-12-02",
+        "announcement_date": "2026-05-01",
+        "replacement_models": [
+          "rerank-v3.5"
+        ],
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Cohere",
+        "shutdown-2025"
+      ]
+    },
+    {
+      "id": "cohere-rerank-multilingual-v2.0",
+      "url": "https://docs.cohere.com/docs/deprecations#2024-12-02-rerank-v2-0",
+      "title": "Cohere: rerank-multilingual-v2.0",
+      "content_text": "",
+      "date_published": "2026-05-01T21:39:32.667541+00:00",
+      "_deprecation": {
+        "provider": "Cohere",
+        "model_id": "rerank-multilingual-v2.0",
+        "shutdown_date": "2025-04-30",
+        "deprecation_date": "2024-12-02",
+        "announcement_date": "2026-05-01",
+        "replacement_models": [
+          "rerank-v3.5"
+        ],
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Cohere",
+        "shutdown-2025"
+      ]
+    },
+    {
       "id": "azure-codex-mini",
       "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
       "title": "Azure: codex-mini",
@@ -4549,20 +5538,20 @@
       "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
       "title": "Azure: gpt-4o-transcribe-diarize",
       "content_text": "",
-      "date_published": "2026-04-25T04:37:34.697793+00:00",
+      "date_published": "2026-05-01T21:39:32.794046+00:00",
       "_deprecation": {
         "provider": "Azure",
         "model_id": "gpt-4o-transcribe-diarize",
-        "shutdown_date": "2027-04-16",
-        "deprecation_date": "2027-04-16",
+        "shutdown_date": "2026-10-15",
+        "deprecation_date": "2026-10-15",
         "announcement_date": "2026-04-25",
         "replacement_models": null,
         "first_observed": "2026-04-25",
-        "last_observed": "2026-04-25"
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "Azure",
-        "shutdown-2027"
+        "shutdown-2026"
       ]
     },
     {
@@ -4591,18 +5580,18 @@
       "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
       "title": "Azure: gpt-5-chat",
       "content_text": "",
-      "date_published": "2026-04-25T04:37:34.697899+00:00",
+      "date_published": "2026-05-01T21:39:32.794174+00:00",
       "_deprecation": {
         "provider": "Azure",
         "model_id": "gpt-5-chat",
-        "shutdown_date": "2026-05-13",
-        "deprecation_date": "2026-05-13",
+        "shutdown_date": "2026-06-09",
+        "deprecation_date": "2026-06-09",
         "announcement_date": "2026-04-25",
         "replacement_models": [
           "gpt-5.3-chat"
         ],
         "first_observed": "2026-04-25",
-        "last_observed": "2026-04-25"
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "Azure",
@@ -4719,18 +5708,18 @@
       "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
       "title": "Azure: gpt-5.1-chat",
       "content_text": "",
-      "date_published": "2026-04-25T04:37:34.698274+00:00",
+      "date_published": "2026-05-01T21:39:32.794622+00:00",
       "_deprecation": {
         "provider": "Azure",
         "model_id": "gpt-5.1-chat",
-        "shutdown_date": "2026-05-13",
-        "deprecation_date": "2026-05-13",
+        "shutdown_date": "2026-06-09",
+        "deprecation_date": "2026-06-09",
         "announcement_date": "2026-04-25",
         "replacement_models": [
           "gpt-5.3-chat"
         ],
         "first_observed": "2026-04-25",
-        "last_observed": "2026-04-25"
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "Azure",
@@ -4826,18 +5815,18 @@
       "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
       "title": "Azure: gpt-5.2-chat",
       "content_text": "",
-      "date_published": "2026-04-25T04:37:34.698534+00:00",
+      "date_published": "2026-05-01T21:39:32.794939+00:00",
       "_deprecation": {
         "provider": "Azure",
         "model_id": "gpt-5.2-chat",
-        "shutdown_date": "2026-05-13",
-        "deprecation_date": "2026-05-13",
+        "shutdown_date": "2026-06-09",
+        "deprecation_date": "2026-06-09",
         "announcement_date": "2026-04-25",
         "replacement_models": [
           "gpt-5.3-chat"
         ],
         "first_observed": "2026-04-25",
-        "last_observed": "2026-04-25"
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "Azure",
@@ -4870,16 +5859,16 @@
       "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
       "title": "Azure: gpt-5.3-chat",
       "content_text": "",
-      "date_published": "2026-04-25T04:37:34.698723+00:00",
+      "date_published": "2026-05-01T21:39:32.795129+00:00",
       "_deprecation": {
         "provider": "Azure",
         "model_id": "gpt-5.3-chat",
-        "shutdown_date": "2026-06-03",
-        "deprecation_date": "2026-06-03",
+        "shutdown_date": "2026-06-09",
+        "deprecation_date": "2026-06-09",
         "announcement_date": "2026-04-25",
         "replacement_models": null,
         "first_observed": "2026-04-25",
-        "last_observed": "2026-04-25"
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "Azure",
@@ -5059,20 +6048,20 @@
       "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
       "title": "Azure: gpt-audio-mini",
       "content_text": "",
-      "date_published": "2026-04-25T04:37:34.699132+00:00",
+      "date_published": "2026-05-01T21:39:32.795695+00:00",
       "_deprecation": {
         "provider": "Azure",
         "model_id": "gpt-audio-mini",
-        "shutdown_date": "2027-04-07",
-        "deprecation_date": "2027-04-07",
+        "shutdown_date": "2026-07-23",
+        "deprecation_date": "2026-07-23",
         "announcement_date": "2026-04-25",
         "replacement_models": null,
         "first_observed": "2026-04-25",
-        "last_observed": "2026-04-25"
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "Azure",
-        "shutdown-2027"
+        "shutdown-2026"
       ]
     },
     {
@@ -5206,20 +6195,20 @@
       "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
       "title": "Azure: gpt-realtime-mini",
       "content_text": "",
-      "date_published": "2026-04-25T04:37:34.699510+00:00",
+      "date_published": "2026-05-01T21:39:32.796194+00:00",
       "_deprecation": {
         "provider": "Azure",
         "model_id": "gpt-realtime-mini",
-        "shutdown_date": "2027-04-07",
-        "deprecation_date": "2027-04-07",
+        "shutdown_date": "2026-07-23",
+        "deprecation_date": "2026-07-23",
         "announcement_date": "2026-04-25",
         "replacement_models": null,
         "first_observed": "2026-04-25",
-        "last_observed": "2026-04-25"
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "Azure",
-        "shutdown-2027"
+        "shutdown-2026"
       ]
     },
     {
@@ -5439,16 +6428,16 @@
       "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
       "title": "Azure: tts",
       "content_text": "",
-      "date_published": "2026-04-25T04:37:34.700273+00:00",
+      "date_published": "2026-05-01T21:39:32.797034+00:00",
       "_deprecation": {
         "provider": "Azure",
         "model_id": "tts",
-        "shutdown_date": "2026-06-18",
-        "deprecation_date": "2026-06-18",
+        "shutdown_date": "2026-12-15",
+        "deprecation_date": "2026-12-15",
         "announcement_date": "2026-04-25",
         "replacement_models": null,
         "first_observed": "2026-04-25",
-        "last_observed": "2026-04-25"
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "Azure",
@@ -5460,16 +6449,16 @@
       "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
       "title": "Azure: tts-hd",
       "content_text": "",
-      "date_published": "2026-04-25T04:37:34.700324+00:00",
+      "date_published": "2026-05-01T21:39:32.797099+00:00",
       "_deprecation": {
         "provider": "Azure",
         "model_id": "tts-hd",
-        "shutdown_date": "2026-06-18",
-        "deprecation_date": "2026-06-18",
+        "shutdown_date": "2026-12-15",
+        "deprecation_date": "2026-12-15",
         "announcement_date": "2026-04-25",
         "replacement_models": null,
         "first_observed": "2026-04-25",
-        "last_observed": "2026-04-25"
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "Azure",
@@ -5481,16 +6470,16 @@
       "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
       "title": "Azure: whisper",
       "content_text": "",
-      "date_published": "2026-04-25T04:37:34.700376+00:00",
+      "date_published": "2026-05-01T21:39:32.797163+00:00",
       "_deprecation": {
         "provider": "Azure",
         "model_id": "whisper",
-        "shutdown_date": "2026-06-18",
-        "deprecation_date": "2026-06-18",
+        "shutdown_date": "2026-12-15",
+        "deprecation_date": "2026-12-15",
         "announcement_date": "2026-04-25",
         "replacement_models": null,
         "first_observed": "2026-04-25",
-        "last_observed": "2026-04-25"
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "Azure",
@@ -5758,6 +6747,27 @@
       ]
     },
     {
+      "id": "azure-claude-opus-4-7",
+      "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
+      "title": "Azure: claude-opus-4-7",
+      "content_text": "",
+      "date_published": "2026-05-01T21:39:32.800598+00:00",
+      "_deprecation": {
+        "provider": "Azure",
+        "model_id": "claude-opus-4-7",
+        "shutdown_date": "2027-04-06",
+        "deprecation_date": "2027-04-06",
+        "announcement_date": "2026-05-01",
+        "replacement_models": null,
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Azure",
+        "shutdown-2027"
+      ]
+    },
+    {
       "id": "azure-claude-sonnet-4-5",
       "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
       "title": "Azure: claude-sonnet-4-5",
@@ -5859,6 +6869,279 @@
         ],
         "first_observed": "2026-01-14",
         "last_observed": "2026-04-25"
+      },
+      "tags": [
+        "Azure",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "azure-fw-deepseek-v3.1",
+      "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
+      "title": "Azure: FW-DeepSeek-V3.1",
+      "content_text": "",
+      "date_published": "2026-05-01T21:39:32.801413+00:00",
+      "_deprecation": {
+        "provider": "Azure",
+        "model_id": "FW-DeepSeek-V3.1",
+        "shutdown_date": "2026-07-01",
+        "deprecation_date": "2026-07-01",
+        "announcement_date": "2026-05-01",
+        "replacement_models": null,
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Azure",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "azure-fw-deepseek-v3.2",
+      "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
+      "title": "Azure: FW-DeepSeek-V3.2",
+      "content_text": "",
+      "date_published": "2026-05-01T21:39:32.801476+00:00",
+      "_deprecation": {
+        "provider": "Azure",
+        "model_id": "FW-DeepSeek-V3.2",
+        "shutdown_date": "2026-07-01",
+        "deprecation_date": "2026-07-01",
+        "announcement_date": "2026-05-01",
+        "replacement_models": null,
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Azure",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "azure-fw-glm-4.7",
+      "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
+      "title": "Azure: FW-GLM-4.7",
+      "content_text": "",
+      "date_published": "2026-05-01T21:39:32.801536+00:00",
+      "_deprecation": {
+        "provider": "Azure",
+        "model_id": "FW-GLM-4.7",
+        "shutdown_date": "2026-07-01",
+        "deprecation_date": "2026-07-01",
+        "announcement_date": "2026-05-01",
+        "replacement_models": null,
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Azure",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "azure-fw-glm-5",
+      "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
+      "title": "Azure: FW-GLM-5",
+      "content_text": "",
+      "date_published": "2026-05-01T21:39:32.801595+00:00",
+      "_deprecation": {
+        "provider": "Azure",
+        "model_id": "FW-GLM-5",
+        "shutdown_date": "2026-07-01",
+        "deprecation_date": "2026-07-01",
+        "announcement_date": "2026-05-01",
+        "replacement_models": null,
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Azure",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "azure-fw-glm-5.1",
+      "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
+      "title": "Azure: FW-GLM-5.1",
+      "content_text": "",
+      "date_published": "2026-05-01T21:39:32.801653+00:00",
+      "_deprecation": {
+        "provider": "Azure",
+        "model_id": "FW-GLM-5.1",
+        "shutdown_date": "2026-08-01",
+        "deprecation_date": "2026-08-01",
+        "announcement_date": "2026-05-01",
+        "replacement_models": null,
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Azure",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "azure-fw-gpt-oss-120b",
+      "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
+      "title": "Azure: FW-GPT-OSS-120B",
+      "content_text": "",
+      "date_published": "2026-05-01T21:39:32.801715+00:00",
+      "_deprecation": {
+        "provider": "Azure",
+        "model_id": "FW-GPT-OSS-120B",
+        "shutdown_date": "2026-07-01",
+        "deprecation_date": "2026-07-01",
+        "announcement_date": "2026-05-01",
+        "replacement_models": null,
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Azure",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "azure-fw-kimi-k2-instruct-0905",
+      "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
+      "title": "Azure: FW-Kimi-K2-Instruct-0905",
+      "content_text": "",
+      "date_published": "2026-05-01T21:39:32.801775+00:00",
+      "_deprecation": {
+        "provider": "Azure",
+        "model_id": "FW-Kimi-K2-Instruct-0905",
+        "shutdown_date": "2026-07-01",
+        "deprecation_date": "2026-07-01",
+        "announcement_date": "2026-05-01",
+        "replacement_models": null,
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Azure",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "azure-fw-kimi-k2-thinking",
+      "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
+      "title": "Azure: FW-Kimi-K2-Thinking",
+      "content_text": "",
+      "date_published": "2026-05-01T21:39:32.801836+00:00",
+      "_deprecation": {
+        "provider": "Azure",
+        "model_id": "FW-Kimi-K2-Thinking",
+        "shutdown_date": "2026-07-01",
+        "deprecation_date": "2026-07-01",
+        "announcement_date": "2026-05-01",
+        "replacement_models": null,
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Azure",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "azure-fw-kimi-k2.5",
+      "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
+      "title": "Azure: FW-Kimi-K2.5",
+      "content_text": "",
+      "date_published": "2026-05-01T21:39:32.801894+00:00",
+      "_deprecation": {
+        "provider": "Azure",
+        "model_id": "FW-Kimi-K2.5",
+        "shutdown_date": "2026-07-01",
+        "deprecation_date": "2026-07-01",
+        "announcement_date": "2026-05-01",
+        "replacement_models": null,
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Azure",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "azure-fw-minimax-m2.5",
+      "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
+      "title": "Azure: FW-MiniMax-M2.5",
+      "content_text": "",
+      "date_published": "2026-05-01T21:39:32.801954+00:00",
+      "_deprecation": {
+        "provider": "Azure",
+        "model_id": "FW-MiniMax-M2.5",
+        "shutdown_date": "2026-07-01",
+        "deprecation_date": "2026-07-01",
+        "announcement_date": "2026-05-01",
+        "replacement_models": null,
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Azure",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "azure-fw-qwen3-14b",
+      "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
+      "title": "Azure: FW-Qwen3-14B",
+      "content_text": "",
+      "date_published": "2026-05-01T21:39:32.802011+00:00",
+      "_deprecation": {
+        "provider": "Azure",
+        "model_id": "FW-Qwen3-14B",
+        "shutdown_date": "2026-07-01",
+        "deprecation_date": "2026-07-01",
+        "announcement_date": "2026-05-01",
+        "replacement_models": null,
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Azure",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "azure-fw-qwen3.5-122b-a10b",
+      "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
+      "title": "Azure: FW-Qwen3.5-122B-A10B",
+      "content_text": "",
+      "date_published": "2026-05-01T21:39:32.802070+00:00",
+      "_deprecation": {
+        "provider": "Azure",
+        "model_id": "FW-Qwen3.5-122B-A10B",
+        "shutdown_date": "2026-08-01",
+        "deprecation_date": "2026-08-01",
+        "announcement_date": "2026-05-01",
+        "replacement_models": null,
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
+      },
+      "tags": [
+        "Azure",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "azure-fw-qwen3.5-397b-a17b",
+      "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
+      "title": "Azure: FW-Qwen3.5-397B-A17B",
+      "content_text": "",
+      "date_published": "2026-05-01T21:39:32.802131+00:00",
+      "_deprecation": {
+        "provider": "Azure",
+        "model_id": "FW-Qwen3.5-397B-A17B",
+        "shutdown_date": "2026-08-01",
+        "deprecation_date": "2026-08-01",
+        "announcement_date": "2026-05-01",
+        "replacement_models": null,
+        "first_observed": "2026-05-01",
+        "last_observed": "2026-05-01"
       },
       "tags": [
         "Azure",

--- a/docs/v1/feed.xml
+++ b/docs/v1/feed.xml
@@ -4,7 +4,7 @@
     <title>AI Model Deprecations</title>
     <link>https://deprecations.info/</link>
     <description>RSS feed tracking deprecations across major AI providers</description>
-    <lastBuildDate>Tue, 28 Apr 2026 05:32:49 GMT</lastBuildDate>
+    <lastBuildDate>Fri, 01 May 2026 21:43:36 GMT</lastBuildDate>
     <item>
       <title>OpenAI: computer-use-preview-2025-03-11</title>
       <link>https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots</link>
@@ -13,11 +13,25 @@ Model ID: computer-use-preview-2025-03-11
 Deprecation Date: 2026-04-22
 Shutdown Date: 2026-07-23
 First Observed: 2026-04-23
-Last Observed: 2026-04-23
+Last Observed: 2026-05-01
 
 To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.</description>
-      <pubDate>Thu, 23 Apr 2026 04:51:54 GMT</pubDate>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
       <guid isPermaLink="false">OpenAI-computer-use-preview-2025-03-11-2026-07-23-e3b0c442</guid>
+    </item>
+    <item>
+      <title>OpenAI: computer-use-preview</title>
+      <link>https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots</link>
+      <description>Provider: OpenAI
+Model ID: computer-use-preview
+Deprecation Date: 2026-04-22
+Shutdown Date: 2026-07-23
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
+
+To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.</description>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
+      <guid isPermaLink="false">OpenAI-computer-use-preview-2026-07-23-e3b0c442</guid>
     </item>
     <item>
       <title>OpenAI: gpt-4o-audio-preview-2024-12-17</title>
@@ -27,10 +41,10 @@ Model ID: gpt-4o-audio-preview-2024-12-17
 Deprecation Date: 2026-04-22
 Shutdown Date: 2026-07-23
 First Observed: 2026-04-23
-Last Observed: 2026-04-23
+Last Observed: 2026-05-01
 
 To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.</description>
-      <pubDate>Thu, 23 Apr 2026 04:51:54 GMT</pubDate>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
       <guid isPermaLink="false">OpenAI-gpt-4o-audio-preview-2024-12-17-2026-07-23-e3b0c442</guid>
     </item>
     <item>
@@ -41,10 +55,10 @@ Model ID: gpt-4o-mini-audio-preview-2024-12-17
 Deprecation Date: 2026-04-22
 Shutdown Date: 2026-07-23
 First Observed: 2026-04-23
-Last Observed: 2026-04-23
+Last Observed: 2026-05-01
 
 To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.</description>
-      <pubDate>Thu, 23 Apr 2026 04:51:54 GMT</pubDate>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
       <guid isPermaLink="false">OpenAI-gpt-4o-mini-audio-preview-2024-12-17-2026-07-23-e3b0c442</guid>
     </item>
     <item>
@@ -55,10 +69,10 @@ Model ID: gpt-4o-mini-realtime-preview-2024-12-17
 Deprecation Date: 2026-04-22
 Shutdown Date: 2026-07-23
 First Observed: 2026-04-23
-Last Observed: 2026-04-23
+Last Observed: 2026-05-01
 
 To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.</description>
-      <pubDate>Thu, 23 Apr 2026 04:51:54 GMT</pubDate>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
       <guid isPermaLink="false">OpenAI-gpt-4o-mini-realtime-preview-2024-12-17-2026-07-23-e3b0c442</guid>
     </item>
     <item>
@@ -69,10 +83,10 @@ Model ID: gpt-4o-mini-search-preview-2025-03-11
 Deprecation Date: 2026-04-22
 Shutdown Date: 2026-07-23
 First Observed: 2026-04-23
-Last Observed: 2026-04-23
+Last Observed: 2026-05-01
 
 To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.</description>
-      <pubDate>Thu, 23 Apr 2026 04:51:54 GMT</pubDate>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
       <guid isPermaLink="false">OpenAI-gpt-4o-mini-search-preview-2025-03-11-2026-07-23-e3b0c442</guid>
     </item>
     <item>
@@ -83,10 +97,10 @@ Model ID: gpt-4o-mini-tts-2025-03-20
 Deprecation Date: 2026-04-22
 Shutdown Date: 2026-07-23
 First Observed: 2026-04-23
-Last Observed: 2026-04-23
+Last Observed: 2026-05-01
 
 To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.</description>
-      <pubDate>Thu, 23 Apr 2026 04:51:54 GMT</pubDate>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
       <guid isPermaLink="false">OpenAI-gpt-4o-mini-tts-2025-03-20-2026-07-23-e3b0c442</guid>
     </item>
     <item>
@@ -97,10 +111,10 @@ Model ID: gpt-4o-search-preview-2025-03-11
 Deprecation Date: 2026-04-22
 Shutdown Date: 2026-07-23
 First Observed: 2026-04-23
-Last Observed: 2026-04-23
+Last Observed: 2026-05-01
 
 To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.</description>
-      <pubDate>Thu, 23 Apr 2026 04:51:54 GMT</pubDate>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
       <guid isPermaLink="false">OpenAI-gpt-4o-search-preview-2025-03-11-2026-07-23-e3b0c442</guid>
     </item>
     <item>
@@ -111,10 +125,10 @@ Model ID: gpt-5-chat-latest
 Deprecation Date: 2026-04-22
 Shutdown Date: 2026-07-23
 First Observed: 2026-04-23
-Last Observed: 2026-04-23
+Last Observed: 2026-05-01
 
 To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.</description>
-      <pubDate>Thu, 23 Apr 2026 04:51:54 GMT</pubDate>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
       <guid isPermaLink="false">OpenAI-gpt-5-chat-latest-2026-07-23-e3b0c442</guid>
     </item>
     <item>
@@ -125,10 +139,10 @@ Model ID: gpt-5-codex
 Deprecation Date: 2026-04-22
 Shutdown Date: 2026-07-23
 First Observed: 2026-04-23
-Last Observed: 2026-04-23
+Last Observed: 2026-05-01
 
 To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.</description>
-      <pubDate>Thu, 23 Apr 2026 04:51:54 GMT</pubDate>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
       <guid isPermaLink="false">OpenAI-gpt-5-codex-2026-07-23-e3b0c442</guid>
     </item>
     <item>
@@ -139,10 +153,10 @@ Model ID: gpt-5.1-chat-latest
 Deprecation Date: 2026-04-22
 Shutdown Date: 2026-07-23
 First Observed: 2026-04-23
-Last Observed: 2026-04-23
+Last Observed: 2026-05-01
 
 To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.</description>
-      <pubDate>Thu, 23 Apr 2026 04:51:54 GMT</pubDate>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
       <guid isPermaLink="false">OpenAI-gpt-5.1-chat-latest-2026-07-23-e3b0c442</guid>
     </item>
     <item>
@@ -153,10 +167,10 @@ Model ID: gpt-5.1-codex
 Deprecation Date: 2026-04-22
 Shutdown Date: 2026-07-23
 First Observed: 2026-04-23
-Last Observed: 2026-04-23
+Last Observed: 2026-05-01
 
 To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.</description>
-      <pubDate>Thu, 23 Apr 2026 04:51:54 GMT</pubDate>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
       <guid isPermaLink="false">OpenAI-gpt-5.1-codex-2026-07-23-e3b0c442</guid>
     </item>
     <item>
@@ -167,10 +181,10 @@ Model ID: gpt-5.1-codex-max
 Deprecation Date: 2026-04-22
 Shutdown Date: 2026-07-23
 First Observed: 2026-04-23
-Last Observed: 2026-04-23
+Last Observed: 2026-05-01
 
 To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.</description>
-      <pubDate>Thu, 23 Apr 2026 04:51:54 GMT</pubDate>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
       <guid isPermaLink="false">OpenAI-gpt-5.1-codex-max-2026-07-23-e3b0c442</guid>
     </item>
     <item>
@@ -181,10 +195,10 @@ Model ID: gpt-5.1-codex-mini
 Deprecation Date: 2026-04-22
 Shutdown Date: 2026-07-23
 First Observed: 2026-04-23
-Last Observed: 2026-04-23
+Last Observed: 2026-05-01
 
 To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.</description>
-      <pubDate>Thu, 23 Apr 2026 04:51:54 GMT</pubDate>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
       <guid isPermaLink="false">OpenAI-gpt-5.1-codex-mini-2026-07-23-e3b0c442</guid>
     </item>
     <item>
@@ -195,10 +209,10 @@ Model ID: gpt-audio-mini-2025-10-06
 Deprecation Date: 2026-04-22
 Shutdown Date: 2026-07-23
 First Observed: 2026-04-23
-Last Observed: 2026-04-23
+Last Observed: 2026-05-01
 
 To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.</description>
-      <pubDate>Thu, 23 Apr 2026 04:51:54 GMT</pubDate>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
       <guid isPermaLink="false">OpenAI-gpt-audio-mini-2025-10-06-2026-07-23-e3b0c442</guid>
     </item>
     <item>
@@ -209,10 +223,10 @@ Model ID: gpt-realtime-mini-2025-10-06
 Deprecation Date: 2026-04-22
 Shutdown Date: 2026-07-23
 First Observed: 2026-04-23
-Last Observed: 2026-04-23
+Last Observed: 2026-05-01
 
 To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.</description>
-      <pubDate>Thu, 23 Apr 2026 04:51:54 GMT</pubDate>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
       <guid isPermaLink="false">OpenAI-gpt-realtime-mini-2025-10-06-2026-07-23-e3b0c442</guid>
     </item>
     <item>
@@ -223,11 +237,25 @@ Model ID: o3-deep-research-2025-06-26
 Deprecation Date: 2026-04-22
 Shutdown Date: 2026-07-23
 First Observed: 2026-04-23
-Last Observed: 2026-04-23
+Last Observed: 2026-05-01
 
 To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.</description>
-      <pubDate>Thu, 23 Apr 2026 04:51:54 GMT</pubDate>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
       <guid isPermaLink="false">OpenAI-o3-deep-research-2025-06-26-2026-07-23-e3b0c442</guid>
+    </item>
+    <item>
+      <title>OpenAI: o3-deep-research</title>
+      <link>https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots</link>
+      <description>Provider: OpenAI
+Model ID: o3-deep-research
+Deprecation Date: 2026-04-22
+Shutdown Date: 2026-07-23
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
+
+To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.</description>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
+      <guid isPermaLink="false">OpenAI-o3-deep-research-2026-07-23-e3b0c442</guid>
     </item>
     <item>
       <title>OpenAI: o4-mini-deep-research-2025-06-26</title>
@@ -237,11 +265,25 @@ Model ID: o4-mini-deep-research-2025-06-26
 Deprecation Date: 2026-04-22
 Shutdown Date: 2026-07-23
 First Observed: 2026-04-23
-Last Observed: 2026-04-23
+Last Observed: 2026-05-01
 
 To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.</description>
-      <pubDate>Thu, 23 Apr 2026 04:51:54 GMT</pubDate>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
       <guid isPermaLink="false">OpenAI-o4-mini-deep-research-2025-06-26-2026-07-23-e3b0c442</guid>
+    </item>
+    <item>
+      <title>OpenAI: o4-mini-deep-research</title>
+      <link>https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots</link>
+      <description>Provider: OpenAI
+Model ID: o4-mini-deep-research
+Deprecation Date: 2026-04-22
+Shutdown Date: 2026-07-23
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
+
+To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.</description>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
+      <guid isPermaLink="false">OpenAI-o4-mini-deep-research-2026-07-23-e3b0c442</guid>
     </item>
     <item>
       <title>OpenAI: gpt-5.2-codex</title>
@@ -251,10 +293,10 @@ Model ID: gpt-5.2-codex
 Deprecation Date: 2026-04-22
 Shutdown Date: 2026-07-23
 First Observed: 2026-04-23
-Last Observed: 2026-04-23
+Last Observed: 2026-05-01
 
 To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.</description>
-      <pubDate>Thu, 23 Apr 2026 04:51:54 GMT</pubDate>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
       <guid isPermaLink="false">OpenAI-gpt-5.2-codex-2026-07-23-e3b0c442</guid>
     </item>
     <item>
@@ -265,11 +307,39 @@ Model ID: gpt-3.5-turbo-0125
 Deprecation Date: 2026-04-22
 Shutdown Date: 2026-10-23
 First Observed: 2026-04-23
-Last Observed: 2026-04-23
+Last Observed: 2026-05-01
 
 To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.</description>
-      <pubDate>Thu, 23 Apr 2026 04:51:54 GMT</pubDate>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
       <guid isPermaLink="false">OpenAI-gpt-3.5-turbo-0125-2026-10-23-e3b0c442</guid>
+    </item>
+    <item>
+      <title>OpenAI: gpt-3.5-turbo</title>
+      <link>https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots</link>
+      <description>Provider: OpenAI
+Model ID: gpt-3.5-turbo
+Deprecation Date: 2026-04-22
+Shutdown Date: 2026-10-23
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
+
+To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.</description>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
+      <guid isPermaLink="false">OpenAI-gpt-3.5-turbo-2026-10-23-e3b0c442</guid>
+    </item>
+    <item>
+      <title>OpenAI: gpt-3.5-turbo-completions</title>
+      <link>https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots</link>
+      <description>Provider: OpenAI
+Model ID: gpt-3.5-turbo-completions
+Deprecation Date: 2026-04-22
+Shutdown Date: 2026-10-23
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
+
+To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.</description>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
+      <guid isPermaLink="false">OpenAI-gpt-3.5-turbo-completions-2026-10-23-e3b0c442</guid>
     </item>
     <item>
       <title>OpenAI: gpt-4-0613</title>
@@ -279,11 +349,53 @@ Model ID: gpt-4-0613
 Deprecation Date: 2026-04-22
 Shutdown Date: 2026-10-23
 First Observed: 2026-04-23
-Last Observed: 2026-04-23
+Last Observed: 2026-05-01
 
 To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.</description>
-      <pubDate>Thu, 23 Apr 2026 04:51:54 GMT</pubDate>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
       <guid isPermaLink="false">OpenAI-gpt-4-0613-2026-10-23-e3b0c442</guid>
+    </item>
+    <item>
+      <title>OpenAI: gpt-4</title>
+      <link>https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots</link>
+      <description>Provider: OpenAI
+Model ID: gpt-4
+Deprecation Date: 2026-04-22
+Shutdown Date: 2026-10-23
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
+
+To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.</description>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
+      <guid isPermaLink="false">OpenAI-gpt-4-2026-10-23-e3b0c442</guid>
+    </item>
+    <item>
+      <title>OpenAI: gpt-4-0613-completions</title>
+      <link>https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots</link>
+      <description>Provider: OpenAI
+Model ID: gpt-4-0613-completions
+Deprecation Date: 2026-04-22
+Shutdown Date: 2026-10-23
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
+
+To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.</description>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
+      <guid isPermaLink="false">OpenAI-gpt-4-0613-completions-2026-10-23-e3b0c442</guid>
+    </item>
+    <item>
+      <title>OpenAI: gpt-4-completions</title>
+      <link>https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots</link>
+      <description>Provider: OpenAI
+Model ID: gpt-4-completions
+Deprecation Date: 2026-04-22
+Shutdown Date: 2026-10-23
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
+
+To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.</description>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
+      <guid isPermaLink="false">OpenAI-gpt-4-completions-2026-10-23-e3b0c442</guid>
     </item>
     <item>
       <title>OpenAI: gpt-4-1106-preview</title>
@@ -293,10 +405,10 @@ Model ID: gpt-4-1106-preview
 Deprecation Date: 2026-04-22
 Shutdown Date: 2026-10-23
 First Observed: 2026-03-26
-Last Observed: 2026-04-23
+Last Observed: 2026-05-01
 
 To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.</description>
-      <pubDate>Thu, 23 Apr 2026 04:51:54 GMT</pubDate>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
       <guid isPermaLink="false">OpenAI-gpt-4-1106-preview-2026-10-23-e3b0c442</guid>
     </item>
     <item>
@@ -307,11 +419,39 @@ Model ID: gpt-4-turbo
 Deprecation Date: 2026-04-22
 Shutdown Date: 2026-10-23
 First Observed: 2026-04-23
-Last Observed: 2026-04-23
+Last Observed: 2026-05-01
 
 To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.</description>
-      <pubDate>Thu, 23 Apr 2026 04:51:54 GMT</pubDate>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
       <guid isPermaLink="false">OpenAI-gpt-4-turbo-2026-10-23-e3b0c442</guid>
+    </item>
+    <item>
+      <title>OpenAI: gpt-4-turbo-2024-04-09</title>
+      <link>https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots</link>
+      <description>Provider: OpenAI
+Model ID: gpt-4-turbo-2024-04-09
+Deprecation Date: 2026-04-22
+Shutdown Date: 2026-10-23
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
+
+To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.</description>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
+      <guid isPermaLink="false">OpenAI-gpt-4-turbo-2024-04-09-2026-10-23-e3b0c442</guid>
+    </item>
+    <item>
+      <title>OpenAI: gpt-4-turbo-completions</title>
+      <link>https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots</link>
+      <description>Provider: OpenAI
+Model ID: gpt-4-turbo-completions
+Deprecation Date: 2026-04-22
+Shutdown Date: 2026-10-23
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
+
+To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.</description>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
+      <guid isPermaLink="false">OpenAI-gpt-4-turbo-completions-2026-10-23-e3b0c442</guid>
     </item>
     <item>
       <title>OpenAI: gpt-4.1-nano</title>
@@ -321,11 +461,25 @@ Model ID: gpt-4.1-nano
 Deprecation Date: 2026-04-22
 Shutdown Date: 2026-10-23
 First Observed: 2026-04-23
-Last Observed: 2026-04-23
+Last Observed: 2026-05-01
 
 To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.</description>
-      <pubDate>Thu, 23 Apr 2026 04:51:54 GMT</pubDate>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
       <guid isPermaLink="false">OpenAI-gpt-4.1-nano-2026-10-23-e3b0c442</guid>
+    </item>
+    <item>
+      <title>OpenAI: gpt-4.1-nano-2025-04-14</title>
+      <link>https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots</link>
+      <description>Provider: OpenAI
+Model ID: gpt-4.1-nano-2025-04-14
+Deprecation Date: 2026-04-22
+Shutdown Date: 2026-10-23
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
+
+To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.</description>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
+      <guid isPermaLink="false">OpenAI-gpt-4.1-nano-2025-04-14-2026-10-23-e3b0c442</guid>
     </item>
     <item>
       <title>OpenAI: gpt-4o-2024-05-13</title>
@@ -335,10 +489,10 @@ Model ID: gpt-4o-2024-05-13
 Deprecation Date: 2026-04-22
 Shutdown Date: 2026-10-23
 First Observed: 2026-04-23
-Last Observed: 2026-04-23
+Last Observed: 2026-05-01
 
 To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.</description>
-      <pubDate>Thu, 23 Apr 2026 04:51:54 GMT</pubDate>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
       <guid isPermaLink="false">OpenAI-gpt-4o-2024-05-13-2026-10-23-e3b0c442</guid>
     </item>
     <item>
@@ -349,10 +503,10 @@ Model ID: gpt-image-1
 Deprecation Date: 2026-04-22
 Shutdown Date: 2026-10-23
 First Observed: 2026-04-23
-Last Observed: 2026-04-23
+Last Observed: 2026-05-01
 
 To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.</description>
-      <pubDate>Thu, 23 Apr 2026 04:51:54 GMT</pubDate>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
       <guid isPermaLink="false">OpenAI-gpt-image-1-2026-10-23-e3b0c442</guid>
     </item>
     <item>
@@ -363,11 +517,25 @@ Model ID: o1-2024-12-17
 Deprecation Date: 2026-04-22
 Shutdown Date: 2026-10-23
 First Observed: 2026-04-23
-Last Observed: 2026-04-23
+Last Observed: 2026-05-01
 
 To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.</description>
-      <pubDate>Thu, 23 Apr 2026 04:51:54 GMT</pubDate>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
       <guid isPermaLink="false">OpenAI-o1-2024-12-17-2026-10-23-e3b0c442</guid>
+    </item>
+    <item>
+      <title>OpenAI: o1</title>
+      <link>https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots</link>
+      <description>Provider: OpenAI
+Model ID: o1
+Deprecation Date: 2026-04-22
+Shutdown Date: 2026-10-23
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
+
+To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.</description>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
+      <guid isPermaLink="false">OpenAI-o1-2026-10-23-e3b0c442</guid>
     </item>
     <item>
       <title>OpenAI: o1-pro-2025-03-19</title>
@@ -377,11 +545,25 @@ Model ID: o1-pro-2025-03-19
 Deprecation Date: 2026-04-22
 Shutdown Date: 2026-10-23
 First Observed: 2026-04-23
-Last Observed: 2026-04-23
+Last Observed: 2026-05-01
 
 To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.</description>
-      <pubDate>Thu, 23 Apr 2026 04:51:54 GMT</pubDate>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
       <guid isPermaLink="false">OpenAI-o1-pro-2025-03-19-2026-10-23-e3b0c442</guid>
+    </item>
+    <item>
+      <title>OpenAI: o1-pro</title>
+      <link>https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots</link>
+      <description>Provider: OpenAI
+Model ID: o1-pro
+Deprecation Date: 2026-04-22
+Shutdown Date: 2026-10-23
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
+
+To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.</description>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
+      <guid isPermaLink="false">OpenAI-o1-pro-2026-10-23-e3b0c442</guid>
     </item>
     <item>
       <title>OpenAI: o3-mini-2025-01-31</title>
@@ -391,11 +573,25 @@ Model ID: o3-mini-2025-01-31
 Deprecation Date: 2026-04-22
 Shutdown Date: 2026-10-23
 First Observed: 2026-04-23
-Last Observed: 2026-04-23
+Last Observed: 2026-05-01
 
 To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.</description>
-      <pubDate>Thu, 23 Apr 2026 04:51:54 GMT</pubDate>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
       <guid isPermaLink="false">OpenAI-o3-mini-2025-01-31-2026-10-23-e3b0c442</guid>
+    </item>
+    <item>
+      <title>OpenAI: o3-mini</title>
+      <link>https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots</link>
+      <description>Provider: OpenAI
+Model ID: o3-mini
+Deprecation Date: 2026-04-22
+Shutdown Date: 2026-10-23
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
+
+To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.</description>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
+      <guid isPermaLink="false">OpenAI-o3-mini-2026-10-23-e3b0c442</guid>
     </item>
     <item>
       <title>OpenAI: ft-o4-mini-2025-04-16</title>
@@ -405,10 +601,10 @@ Model ID: ft-o4-mini-2025-04-16
 Deprecation Date: 2026-04-22
 Shutdown Date: 2026-10-23
 First Observed: 2026-04-23
-Last Observed: 2026-04-23
+Last Observed: 2026-05-01
 
 To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.</description>
-      <pubDate>Thu, 23 Apr 2026 04:51:54 GMT</pubDate>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
       <guid isPermaLink="false">OpenAI-ft-o4-mini-2025-04-16-2026-10-23-e3b0c442</guid>
     </item>
     <item>
@@ -419,11 +615,25 @@ Model ID: o4-mini-2025-04-16
 Deprecation Date: 2026-04-22
 Shutdown Date: 2026-10-23
 First Observed: 2026-04-23
-Last Observed: 2026-04-23
+Last Observed: 2026-05-01
 
 To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.</description>
-      <pubDate>Thu, 23 Apr 2026 04:51:54 GMT</pubDate>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
       <guid isPermaLink="false">OpenAI-o4-mini-2025-04-16-2026-10-23-e3b0c442</guid>
+    </item>
+    <item>
+      <title>OpenAI: o4-mini</title>
+      <link>https://platform.openai.com/docs/deprecations#2026-04-22-legacy-gpt-model-snapshots</link>
+      <description>Provider: OpenAI
+Model ID: o4-mini
+Deprecation Date: 2026-04-22
+Shutdown Date: 2026-10-23
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
+
+To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.</description>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
+      <guid isPermaLink="false">OpenAI-o4-mini-2026-10-23-e3b0c442</guid>
     </item>
     <item>
       <title>OpenAI: ft-gpt-3.5-turbo</title>
@@ -433,10 +643,10 @@ Model ID: ft-gpt-3.5-turbo
 Deprecation Date: 2026-04-22
 Shutdown Date: 2026-10-23
 First Observed: 2026-04-23
-Last Observed: 2026-04-23
+Last Observed: 2026-05-01
 
 To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.</description>
-      <pubDate>Thu, 23 Apr 2026 04:51:54 GMT</pubDate>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
       <guid isPermaLink="false">OpenAI-ft-gpt-3.5-turbo-2026-10-23-e3b0c442</guid>
     </item>
     <item>
@@ -447,10 +657,10 @@ Model ID: ft-gpt-4
 Deprecation Date: 2026-04-22
 Shutdown Date: 2026-10-23
 First Observed: 2026-04-23
-Last Observed: 2026-04-23
+Last Observed: 2026-05-01
 
 To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.</description>
-      <pubDate>Thu, 23 Apr 2026 04:51:54 GMT</pubDate>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
       <guid isPermaLink="false">OpenAI-ft-gpt-4-2026-10-23-e3b0c442</guid>
     </item>
     <item>
@@ -461,10 +671,10 @@ Model ID: ft-gpt-4.1-nano-2025-04-14
 Deprecation Date: 2026-04-22
 Shutdown Date: 2026-10-23
 First Observed: 2026-04-23
-Last Observed: 2026-04-23
+Last Observed: 2026-05-01
 
 To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.</description>
-      <pubDate>Thu, 23 Apr 2026 04:51:54 GMT</pubDate>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
       <guid isPermaLink="false">OpenAI-ft-gpt-4.1-nano-2025-04-14-2026-10-23-e3b0c442</guid>
     </item>
     <item>
@@ -475,10 +685,10 @@ Model ID: ft-babbage-002
 Deprecation Date: 2026-04-22
 Shutdown Date: 2026-10-23
 First Observed: 2026-04-23
-Last Observed: 2026-04-23
+Last Observed: 2026-05-01
 
 To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.</description>
-      <pubDate>Thu, 23 Apr 2026 04:51:54 GMT</pubDate>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
       <guid isPermaLink="false">OpenAI-ft-babbage-002-2026-10-23-e3b0c442</guid>
     </item>
     <item>
@@ -489,10 +699,10 @@ Model ID: ft-davinci-002
 Deprecation Date: 2026-04-22
 Shutdown Date: 2026-10-23
 First Observed: 2026-04-23
-Last Observed: 2026-04-23
+Last Observed: 2026-05-01
 
 To improve reliability and make it easier for developers to choose the right models, we are deprecating a set of older OpenAI models. Access to these models will be shut down on the dates below.</description>
-      <pubDate>Thu, 23 Apr 2026 04:51:54 GMT</pubDate>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
       <guid isPermaLink="false">OpenAI-ft-davinci-002-2026-10-23-e3b0c442</guid>
     </item>
     <item>
@@ -503,10 +713,10 @@ Model ID: sora-2
 Deprecation Date: 2026-03-24
 Shutdown Date: 2026-09-24
 First Observed: 2026-03-27
-Last Observed: 2026-03-27
+Last Observed: 2026-05-01
 
 On March 24th, 2026, we notified developers using the Videos API and Sora 2 video generation model aliases and snapshots of their deprecation and removal from the API on September 24, 2026.</description>
-      <pubDate>Fri, 27 Mar 2026 04:35:42 GMT</pubDate>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
       <guid isPermaLink="false">OpenAI-sora-2-2026-09-24-e3b0c442</guid>
     </item>
     <item>
@@ -517,10 +727,10 @@ Model ID: sora-2-pro
 Deprecation Date: 2026-03-24
 Shutdown Date: 2026-09-24
 First Observed: 2026-03-27
-Last Observed: 2026-03-27
+Last Observed: 2026-05-01
 
 On March 24th, 2026, we notified developers using the Videos API and Sora 2 video generation model aliases and snapshots of their deprecation and removal from the API on September 24, 2026.</description>
-      <pubDate>Fri, 27 Mar 2026 04:35:42 GMT</pubDate>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
       <guid isPermaLink="false">OpenAI-sora-2-pro-2026-09-24-e3b0c442</guid>
     </item>
     <item>
@@ -531,10 +741,10 @@ Model ID: sora-2-2025-10-06
 Deprecation Date: 2026-03-24
 Shutdown Date: 2026-09-24
 First Observed: 2026-03-27
-Last Observed: 2026-03-27
+Last Observed: 2026-05-01
 
 On March 24th, 2026, we notified developers using the Videos API and Sora 2 video generation model aliases and snapshots of their deprecation and removal from the API on September 24, 2026.</description>
-      <pubDate>Fri, 27 Mar 2026 04:35:42 GMT</pubDate>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
       <guid isPermaLink="false">OpenAI-sora-2-2025-10-06-2026-09-24-e3b0c442</guid>
     </item>
     <item>
@@ -545,10 +755,10 @@ Model ID: sora-2-2025-12-08
 Deprecation Date: 2026-03-24
 Shutdown Date: 2026-09-24
 First Observed: 2026-03-27
-Last Observed: 2026-03-27
+Last Observed: 2026-05-01
 
 On March 24th, 2026, we notified developers using the Videos API and Sora 2 video generation model aliases and snapshots of their deprecation and removal from the API on September 24, 2026.</description>
-      <pubDate>Fri, 27 Mar 2026 04:35:42 GMT</pubDate>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
       <guid isPermaLink="false">OpenAI-sora-2-2025-12-08-2026-09-24-e3b0c442</guid>
     </item>
     <item>
@@ -559,10 +769,10 @@ Model ID: sora-2-pro-2025-10-06
 Deprecation Date: 2026-03-24
 Shutdown Date: 2026-09-24
 First Observed: 2026-03-27
-Last Observed: 2026-03-27
+Last Observed: 2026-05-01
 
 On March 24th, 2026, we notified developers using the Videos API and Sora 2 video generation model aliases and snapshots of their deprecation and removal from the API on September 24, 2026.</description>
-      <pubDate>Fri, 27 Mar 2026 04:35:42 GMT</pubDate>
+      <pubDate>Fri, 01 May 2026 21:39:21 GMT</pubDate>
       <guid isPermaLink="false">OpenAI-sora-2-pro-2025-10-06-2026-09-24-e3b0c442</guid>
     </item>
     <item>
@@ -1739,209 +1949,508 @@ Last Observed: 2026-03-26
       <guid isPermaLink="false">Anthropic-claude-instant-1.2-2024-11-06-e3b0c442</guid>
     </item>
     <item>
-      <title>Google: gemini-robotics-er-1.6-preview</title>
-      <link>https://ai.google.dev/gemini-api/docs/changelog#20260414</link>
+      <title>Google: gemini-3-pro-preview</title>
+      <link>https://ai.google.dev/gemini-api/docs/deprecations#gemini-3-models</link>
       <description>Provider: Google
-Model ID: gemini-robotics-er-1.6-preview
-Deprecation Date: 2026-04-14
-First Observed: 2026-04-15
-Last Observed: 2026-04-15
+Model ID: gemini-3-pro-preview
+Deprecation Date: 2026-03-09
+Shutdown Date: 2026-03-09
+First Observed: 2026-02-27
+Last Observed: 2026-05-01
 
-Released gemini-robotics-er-1.6-preview , our updated robotics model.
-It now has new capabilities like instrument reading, improved spatial and
-physical reasoning capabilities. To learn more, see Gemini Robotics-ER page and the blog .</description>
-      <pubDate>Wed, 15 Apr 2026 04:47:23 GMT</pubDate>
-      <guid isPermaLink="false">Google-gemini-robotics-er-1.6-preview-e3b0c442</guid>
+Gemini deprecations table: Gemini 3 models. Release date: 2025-11-18. Shutdown date: 2026-03-09. Recommended replacement: gemini-3.1-pro-preview.</description>
+      <pubDate>Fri, 01 May 2026 21:43:36 GMT</pubDate>
+      <guid isPermaLink="false">Google-gemini-3-pro-preview-2026-03-09-e3b0c442</guid>
     </item>
     <item>
-      <title>Google: gemini-robotics-er-1.5-preview</title>
-      <link>https://ai.google.dev/gemini-api/docs/changelog#20260414</link>
+      <title>Google: gemini-2.5-pro</title>
+      <link>https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.5-pro-models</link>
       <description>Provider: Google
-Model ID: gemini-robotics-er-1.5-preview
-Deprecation Date: 2026-04-14
-First Observed: 2026-04-15
-Last Observed: 2026-04-15
+Model ID: gemini-2.5-pro
+Deprecation Date: 2026-06-17
+Shutdown Date: 2026-06-17
+First Observed: 2025-12-05
+Last Observed: 2026-05-01
 
-Deprecation announcement: The gemini-robotics-er-1.5-preview model
-will be shut down on April 30, 2026 at 9AM
-PST.</description>
-      <pubDate>Wed, 15 Apr 2026 04:47:23 GMT</pubDate>
-      <guid isPermaLink="false">Google-gemini-robotics-er-1.5-preview-e3b0c442</guid>
+Gemini deprecations table: Gemini 2.5 Pro models. Release date: 2025-06-17. Shutdown date: 2026-06-17. Recommended replacement: gemini-3.1-pro-preview.</description>
+      <pubDate>Fri, 01 May 2026 21:43:36 GMT</pubDate>
+      <guid isPermaLink="false">Google-gemini-2.5-pro-2026-06-17-e3b0c442</guid>
     </item>
     <item>
-      <title>Google: gemini-embedding-2-preview</title>
-      <link>https://ai.google.dev/gemini-api/docs/changelog#20260310</link>
+      <title>Google: gemini-2.5-pro-preview-03-25</title>
+      <link>https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.5-pro-models</link>
       <description>Provider: Google
-Model ID: gemini-embedding-2-preview
-Deprecation Date: 2026-03-10
-First Observed: 2026-03-12
-Last Observed: 2026-03-12
+Model ID: gemini-2.5-pro-preview-03-25
+Deprecation Date: 2025-12-02
+Shutdown Date: 2025-12-02
+First Observed: 2025-12-05
+Last Observed: 2026-05-01
 
-Released gemini-embedding-2-preview , our first multimodal embedding model.
-It supports text, image, video, audio, and PDF inputs,
-mapping all modalities into a unified embedding space. To learn more, see Embeddings .</description>
-      <pubDate>Thu, 12 Mar 2026 04:07:19 GMT</pubDate>
-      <guid isPermaLink="false">Google-gemini-embedding-2-preview-e3b0c442</guid>
+Gemini deprecations table: Gemini 2.5 Pro models. Release date: 2025-03-03. Shutdown date: 2025-12-02. Recommended replacement: gemini-3.1-pro-preview.</description>
+      <pubDate>Fri, 01 May 2026 21:43:36 GMT</pubDate>
+      <guid isPermaLink="false">Google-gemini-2.5-pro-preview-03-25-2025-12-02-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Google: gemini-2.5-pro-preview-05-06</title>
+      <link>https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.5-pro-models</link>
+      <description>Provider: Google
+Model ID: gemini-2.5-pro-preview-05-06
+Deprecation Date: 2025-12-02
+Shutdown Date: 2025-12-02
+First Observed: 2025-12-05
+Last Observed: 2026-05-01
+
+Gemini deprecations table: Gemini 2.5 Pro models. Release date: 2025-05-06. Shutdown date: 2025-12-02. Recommended replacement: gemini-3.1-pro-preview.</description>
+      <pubDate>Fri, 01 May 2026 21:43:36 GMT</pubDate>
+      <guid isPermaLink="false">Google-gemini-2.5-pro-preview-05-06-2025-12-02-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Google: gemini-2.5-pro-preview-06-05</title>
+      <link>https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.5-pro-models</link>
+      <description>Provider: Google
+Model ID: gemini-2.5-pro-preview-06-05
+Deprecation Date: 2025-12-02
+Shutdown Date: 2025-12-02
+First Observed: 2025-12-05
+Last Observed: 2026-05-01
+
+Gemini deprecations table: Gemini 2.5 Pro models. Release date: 2025-06-05. Shutdown date: 2025-12-02. Recommended replacement: gemini-3.1-pro-preview.</description>
+      <pubDate>Fri, 01 May 2026 21:43:36 GMT</pubDate>
+      <guid isPermaLink="false">Google-gemini-2.5-pro-preview-06-05-2025-12-02-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Google: gemini-2.5-flash</title>
+      <link>https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.5-flash-models</link>
+      <description>Provider: Google
+Model ID: gemini-2.5-flash
+Deprecation Date: 2026-06-17
+Shutdown Date: 2026-06-17
+First Observed: 2025-12-05
+Last Observed: 2026-05-01
+
+Gemini deprecations table: Gemini 2.5 Flash models. Release date: 2025-06-17. Shutdown date: 2026-06-17. Recommended replacement: gemini-3-flash-preview.</description>
+      <pubDate>Fri, 01 May 2026 21:43:36 GMT</pubDate>
+      <guid isPermaLink="false">Google-gemini-2.5-flash-2026-06-17-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Google: gemini-2.5-flash-image</title>
+      <link>https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.5-flash-models</link>
+      <description>Provider: Google
+Model ID: gemini-2.5-flash-image
+Deprecation Date: 2026-10-02
+Shutdown Date: 2026-10-02
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
+
+Gemini deprecations table: Gemini 2.5 Flash models. Release date: 2025-10-02. Shutdown date: 2026-10-02. Recommended replacement: gemini-3.1-flash-image-preview.</description>
+      <pubDate>Fri, 01 May 2026 21:43:36 GMT</pubDate>
+      <guid isPermaLink="false">Google-gemini-2.5-flash-image-2026-10-02-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Google: gemini-2.5-flash-lite</title>
+      <link>https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.5-flash-models</link>
+      <description>Provider: Google
+Model ID: gemini-2.5-flash-lite
+Deprecation Date: 2026-07-22
+Shutdown Date: 2026-07-22
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
+
+Gemini deprecations table: Gemini 2.5 Flash models. Release date: 2025-07-22. Shutdown date: 2026-07-22. Recommended replacement: gemini-3.1-flash-lite-preview.</description>
+      <pubDate>Fri, 01 May 2026 21:43:36 GMT</pubDate>
+      <guid isPermaLink="false">Google-gemini-2.5-flash-lite-2026-07-22-e3b0c442</guid>
     </item>
     <item>
       <title>Google: gemini-2.5-flash-lite-preview-09-2025</title>
-      <link>https://ai.google.dev/gemini-api/docs/changelog#20260310</link>
+      <link>https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.5-flash-models</link>
       <description>Provider: Google
 Model ID: gemini-2.5-flash-lite-preview-09-2025
-Deprecation Date: 2026-03-10
+Deprecation Date: 2026-03-31
+Shutdown Date: 2026-03-31
 First Observed: 2026-03-12
-Last Observed: 2026-03-12
+Last Observed: 2026-05-01
 
-Deprecation announcement: The gemini-2.5-flash-lite-preview-09-2025 model
-will be shut down on March 31, 2026.</description>
-      <pubDate>Thu, 12 Mar 2026 04:07:19 GMT</pubDate>
-      <guid isPermaLink="false">Google-gemini-2.5-flash-lite-preview-09-2025-e3b0c442</guid>
+Gemini deprecations table: Gemini 2.5 Flash models. Release date: 2025-09-25. Shutdown date: 2026-03-31. Recommended replacement: gemini-3.1-flash-lite-preview.</description>
+      <pubDate>Fri, 01 May 2026 21:43:36 GMT</pubDate>
+      <guid isPermaLink="false">Google-gemini-2.5-flash-lite-preview-09-2025-2026-03-31-e3b0c442</guid>
     </item>
     <item>
-      <title>Google: gemini-3-pro-preview</title>
-      <link>https://ai.google.dev/gemini-api/docs/changelog#20260226</link>
+      <title>Google: gemini-2.5-flash-preview-05-20</title>
+      <link>https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.5-flash-models</link>
       <description>Provider: Google
-Model ID: gemini-3-pro-preview
-Deprecation Date: 2026-02-26
-First Observed: 2026-02-27
-Last Observed: 2026-02-27
+Model ID: gemini-2.5-flash-preview-05-20
+Deprecation Date: 2025-11-18
+Shutdown Date: 2025-11-18
+First Observed: 2025-12-05
+Last Observed: 2026-05-01
 
-Deprecation announcement: Gemini 3 Pro Preview ( gemini-3-pro-preview )
-will be shut down March 9, 2026.</description>
-      <pubDate>Fri, 27 Feb 2026 04:06:58 GMT</pubDate>
-      <guid isPermaLink="false">Google-gemini-3-pro-preview-e3b0c442</guid>
-    </item>
-    <item>
-      <title>Google: gemini-2.0-flash</title>
-      <link>https://ai.google.dev/gemini-api/docs/changelog#20260218</link>
-      <description>Provider: Google
-Model ID: gemini-2.0-flash
-Deprecation Date: 2026-02-18
-First Observed: 2026-02-20
-Last Observed: 2026-02-20
-
-Deprecation announcement: The following models will be shut down June 1, 2026: gemini-2.0-flash gemini-2.0-flash-001 gemini-2.0-flash-lite gemini-2.0-flash-lite-001</description>
-      <pubDate>Fri, 20 Feb 2026 04:09:02 GMT</pubDate>
-      <guid isPermaLink="false">Google-gemini-2.0-flash-e3b0c442</guid>
-    </item>
-    <item>
-      <title>Google: gemini-2.0-flash-001</title>
-      <link>https://ai.google.dev/gemini-api/docs/changelog#20260218</link>
-      <description>Provider: Google
-Model ID: gemini-2.0-flash-001
-Deprecation Date: 2026-02-18
-First Observed: 2026-02-20
-Last Observed: 2026-02-20
-
-Deprecation announcement: The following models will be shut down June 1, 2026: gemini-2.0-flash gemini-2.0-flash-001 gemini-2.0-flash-lite gemini-2.0-flash-lite-001</description>
-      <pubDate>Fri, 20 Feb 2026 04:09:02 GMT</pubDate>
-      <guid isPermaLink="false">Google-gemini-2.0-flash-001-e3b0c442</guid>
-    </item>
-    <item>
-      <title>Google: gemini-2.0-flash-lite</title>
-      <link>https://ai.google.dev/gemini-api/docs/changelog#20260218</link>
-      <description>Provider: Google
-Model ID: gemini-2.0-flash-lite
-Deprecation Date: 2026-02-18
-First Observed: 2026-02-20
-Last Observed: 2026-02-20
-
-Deprecation announcement: The following models will be shut down June 1, 2026: gemini-2.0-flash gemini-2.0-flash-001 gemini-2.0-flash-lite gemini-2.0-flash-lite-001</description>
-      <pubDate>Fri, 20 Feb 2026 04:09:02 GMT</pubDate>
-      <guid isPermaLink="false">Google-gemini-2.0-flash-lite-e3b0c442</guid>
-    </item>
-    <item>
-      <title>Google: gemini-2.0-flash-lite-001</title>
-      <link>https://ai.google.dev/gemini-api/docs/changelog#20260218</link>
-      <description>Provider: Google
-Model ID: gemini-2.0-flash-lite-001
-Deprecation Date: 2026-02-18
-First Observed: 2026-02-20
-Last Observed: 2026-02-20
-
-Deprecation announcement: The following models will be shut down June 1, 2026: gemini-2.0-flash gemini-2.0-flash-001 gemini-2.0-flash-lite gemini-2.0-flash-lite-001</description>
-      <pubDate>Fri, 20 Feb 2026 04:09:02 GMT</pubDate>
-      <guid isPermaLink="false">Google-gemini-2.0-flash-lite-001-e3b0c442</guid>
-    </item>
-    <item>
-      <title>Google: gemini-2.5-flash-preview-09-25</title>
-      <link>https://ai.google.dev/gemini-api/docs/changelog#20260115</link>
-      <description>Provider: Google
-Model ID: gemini-2.5-flash-preview-09-25
-Deprecation Date: 2026-01-15
-First Observed: 2026-01-16
-Last Observed: 2026-01-16
-
-Insufficient information provided in the deprecation notice to complete analysis.</description>
-      <pubDate>Fri, 16 Jan 2026 03:24:29 GMT</pubDate>
-      <guid isPermaLink="false">Google-gemini-2.5-flash-preview-09-25-68660377</guid>
-    </item>
-    <item>
-      <title>Google: imagen-4.0-generate-preview-06-06</title>
-      <link>https://ai.google.dev/gemini-api/docs/changelog#20260115</link>
-      <description>Provider: Google
-Model ID: imagen-4.0-generate-preview-06-06
-Deprecation Date: 2026-01-15
-First Observed: 2026-01-16
-Last Observed: 2026-01-16
-
-Insufficient information provided in the deprecation notice. Unable to extract specific details about model deprecation.</description>
-      <pubDate>Fri, 16 Jan 2026 03:24:29 GMT</pubDate>
-      <guid isPermaLink="false">Google-imagen-4.0-generate-preview-06-06-f7a59ecd</guid>
-    </item>
-    <item>
-      <title>Google: imagen-4.0-ultra-generate-preview-06-06</title>
-      <link>https://ai.google.dev/gemini-api/docs/changelog#20260115</link>
-      <description>Provider: Google
-Model ID: imagen-4.0-ultra-generate-preview-06-06
-Deprecation Date: 2026-01-15
-First Observed: 2026-01-16
-Last Observed: 2026-01-16
-
-Insufficient information provided in the deprecation notice to extract specific details.</description>
-      <pubDate>Fri, 16 Jan 2026 03:24:29 GMT</pubDate>
-      <guid isPermaLink="false">Google-imagen-4.0-ultra-generate-preview-06-06-1357e0cc</guid>
+Gemini deprecations table: Gemini 2.5 Flash models. Release date: 2025-05-20. Shutdown date: 2025-11-18. Recommended replacement: gemini-3-flash-preview.</description>
+      <pubDate>Fri, 01 May 2026 21:43:36 GMT</pubDate>
+      <guid isPermaLink="false">Google-gemini-2.5-flash-preview-05-20-2025-11-18-e3b0c442</guid>
     </item>
     <item>
       <title>Google: gemini-2.5-flash-image-preview</title>
-      <link>https://ai.google.dev/gemini-api/docs/changelog#20260115</link>
+      <link>https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.5-flash-models</link>
       <description>Provider: Google
 Model ID: gemini-2.5-flash-image-preview
 Deprecation Date: 2026-01-15
+Shutdown Date: 2026-01-15
 First Observed: 2026-03-26
-Last Observed: 2026-03-26
+Last Observed: 2026-05-01
 
-The gemini-2.5-flash-image-preview model has been shut down.</description>
-      <pubDate>Thu, 26 Mar 2026 13:07:23 GMT</pubDate>
-      <guid isPermaLink="false">Google-gemini-2.5-flash-image-preview-e3b0c442</guid>
+Gemini deprecations table: Gemini 2.5 Flash models. Release date: 2025-05-07. Shutdown date: 2026-01-15. Recommended replacement: gemini-2.5-flash-image.</description>
+      <pubDate>Fri, 01 May 2026 21:39:32 GMT</pubDate>
+      <guid isPermaLink="false">Google-gemini-2.5-flash-image-preview-2026-01-15-e3b0c442</guid>
     </item>
     <item>
-      <title>Google: veo-3.0-fast-generate-preview</title>
-      <link>https://ai.google.dev/gemini-api/docs/changelog#20251111</link>
+      <title>Google: gemini-2.5-flash-preview-09-25</title>
+      <link>https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.5-flash-models</link>
       <description>Provider: Google
-Model ID: veo-3.0-fast-generate-preview
-Deprecation Date: 2025-11-11
-Shutdown Date: 2025-11-12
-First Observed: 2025-12-05
-Last Observed: 2025-12-05
+Model ID: gemini-2.5-flash-preview-09-25
+Deprecation Date: 2026-02-17
+Shutdown Date: 2026-02-17
+First Observed: 2026-01-16
+Last Observed: 2026-05-01
 
-November 12: veo-3.0-fast-generate-preview veo-3.0-generate-preview</description>
-      <pubDate>Fri, 05 Dec 2025 16:52:41 GMT</pubDate>
-      <guid isPermaLink="false">Google-veo-3.0-fast-generate-preview-2025-11-12-e3b0c442</guid>
+Gemini deprecations table: Gemini 2.5 Flash models. Release date: 2025-09-25. Shutdown date: 2026-02-17. Recommended replacement: gemini-3-flash-preview.</description>
+      <pubDate>Fri, 01 May 2026 21:43:36 GMT</pubDate>
+      <guid isPermaLink="false">Google-gemini-2.5-flash-preview-09-25-2026-02-17-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Google: gemini-2.0-flash</title>
+      <link>https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.0-models</link>
+      <description>Provider: Google
+Model ID: gemini-2.0-flash
+Deprecation Date: 2026-06-01
+Shutdown Date: 2026-06-01
+First Observed: 2026-02-20
+Last Observed: 2026-05-01
+
+Gemini deprecations table: Gemini 2.0 models. Release date: 2025-02-05. Shutdown date: 2026-06-01. Recommended replacement: gemini-2.5-flash.</description>
+      <pubDate>Fri, 01 May 2026 21:43:36 GMT</pubDate>
+      <guid isPermaLink="false">Google-gemini-2.0-flash-2026-06-01-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Google: gemini-2.0-flash-001</title>
+      <link>https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.0-models</link>
+      <description>Provider: Google
+Model ID: gemini-2.0-flash-001
+Deprecation Date: 2026-06-01
+Shutdown Date: 2026-06-01
+First Observed: 2026-02-20
+Last Observed: 2026-05-01
+
+Gemini deprecations table: Gemini 2.0 models. Release date: 2025-02-05. Shutdown date: 2026-06-01. Recommended replacement: gemini-2.5-flash.</description>
+      <pubDate>Fri, 01 May 2026 21:43:36 GMT</pubDate>
+      <guid isPermaLink="false">Google-gemini-2.0-flash-001-2026-06-01-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Google: gemini-2.0-flash-lite</title>
+      <link>https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.0-models</link>
+      <description>Provider: Google
+Model ID: gemini-2.0-flash-lite
+Deprecation Date: 2026-06-01
+Shutdown Date: 2026-06-01
+First Observed: 2026-02-20
+Last Observed: 2026-05-01
+
+Gemini deprecations table: Gemini 2.0 models. Release date: 2025-02-25. Shutdown date: 2026-06-01. Recommended replacement: gemini-2.5-flash-lite.</description>
+      <pubDate>Fri, 01 May 2026 21:43:36 GMT</pubDate>
+      <guid isPermaLink="false">Google-gemini-2.0-flash-lite-2026-06-01-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Google: gemini-2.0-flash-lite-001</title>
+      <link>https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.0-models</link>
+      <description>Provider: Google
+Model ID: gemini-2.0-flash-lite-001
+Deprecation Date: 2026-06-01
+Shutdown Date: 2026-06-01
+First Observed: 2026-02-20
+Last Observed: 2026-05-01
+
+Gemini deprecations table: Gemini 2.0 models. Release date: 2025-02-25. Shutdown date: 2026-06-01. Recommended replacement: gemini-2.5-flash-lite.</description>
+      <pubDate>Fri, 01 May 2026 21:43:36 GMT</pubDate>
+      <guid isPermaLink="false">Google-gemini-2.0-flash-lite-001-2026-06-01-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Google: gemini-2.0-flash-preview-image-generation</title>
+      <link>https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.0-models</link>
+      <description>Provider: Google
+Model ID: gemini-2.0-flash-preview-image-generation
+Deprecation Date: 2025-11-14
+Shutdown Date: 2025-11-14
+First Observed: 2025-12-05
+Last Observed: 2026-05-01
+
+Gemini deprecations table: Gemini 2.0 models. Release date: 2025-05-07. Shutdown date: 2025-11-14. Recommended replacement: gemini-2.5-flash-image.</description>
+      <pubDate>Fri, 01 May 2026 21:43:36 GMT</pubDate>
+      <guid isPermaLink="false">Google-gemini-2.0-flash-preview-image-generation-2025-11-14-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Google: gemini-2.0-flash-lite-preview</title>
+      <link>https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.0-models</link>
+      <description>Provider: Google
+Model ID: gemini-2.0-flash-lite-preview
+Deprecation Date: 2025-12-09
+Shutdown Date: 2025-12-09
+First Observed: 2026-03-26
+Last Observed: 2026-05-01
+
+Gemini deprecations table: Gemini 2.0 models. Release date: 2025-02-05. Shutdown date: 2025-12-09. Recommended replacement: gemini-2.5-flash-lite.</description>
+      <pubDate>Fri, 01 May 2026 21:43:36 GMT</pubDate>
+      <guid isPermaLink="false">Google-gemini-2.0-flash-lite-preview-2025-12-09-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Google: gemini-2.0-flash-lite-preview-02-05</title>
+      <link>https://ai.google.dev/gemini-api/docs/deprecations#gemini-2.0-models</link>
+      <description>Provider: Google
+Model ID: gemini-2.0-flash-lite-preview-02-05
+Deprecation Date: 2025-12-09
+Shutdown Date: 2025-12-09
+First Observed: 2025-12-05
+Last Observed: 2026-05-01
+
+Gemini deprecations table: Gemini 2.0 models. Release date: 2025-02-05. Shutdown date: 2025-12-09. Recommended replacement: gemini-2.5-flash-lite.</description>
+      <pubDate>Fri, 01 May 2026 21:43:36 GMT</pubDate>
+      <guid isPermaLink="false">Google-gemini-2.0-flash-lite-preview-02-05-2025-12-09-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Google: gemini-2.0-flash-live-001</title>
+      <link>https://ai.google.dev/gemini-api/docs/deprecations#live-api-models</link>
+      <description>Provider: Google
+Model ID: gemini-2.0-flash-live-001
+Deprecation Date: 2025-12-09
+Shutdown Date: 2025-12-09
+First Observed: 2025-12-05
+Last Observed: 2026-05-01
+
+Gemini deprecations table: Live API models. Release date: 2025-04-09. Shutdown date: 2025-12-09. Recommended replacement: gemini-3.1-flash-live-preview.</description>
+      <pubDate>Fri, 01 May 2026 21:43:36 GMT</pubDate>
+      <guid isPermaLink="false">Google-gemini-2.0-flash-live-001-2025-12-09-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Google: gemini-live-2.5-flash-preview</title>
+      <link>https://ai.google.dev/gemini-api/docs/deprecations#live-api-models</link>
+      <description>Provider: Google
+Model ID: gemini-live-2.5-flash-preview
+Deprecation Date: 2025-12-09
+Shutdown Date: 2025-12-09
+First Observed: 2025-12-05
+Last Observed: 2026-05-01
+
+Gemini deprecations table: Live API models. Release date: 2025-06-17. Shutdown date: 2025-12-09. Recommended replacement: gemini-3.1-flash-live-preview.</description>
+      <pubDate>Fri, 01 May 2026 21:43:36 GMT</pubDate>
+      <guid isPermaLink="false">Google-gemini-live-2.5-flash-preview-2025-12-09-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Google: gemini-embedding-001</title>
+      <link>https://ai.google.dev/gemini-api/docs/deprecations#embedding-models</link>
+      <description>Provider: Google
+Model ID: gemini-embedding-001
+Deprecation Date: 2026-07-14
+Shutdown Date: 2026-07-14
+First Observed: 2025-12-05
+Last Observed: 2026-05-01
+
+Gemini deprecations table: Embedding models. Release date: 2025-07-14. Shutdown date: 2026-07-14.</description>
+      <pubDate>Fri, 01 May 2026 21:43:36 GMT</pubDate>
+      <guid isPermaLink="false">Google-gemini-embedding-001-2026-07-14-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Google: text-embedding-004</title>
+      <link>https://ai.google.dev/gemini-api/docs/deprecations#embedding-models</link>
+      <description>Provider: Google
+Model ID: text-embedding-004
+Deprecation Date: 2026-01-14
+Shutdown Date: 2026-01-14
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
+
+Gemini deprecations table: Embedding models. Release date: 2024-04-09. Shutdown date: 2026-01-14. Recommended replacement: gemini-embedding-001.</description>
+      <pubDate>Fri, 01 May 2026 21:43:36 GMT</pubDate>
+      <guid isPermaLink="false">Google-text-embedding-004-2026-01-14-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Google: embedding-001</title>
+      <link>https://ai.google.dev/gemini-api/docs/deprecations#embedding-models</link>
+      <description>Provider: Google
+Model ID: embedding-001
+Deprecation Date: 2025-10-30
+Shutdown Date: 2025-10-30
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
+
+Gemini deprecations table: Embedding models. Release date: 2024-04-09. Shutdown date: 2025-10-30. Recommended replacement: gemini-embedding-001.</description>
+      <pubDate>Fri, 01 May 2026 21:43:36 GMT</pubDate>
+      <guid isPermaLink="false">Google-embedding-001-2025-10-30-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Google: embedding-gecko-001</title>
+      <link>https://ai.google.dev/gemini-api/docs/deprecations#embedding-models</link>
+      <description>Provider: Google
+Model ID: embedding-gecko-001
+Deprecation Date: 2025-10-30
+Shutdown Date: 2025-10-30
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
+
+Gemini deprecations table: Embedding models. Shutdown date: 2025-10-30. Recommended replacement: gemini-embedding-001.</description>
+      <pubDate>Fri, 01 May 2026 21:43:36 GMT</pubDate>
+      <guid isPermaLink="false">Google-embedding-gecko-001-2025-10-30-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Google: gemini-embedding-exp</title>
+      <link>https://ai.google.dev/gemini-api/docs/deprecations#embedding-models</link>
+      <description>Provider: Google
+Model ID: gemini-embedding-exp
+Deprecation Date: 2025-10-30
+Shutdown Date: 2025-10-30
+First Observed: 2025-12-05
+Last Observed: 2026-05-01
+
+Gemini deprecations table: Embedding models. Shutdown date: 2025-10-30. Recommended replacement: gemini-embedding-001.</description>
+      <pubDate>Fri, 01 May 2026 21:43:36 GMT</pubDate>
+      <guid isPermaLink="false">Google-gemini-embedding-exp-2025-10-30-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Google: gemini-embedding-exp-03-07</title>
+      <link>https://ai.google.dev/gemini-api/docs/deprecations#embedding-models</link>
+      <description>Provider: Google
+Model ID: gemini-embedding-exp-03-07
+Deprecation Date: 2025-10-30
+Shutdown Date: 2025-10-30
+First Observed: 2025-12-05
+Last Observed: 2026-05-01
+
+Gemini deprecations table: Embedding models. Shutdown date: 2025-10-30. Recommended replacement: gemini-embedding-001.</description>
+      <pubDate>Fri, 01 May 2026 21:43:36 GMT</pubDate>
+      <guid isPermaLink="false">Google-gemini-embedding-exp-03-07-2025-10-30-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Google: imagen-4.0-generate-001</title>
+      <link>https://ai.google.dev/gemini-api/docs/deprecations#imagen-models</link>
+      <description>Provider: Google
+Model ID: imagen-4.0-generate-001
+Deprecation Date: 2026-06-24
+Shutdown Date: 2026-06-24
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
+
+Gemini deprecations table: Imagen models. Release date: 2025-06-24. Shutdown date: 2026-06-24. Recommended replacement: gemini-3-pro-image-preview, gemini-2.5-flash-image.</description>
+      <pubDate>Fri, 01 May 2026 21:43:36 GMT</pubDate>
+      <guid isPermaLink="false">Google-imagen-4.0-generate-001-2026-06-24-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Google: imagen-4.0-ultra-generate-001</title>
+      <link>https://ai.google.dev/gemini-api/docs/deprecations#imagen-models</link>
+      <description>Provider: Google
+Model ID: imagen-4.0-ultra-generate-001
+Deprecation Date: 2026-06-24
+Shutdown Date: 2026-06-24
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
+
+Gemini deprecations table: Imagen models. Release date: 2025-06-24. Shutdown date: 2026-06-24. Recommended replacement: gemini-3-pro-image-preview, gemini-2.5-flash-image.</description>
+      <pubDate>Fri, 01 May 2026 21:43:36 GMT</pubDate>
+      <guid isPermaLink="false">Google-imagen-4.0-ultra-generate-001-2026-06-24-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Google: imagen-4.0-fast-generate-001</title>
+      <link>https://ai.google.dev/gemini-api/docs/deprecations#imagen-models</link>
+      <description>Provider: Google
+Model ID: imagen-4.0-fast-generate-001
+Deprecation Date: 2026-06-24
+Shutdown Date: 2026-06-24
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
+
+Gemini deprecations table: Imagen models. Release date: 2025-06-24. Shutdown date: 2026-06-24. Recommended replacement: gemini-3-pro-image-preview, gemini-2.5-flash-image.</description>
+      <pubDate>Fri, 01 May 2026 21:43:36 GMT</pubDate>
+      <guid isPermaLink="false">Google-imagen-4.0-fast-generate-001-2026-06-24-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Google: imagen-3.0-generate-002</title>
+      <link>https://ai.google.dev/gemini-api/docs/deprecations#imagen-models</link>
+      <description>Provider: Google
+Model ID: imagen-3.0-generate-002
+Deprecation Date: 2025-11-10
+Shutdown Date: 2025-11-10
+First Observed: 2025-12-05
+Last Observed: 2026-05-01
+
+Gemini deprecations table: Imagen models. Release date: 2025-02-06. Shutdown date: 2025-11-10. Recommended replacement: imagen-4.0-generate-001.</description>
+      <pubDate>Fri, 01 May 2026 21:39:32 GMT</pubDate>
+      <guid isPermaLink="false">Google-imagen-3.0-generate-002-2025-11-10-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Google: imagen-4.0-generate-preview-06-06</title>
+      <link>https://ai.google.dev/gemini-api/docs/deprecations#imagen-models</link>
+      <description>Provider: Google
+Model ID: imagen-4.0-generate-preview-06-06
+Deprecation Date: 2026-02-17
+Shutdown Date: 2026-02-17
+First Observed: 2026-01-16
+Last Observed: 2026-05-01
+
+Gemini deprecations table: Imagen models. Release date: 2025-06-24. Shutdown date: 2026-02-17. Recommended replacement: imagen-4.0-generate-001.</description>
+      <pubDate>Fri, 01 May 2026 21:43:36 GMT</pubDate>
+      <guid isPermaLink="false">Google-imagen-4.0-generate-preview-06-06-2026-02-17-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Google: imagen-4.0-ultra-generate-preview-06-06</title>
+      <link>https://ai.google.dev/gemini-api/docs/deprecations#imagen-models</link>
+      <description>Provider: Google
+Model ID: imagen-4.0-ultra-generate-preview-06-06
+Deprecation Date: 2026-02-17
+Shutdown Date: 2026-02-17
+First Observed: 2026-01-16
+Last Observed: 2026-05-01
+
+Gemini deprecations table: Imagen models. Release date: 2025-06-24. Shutdown date: 2026-02-17. Recommended replacement: imagen-4.0-ultra-generate-001.</description>
+      <pubDate>Fri, 01 May 2026 21:43:36 GMT</pubDate>
+      <guid isPermaLink="false">Google-imagen-4.0-ultra-generate-preview-06-06-2026-02-17-e3b0c442</guid>
     </item>
     <item>
       <title>Google: veo-3.0-generate-preview</title>
-      <link>https://ai.google.dev/gemini-api/docs/changelog#20251111</link>
+      <link>https://ai.google.dev/gemini-api/docs/deprecations#veo-models</link>
       <description>Provider: Google
 Model ID: veo-3.0-generate-preview
-Deprecation Date: 2025-11-11
+Deprecation Date: 2025-11-12
 Shutdown Date: 2025-11-12
 First Observed: 2025-12-05
-Last Observed: 2025-12-05
+Last Observed: 2026-05-01
 
-November 12: veo-3.0-fast-generate-preview veo-3.0-generate-preview</description>
-      <pubDate>Fri, 05 Dec 2025 16:52:41 GMT</pubDate>
+Gemini deprecations table: Veo models. Release date: 2025-07-31. Shutdown date: 2025-11-12. Recommended replacement: veo-3.1-generate-preview.</description>
+      <pubDate>Fri, 01 May 2026 21:43:36 GMT</pubDate>
       <guid isPermaLink="false">Google-veo-3.0-generate-preview-2025-11-12-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Google: veo-3.0-fast-generate-preview</title>
+      <link>https://ai.google.dev/gemini-api/docs/deprecations#veo-models</link>
+      <description>Provider: Google
+Model ID: veo-3.0-fast-generate-preview
+Deprecation Date: 2025-11-12
+Shutdown Date: 2025-11-12
+First Observed: 2025-12-05
+Last Observed: 2026-05-01
+
+Gemini deprecations table: Veo models. Release date: 2025-07-31. Shutdown date: 2025-11-12. Recommended replacement: veo-3.1-fast-generate-preview.</description>
+      <pubDate>Fri, 01 May 2026 21:43:36 GMT</pubDate>
+      <guid isPermaLink="false">Google-veo-3.0-fast-generate-preview-2025-11-12-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Google: gemini-robotics-er-1.5-preview</title>
+      <link>https://ai.google.dev/gemini-api/docs/deprecations#robotics-models</link>
+      <description>Provider: Google
+Model ID: gemini-robotics-er-1.5-preview
+Deprecation Date: 2026-04-30
+Shutdown Date: 2026-04-30
+First Observed: 2026-04-15
+Last Observed: 2026-05-01
+
+Gemini deprecations table: Robotics models. Release date: 2025-09-25. Shutdown date: 2026-04-30. Recommended replacement: gemini-robotics-er-1.6-preview.</description>
+      <pubDate>Fri, 01 May 2026 21:43:36 GMT</pubDate>
+      <guid isPermaLink="false">Google-gemini-robotics-er-1.5-preview-2026-04-30-e3b0c442</guid>
     </item>
     <item>
       <title>Google: gemini-2.0-flash-exp-image-generation</title>
@@ -1949,38 +2458,13 @@ November 12: veo-3.0-fast-generate-preview veo-3.0-generate-preview</description
       <description>Provider: Google
 Model ID: gemini-2.0-flash-exp-image-generation
 Deprecation Date: 2025-11-11
-First Observed: 2025-12-05
-Last Observed: 2025-12-05
+Shutdown Date: 2025-11-14
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
 
-gemini-2.0-flash-exp-image-generation</description>
-      <pubDate>Fri, 05 Dec 2025 16:52:41 GMT</pubDate>
-      <guid isPermaLink="false">Google-gemini-2.0-flash-exp-image-generation-e3b0c442</guid>
-    </item>
-    <item>
-      <title>Google: gemini-2.0-flash-preview-image-generation</title>
-      <link>https://ai.google.dev/gemini-api/docs/changelog#20251111</link>
-      <description>Provider: Google
-Model ID: gemini-2.0-flash-preview-image-generation
-Deprecation Date: 2025-11-11
-First Observed: 2025-12-05
-Last Observed: 2025-12-05
-
-gemini-2.0-flash-preview-image-generation</description>
-      <pubDate>Fri, 05 Dec 2025 16:52:41 GMT</pubDate>
-      <guid isPermaLink="false">Google-gemini-2.0-flash-preview-image-generation-e3b0c442</guid>
-    </item>
-    <item>
-      <title>Google: imagen-3.0-generate-002</title>
-      <link>https://ai.google.dev/gemini-api/docs/changelog#20251110</link>
-      <description>Provider: Google
-Model ID: imagen-3.0-generate-002
-Deprecation Date: 2025-11-10
-First Observed: 2025-12-05
-Last Observed: 2025-12-05
-
-The following model is shut down: imagen-3.0-generate-002 Use Imagen 4 instead. Refer to the Gemini deprecations table for more details.</description>
-      <pubDate>Fri, 05 Dec 2025 16:52:41 GMT</pubDate>
-      <guid isPermaLink="false">Google-imagen-3.0-generate-002-e3b0c442</guid>
+Deprecation announcement: The following models will be shut down: November 12: veo-3.0-fast-generate-preview veo-3.0-generate-preview November 14: gemini-2.0-flash-exp-image-generation gemini-2.0-flash-preview-image-generation</description>
+      <pubDate>Fri, 01 May 2026 21:41:37 GMT</pubDate>
+      <guid isPermaLink="false">Google-gemini-2.0-flash-exp-image-generation-2025-11-14-e3b0c442</guid>
     </item>
     <item>
       <title>Google: gemini-2.5-flash-lite-preview-06-17</title>
@@ -1988,25 +2472,13 @@ The following model is shut down: imagen-3.0-generate-002 Use Imagen 4 instead. 
       <description>Provider: Google
 Model ID: gemini-2.5-flash-lite-preview-06-17
 Deprecation Date: 2025-11-04
-First Observed: 2025-12-05
-Last Observed: 2025-12-05
+Shutdown Date: 2025-11-18
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
 
-gemini-2.5-flash-lite-preview-06-17</description>
-      <pubDate>Fri, 05 Dec 2025 16:52:41 GMT</pubDate>
-      <guid isPermaLink="false">Google-gemini-2.5-flash-lite-preview-06-17-e3b0c442</guid>
-    </item>
-    <item>
-      <title>Google: gemini-2.5-flash-preview-05-20</title>
-      <link>https://ai.google.dev/gemini-api/docs/changelog#20251104</link>
-      <description>Provider: Google
-Model ID: gemini-2.5-flash-preview-05-20
-Deprecation Date: 2025-11-04
-First Observed: 2025-12-05
-Last Observed: 2025-12-05
-
-gemini-2.5-flash-preview-05-20</description>
-      <pubDate>Fri, 05 Dec 2025 16:52:41 GMT</pubDate>
-      <guid isPermaLink="false">Google-gemini-2.5-flash-preview-05-20-e3b0c442</guid>
+Deprecation announcement: The following models will be shut down: November 18th: gemini-2.5-flash-lite-preview-06-17 gemini-2.5-flash-preview-05-20 December 2nd: gemini-2.0-flash-thinking-exp gemini-2.0-flash-thinking-exp-01-21 gemini-2.0-flash-thinking-exp-1219 gemini-2.5-pro-preview-03-25 gemini-2.5-pro-preview-05-06 gemini-2.5-pro-preview-06-05 December 9th: gemini-2.0-flash-lite-preview gemini-2.0-flash-lite-preview-02-05 gemini-2.0-flash-exp gemini-2.0-pro-exp gemini-2.0-pro-exp-02-05</description>
+      <pubDate>Fri, 01 May 2026 21:41:37 GMT</pubDate>
+      <guid isPermaLink="false">Google-gemini-2.5-flash-lite-preview-06-17-2025-11-18-e3b0c442</guid>
     </item>
     <item>
       <title>Google: gemini-2.0-flash-thinking-exp</title>
@@ -2015,11 +2487,11 @@ gemini-2.5-flash-preview-05-20</description>
 Model ID: gemini-2.0-flash-thinking-exp
 Deprecation Date: 2025-11-04
 Shutdown Date: 2025-12-02
-First Observed: 2025-12-05
-Last Observed: 2025-12-05
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
 
-December 2nd: gemini-2.0-flash-thinking-exp gemini-2.0-flash-thinking-exp-01-21 gemini-2.0-flash-thinking-exp-1219 gemini-2.5-pro-preview-03-25 gemini-2.5-pro-preview-05-06 gemini-2.5-pro-preview-06-05</description>
-      <pubDate>Fri, 05 Dec 2025 16:52:41 GMT</pubDate>
+Deprecation announcement: The following models will be shut down: November 18th: gemini-2.5-flash-lite-preview-06-17 gemini-2.5-flash-preview-05-20 December 2nd: gemini-2.0-flash-thinking-exp gemini-2.0-flash-thinking-exp-01-21 gemini-2.0-flash-thinking-exp-1219 gemini-2.5-pro-preview-03-25 gemini-2.5-pro-preview-05-06 gemini-2.5-pro-preview-06-05 December 9th: gemini-2.0-flash-lite-preview gemini-2.0-flash-lite-preview-02-05 gemini-2.0-flash-exp gemini-2.0-pro-exp gemini-2.0-pro-exp-02-05</description>
+      <pubDate>Fri, 01 May 2026 21:41:37 GMT</pubDate>
       <guid isPermaLink="false">Google-gemini-2.0-flash-thinking-exp-2025-12-02-e3b0c442</guid>
     </item>
     <item>
@@ -2028,12 +2500,13 @@ December 2nd: gemini-2.0-flash-thinking-exp gemini-2.0-flash-thinking-exp-01-21 
       <description>Provider: Google
 Model ID: gemini-2.0-flash-thinking-exp-01-21
 Deprecation Date: 2025-11-04
-First Observed: 2025-12-05
-Last Observed: 2025-12-05
+Shutdown Date: 2025-12-02
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
 
-gemini-2.0-flash-thinking-exp-01-21</description>
-      <pubDate>Fri, 05 Dec 2025 16:52:41 GMT</pubDate>
-      <guid isPermaLink="false">Google-gemini-2.0-flash-thinking-exp-01-21-e3b0c442</guid>
+Deprecation announcement: The following models will be shut down: November 18th: gemini-2.5-flash-lite-preview-06-17 gemini-2.5-flash-preview-05-20 December 2nd: gemini-2.0-flash-thinking-exp gemini-2.0-flash-thinking-exp-01-21 gemini-2.0-flash-thinking-exp-1219 gemini-2.5-pro-preview-03-25 gemini-2.5-pro-preview-05-06 gemini-2.5-pro-preview-06-05 December 9th: gemini-2.0-flash-lite-preview gemini-2.0-flash-lite-preview-02-05 gemini-2.0-flash-exp gemini-2.0-pro-exp gemini-2.0-pro-exp-02-05</description>
+      <pubDate>Fri, 01 May 2026 21:41:37 GMT</pubDate>
+      <guid isPermaLink="false">Google-gemini-2.0-flash-thinking-exp-01-21-2025-12-02-e3b0c442</guid>
     </item>
     <item>
       <title>Google: gemini-2.0-flash-thinking-exp-1219</title>
@@ -2041,81 +2514,13 @@ gemini-2.0-flash-thinking-exp-01-21</description>
       <description>Provider: Google
 Model ID: gemini-2.0-flash-thinking-exp-1219
 Deprecation Date: 2025-11-04
-First Observed: 2025-12-05
-Last Observed: 2025-12-05
-
-gemini-2.0-flash-thinking-exp-1219</description>
-      <pubDate>Fri, 05 Dec 2025 16:52:41 GMT</pubDate>
-      <guid isPermaLink="false">Google-gemini-2.0-flash-thinking-exp-1219-e3b0c442</guid>
-    </item>
-    <item>
-      <title>Google: gemini-2.5-pro-preview-03-25</title>
-      <link>https://ai.google.dev/gemini-api/docs/changelog#20251104</link>
-      <description>Provider: Google
-Model ID: gemini-2.5-pro-preview-03-25
-Deprecation Date: 2025-11-04
 Shutdown Date: 2025-12-02
-First Observed: 2025-12-05
-Last Observed: 2025-12-05
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
 
-December 2nd: gemini-2.0-flash-thinking-exp gemini-2.0-flash-thinking-exp-01-21 gemini-2.0-flash-thinking-exp-1219 gemini-2.5-pro-preview-03-25 gemini-2.5-pro-preview-05-06 gemini-2.5-pro-preview-06-05</description>
-      <pubDate>Fri, 05 Dec 2025 16:52:41 GMT</pubDate>
-      <guid isPermaLink="false">Google-gemini-2.5-pro-preview-03-25-2025-12-02-e3b0c442</guid>
-    </item>
-    <item>
-      <title>Google: gemini-2.5-pro-preview-05-06</title>
-      <link>https://ai.google.dev/gemini-api/docs/changelog#20251104</link>
-      <description>Provider: Google
-Model ID: gemini-2.5-pro-preview-05-06
-Deprecation Date: 2025-11-04
-Shutdown Date: 2025-12-02
-First Observed: 2025-12-05
-Last Observed: 2025-12-05
-
-December 2nd: gemini-2.0-flash-thinking-exp gemini-2.0-flash-thinking-exp-01-21 gemini-2.0-flash-thinking-exp-1219 gemini-2.5-pro-preview-03-25 gemini-2.5-pro-preview-05-06 gemini-2.5-pro-preview-06-05</description>
-      <pubDate>Fri, 05 Dec 2025 16:52:41 GMT</pubDate>
-      <guid isPermaLink="false">Google-gemini-2.5-pro-preview-05-06-2025-12-02-e3b0c442</guid>
-    </item>
-    <item>
-      <title>Google: gemini-2.5-pro-preview-06-05</title>
-      <link>https://ai.google.dev/gemini-api/docs/changelog#20251104</link>
-      <description>Provider: Google
-Model ID: gemini-2.5-pro-preview-06-05
-Deprecation Date: 2025-11-04
-Shutdown Date: 2025-12-02
-First Observed: 2025-12-05
-Last Observed: 2025-12-05
-
-December 2nd: gemini-2.0-flash-thinking-exp gemini-2.0-flash-thinking-exp-01-21 gemini-2.0-flash-thinking-exp-1219 gemini-2.5-pro-preview-03-25 gemini-2.5-pro-preview-05-06 gemini-2.5-pro-preview-06-05</description>
-      <pubDate>Fri, 05 Dec 2025 16:52:41 GMT</pubDate>
-      <guid isPermaLink="false">Google-gemini-2.5-pro-preview-06-05-2025-12-02-e3b0c442</guid>
-    </item>
-    <item>
-      <title>Google: gemini-2.0-flash-lite-preview</title>
-      <link>https://ai.google.dev/gemini-api/docs/changelog#20251104</link>
-      <description>Provider: Google
-Model ID: gemini-2.0-flash-lite-preview
-Deprecation Date: 2025-11-04
-Shutdown Date: 2025-12-09
-First Observed: 2026-03-26
-Last Observed: 2026-03-26
-
-December 9th: gemini-2.0-flash-lite-preview gemini-2.0-flash-lite-preview-02-05 gemini-2.0-flash-exp gemini-2.0-pro-exp gemini-2.0-pro-exp-02-05</description>
-      <pubDate>Thu, 26 Mar 2026 13:07:23 GMT</pubDate>
-      <guid isPermaLink="false">Google-gemini-2.0-flash-lite-preview-2025-12-09-e3b0c442</guid>
-    </item>
-    <item>
-      <title>Google: gemini-2.0-flash-lite-preview-02-05</title>
-      <link>https://ai.google.dev/gemini-api/docs/changelog#20251104</link>
-      <description>Provider: Google
-Model ID: gemini-2.0-flash-lite-preview-02-05
-Deprecation Date: 2025-11-04
-First Observed: 2025-12-05
-Last Observed: 2025-12-05
-
-gemini-2.0-flash-lite-preview-02-05</description>
-      <pubDate>Fri, 05 Dec 2025 16:52:41 GMT</pubDate>
-      <guid isPermaLink="false">Google-gemini-2.0-flash-lite-preview-02-05-e3b0c442</guid>
+Deprecation announcement: The following models will be shut down: November 18th: gemini-2.5-flash-lite-preview-06-17 gemini-2.5-flash-preview-05-20 December 2nd: gemini-2.0-flash-thinking-exp gemini-2.0-flash-thinking-exp-01-21 gemini-2.0-flash-thinking-exp-1219 gemini-2.5-pro-preview-03-25 gemini-2.5-pro-preview-05-06 gemini-2.5-pro-preview-06-05 December 9th: gemini-2.0-flash-lite-preview gemini-2.0-flash-lite-preview-02-05 gemini-2.0-flash-exp gemini-2.0-pro-exp gemini-2.0-pro-exp-02-05</description>
+      <pubDate>Fri, 01 May 2026 21:41:37 GMT</pubDate>
+      <guid isPermaLink="false">Google-gemini-2.0-flash-thinking-exp-1219-2025-12-02-e3b0c442</guid>
     </item>
     <item>
       <title>Google: gemini-2.0-flash-exp</title>
@@ -2124,11 +2529,11 @@ gemini-2.0-flash-lite-preview-02-05</description>
 Model ID: gemini-2.0-flash-exp
 Deprecation Date: 2025-11-04
 Shutdown Date: 2025-12-09
-First Observed: 2026-01-29
-Last Observed: 2026-01-29
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
 
-December 9th: gemini-2.0-flash-lite-preview gemini-2.0-flash-lite-preview-02-05 gemini-2.0-flash-exp gemini-2.0-pro-exp gemini-2.0-pro-exp-02-05</description>
-      <pubDate>Thu, 29 Jan 2026 04:02:00 GMT</pubDate>
+Deprecation announcement: The following models will be shut down: November 18th: gemini-2.5-flash-lite-preview-06-17 gemini-2.5-flash-preview-05-20 December 2nd: gemini-2.0-flash-thinking-exp gemini-2.0-flash-thinking-exp-01-21 gemini-2.0-flash-thinking-exp-1219 gemini-2.5-pro-preview-03-25 gemini-2.5-pro-preview-05-06 gemini-2.5-pro-preview-06-05 December 9th: gemini-2.0-flash-lite-preview gemini-2.0-flash-lite-preview-02-05 gemini-2.0-flash-exp gemini-2.0-pro-exp gemini-2.0-pro-exp-02-05</description>
+      <pubDate>Fri, 01 May 2026 21:41:37 GMT</pubDate>
       <guid isPermaLink="false">Google-gemini-2.0-flash-exp-2025-12-09-e3b0c442</guid>
     </item>
     <item>
@@ -2138,11 +2543,11 @@ December 9th: gemini-2.0-flash-lite-preview gemini-2.0-flash-lite-preview-02-05 
 Model ID: gemini-2.0-pro-exp
 Deprecation Date: 2025-11-04
 Shutdown Date: 2025-12-09
-First Observed: 2026-01-29
-Last Observed: 2026-01-29
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
 
-December 9th: gemini-2.0-flash-lite-preview gemini-2.0-flash-lite-preview-02-05 gemini-2.0-flash-exp gemini-2.0-pro-exp gemini-2.0-pro-exp-02-05</description>
-      <pubDate>Thu, 29 Jan 2026 04:02:00 GMT</pubDate>
+Deprecation announcement: The following models will be shut down: November 18th: gemini-2.5-flash-lite-preview-06-17 gemini-2.5-flash-preview-05-20 December 2nd: gemini-2.0-flash-thinking-exp gemini-2.0-flash-thinking-exp-01-21 gemini-2.0-flash-thinking-exp-1219 gemini-2.5-pro-preview-03-25 gemini-2.5-pro-preview-05-06 gemini-2.5-pro-preview-06-05 December 9th: gemini-2.0-flash-lite-preview gemini-2.0-flash-lite-preview-02-05 gemini-2.0-flash-exp gemini-2.0-pro-exp gemini-2.0-pro-exp-02-05</description>
+      <pubDate>Fri, 01 May 2026 21:41:37 GMT</pubDate>
       <guid isPermaLink="false">Google-gemini-2.0-pro-exp-2025-12-09-e3b0c442</guid>
     </item>
     <item>
@@ -2152,11 +2557,11 @@ December 9th: gemini-2.0-flash-lite-preview gemini-2.0-flash-lite-preview-02-05 
 Model ID: gemini-2.0-pro-exp-02-05
 Deprecation Date: 2025-11-04
 Shutdown Date: 2025-12-09
-First Observed: 2026-01-29
-Last Observed: 2026-01-29
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
 
-December 9th: gemini-2.0-flash-lite-preview gemini-2.0-flash-lite-preview-02-05 gemini-2.0-flash-exp gemini-2.0-pro-exp gemini-2.0-pro-exp-02-05</description>
-      <pubDate>Thu, 29 Jan 2026 04:02:00 GMT</pubDate>
+Deprecation announcement: The following models will be shut down: November 18th: gemini-2.5-flash-lite-preview-06-17 gemini-2.5-flash-preview-05-20 December 2nd: gemini-2.0-flash-thinking-exp gemini-2.0-flash-thinking-exp-01-21 gemini-2.0-flash-thinking-exp-1219 gemini-2.5-pro-preview-03-25 gemini-2.5-pro-preview-05-06 gemini-2.5-pro-preview-06-05 December 9th: gemini-2.0-flash-lite-preview gemini-2.0-flash-lite-preview-02-05 gemini-2.0-flash-exp gemini-2.0-pro-exp gemini-2.0-pro-exp-02-05</description>
+      <pubDate>Fri, 01 May 2026 21:41:37 GMT</pubDate>
       <guid isPermaLink="false">Google-gemini-2.0-pro-exp-02-05-2025-12-09-e3b0c442</guid>
     </item>
     <item>
@@ -2165,12 +2570,13 @@ December 9th: gemini-2.0-flash-lite-preview gemini-2.0-flash-lite-preview-02-05 
       <description>Provider: Google
 Model ID: gemini-2.5-flash-preview-native-audio-dialog
 Deprecation Date: 2025-10-20
-First Observed: 2025-12-05
-Last Observed: 2025-12-05
+Shutdown Date: 2025-10-20
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
 
-gemini-2.5-flash-preview-native-audio-dialog</description>
-      <pubDate>Fri, 05 Dec 2025 16:52:41 GMT</pubDate>
-      <guid isPermaLink="false">Google-gemini-2.5-flash-preview-native-audio-dialog-e3b0c442</guid>
+The following Gemini Live API models are now shut down: gemini-2.5-flash-preview-native-audio-dialog gemini-2.5-flash-exp-native-audio-thinking-dialog You can use gemini-2.5-flash-native-audio-preview-09-2025 instead.</description>
+      <pubDate>Fri, 01 May 2026 21:41:37 GMT</pubDate>
+      <guid isPermaLink="false">Google-gemini-2.5-flash-preview-native-audio-dialog-2025-10-20-e3b0c442</guid>
     </item>
     <item>
       <title>Google: gemini-2.5-flash-exp-native-audio-thinking-dialog</title>
@@ -2178,119 +2584,69 @@ gemini-2.5-flash-preview-native-audio-dialog</description>
       <description>Provider: Google
 Model ID: gemini-2.5-flash-exp-native-audio-thinking-dialog
 Deprecation Date: 2025-10-20
-First Observed: 2025-12-05
-Last Observed: 2025-12-05
+Shutdown Date: 2025-10-20
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
 
-gemini-2.5-flash-exp-native-audio-thinking-dialog</description>
-      <pubDate>Fri, 05 Dec 2025 16:52:41 GMT</pubDate>
-      <guid isPermaLink="false">Google-gemini-2.5-flash-exp-native-audio-thinking-dialog-e3b0c442</guid>
+The following Gemini Live API models are now shut down: gemini-2.5-flash-preview-native-audio-dialog gemini-2.5-flash-exp-native-audio-thinking-dialog You can use gemini-2.5-flash-native-audio-preview-09-2025 instead.</description>
+      <pubDate>Fri, 01 May 2026 21:41:37 GMT</pubDate>
+      <guid isPermaLink="false">Google-gemini-2.5-flash-exp-native-audio-thinking-dialog-2025-10-20-e3b0c442</guid>
     </item>
     <item>
-      <title>Google: gemini-2.5-flash-native-audio-preview-09-2025</title>
-      <link>https://ai.google.dev/gemini-api/docs/changelog#20251020</link>
+      <title>Google: gemini-1.5-pro</title>
+      <link>https://ai.google.dev/gemini-api/docs/changelog#20250929</link>
       <description>Provider: Google
-Model ID: gemini-2.5-flash-native-audio-preview-09-2025
-Deprecation Date: 2025-10-20
-First Observed: 2025-12-05
-Last Observed: 2025-12-05
+Model ID: gemini-1.5-pro
+Deprecation Date: 2025-09-29
+Shutdown Date: 2025-09-29
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
 
-You can use gemini-2.5-flash-native-audio-preview-09-2025 instead.</description>
-      <pubDate>Fri, 05 Dec 2025 16:52:41 GMT</pubDate>
-      <guid isPermaLink="false">Google-gemini-2.5-flash-native-audio-preview-09-2025-e3b0c442</guid>
+The following Gemini 1.5 models are now shut down: gemini-1.5-pro gemini-1.5-flash-8b gemini-1.5-flash</description>
+      <pubDate>Fri, 01 May 2026 21:41:37 GMT</pubDate>
+      <guid isPermaLink="false">Google-gemini-1.5-pro-2025-09-29-e3b0c442</guid>
     </item>
     <item>
-      <title>Google: gemini-2.0-flash-live-001</title>
-      <link>https://ai.google.dev/gemini-api/docs/changelog#20251020</link>
+      <title>Google: gemini-1.5-flash-8b</title>
+      <link>https://ai.google.dev/gemini-api/docs/changelog#20250929</link>
       <description>Provider: Google
-Model ID: gemini-2.0-flash-live-001
-Deprecation Date: 2025-10-20
-First Observed: 2025-12-05
-Last Observed: 2025-12-05
+Model ID: gemini-1.5-flash-8b
+Deprecation Date: 2025-09-29
+Shutdown Date: 2025-09-29
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
 
-Deprecation announcement: Shut down for gemini-2.0-flash-live-001 and gemini-live-2.5-flash-preview coming December 09, 2025.</description>
-      <pubDate>Fri, 05 Dec 2025 16:52:41 GMT</pubDate>
-      <guid isPermaLink="false">Google-gemini-2.0-flash-live-001-e3b0c442</guid>
+The following Gemini 1.5 models are now shut down: gemini-1.5-pro gemini-1.5-flash-8b gemini-1.5-flash</description>
+      <pubDate>Fri, 01 May 2026 21:41:37 GMT</pubDate>
+      <guid isPermaLink="false">Google-gemini-1.5-flash-8b-2025-09-29-e3b0c442</guid>
     </item>
     <item>
-      <title>Google: gemini-live-2.5-flash-preview</title>
-      <link>https://ai.google.dev/gemini-api/docs/changelog#20251020</link>
+      <title>Google: gemini-1.5-flash</title>
+      <link>https://ai.google.dev/gemini-api/docs/changelog#20250929</link>
       <description>Provider: Google
-Model ID: gemini-live-2.5-flash-preview
-Deprecation Date: 2025-10-20
-First Observed: 2025-12-05
-Last Observed: 2025-12-05
+Model ID: gemini-1.5-flash
+Deprecation Date: 2025-09-29
+Shutdown Date: 2025-09-29
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
 
-Deprecation announcement: Shut down for gemini-2.0-flash-live-001 and gemini-live-2.5-flash-preview coming December 09, 2025.</description>
-      <pubDate>Fri, 05 Dec 2025 16:52:41 GMT</pubDate>
-      <guid isPermaLink="false">Google-gemini-live-2.5-flash-preview-e3b0c442</guid>
+The following Gemini 1.5 models are now shut down: gemini-1.5-pro gemini-1.5-flash-8b gemini-1.5-flash</description>
+      <pubDate>Fri, 01 May 2026 21:41:37 GMT</pubDate>
+      <guid isPermaLink="false">Google-gemini-1.5-flash-2025-09-29-e3b0c442</guid>
     </item>
     <item>
-      <title>Google: gemini-embedding-exp-03-07</title>
-      <link>https://ai.google.dev/gemini-api/docs/changelog#20250916</link>
+      <title>Google: gemini-2.5-pro-exp-03-25</title>
+      <link>https://ai.google.dev/gemini-api/docs/changelog#20250626</link>
       <description>Provider: Google
-Model ID: gemini-embedding-exp-03-07
-Deprecation Date: 2025-09-16
-First Observed: 2025-12-05
-Last Observed: 2025-12-05
+Model ID: gemini-2.5-pro-exp-03-25
+Deprecation Date: 2025-06-26
+Shutdown Date: 2025-06-26
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
 
-gemini-embedding-exp-03-07 ( gemini-embedding-exp )</description>
-      <pubDate>Fri, 05 Dec 2025 16:52:41 GMT</pubDate>
-      <guid isPermaLink="false">Google-gemini-embedding-exp-03-07-e3b0c442</guid>
-    </item>
-    <item>
-      <title>Google: gemini-embedding-exp</title>
-      <link>https://ai.google.dev/gemini-api/docs/changelog#20250916</link>
-      <description>Provider: Google
-Model ID: gemini-embedding-exp
-Deprecation Date: 2025-09-16
-First Observed: 2025-12-05
-Last Observed: 2025-12-05
-
-gemini-embedding-exp-03-07 ( gemini-embedding-exp )</description>
-      <pubDate>Fri, 05 Dec 2025 16:52:41 GMT</pubDate>
-      <guid isPermaLink="false">Google-gemini-embedding-exp-e3b0c442</guid>
-    </item>
-    <item>
-      <title>Google: gemini-embedding-001</title>
-      <link>https://ai.google.dev/gemini-api/docs/changelog#20250714</link>
-      <description>Provider: Google
-Model ID: gemini-embedding-001
-Deprecation Date: 2025-07-14
-First Observed: 2025-12-05
-Last Observed: 2025-12-05
-
-Released gemini-embedding-001 , the stable version of our
-text embedding model. To learn more, see embeddings . The gemini-embedding-exp-03-07 model will be deprecated on August 14, 2025.</description>
-      <pubDate>Fri, 05 Dec 2025 16:52:41 GMT</pubDate>
-      <guid isPermaLink="false">Google-gemini-embedding-001-e3b0c442</guid>
-    </item>
-    <item>
-      <title>Google: gemini-2.5-pro</title>
-      <link>https://ai.google.dev/gemini-api/docs/changelog#20250617</link>
-      <description>Provider: Google
-Model ID: gemini-2.5-pro
-Deprecation Date: 2025-06-17
-First Observed: 2025-12-05
-Last Observed: 2025-12-05
-
-Released gemini-2.5-pro , the stable version of our most powerful
-model, now with adaptive thinking. To learn more, see Gemini 2.5 Pro and Thinking . gemini-2.5-pro-preview-05-06 will be redirected to gemini-2.5-pro on June 26, 2025.</description>
-      <pubDate>Fri, 05 Dec 2025 16:52:41 GMT</pubDate>
-      <guid isPermaLink="false">Google-gemini-2.5-pro-e3b0c442</guid>
-    </item>
-    <item>
-      <title>Google: gemini-2.5-flash</title>
-      <link>https://ai.google.dev/gemini-api/docs/changelog#20250617</link>
-      <description>Provider: Google
-Model ID: gemini-2.5-flash
-Deprecation Date: 2025-06-17
-First Observed: 2025-12-05
-Last Observed: 2025-12-05
-
-Released gemini-2.5-flash , our first stable 2.5 Flash model. To learn
-more, see Gemini 2.5 Flash . gemini-2.5-flash-preview-04-17 will be deprecated on July 15, 2025.</description>
-      <pubDate>Fri, 05 Dec 2025 16:52:41 GMT</pubDate>
-      <guid isPermaLink="false">Google-gemini-2.5-flash-e3b0c442</guid>
+gemini-2.5-pro-exp-03-25 is shut down.</description>
+      <pubDate>Fri, 01 May 2026 21:41:37 GMT</pubDate>
+      <guid isPermaLink="false">Google-gemini-2.5-pro-exp-03-25-2025-06-26-e3b0c442</guid>
     </item>
     <item>
       <title>Google: gemini-2.5-flash-preview-04-17</title>
@@ -2298,28 +2654,13 @@ more, see Gemini 2.5 Flash . gemini-2.5-flash-preview-04-17 will be deprecated o
       <description>Provider: Google
 Model ID: gemini-2.5-flash-preview-04-17
 Deprecation Date: 2025-06-17
-First Observed: 2025-12-05
-Last Observed: 2025-12-05
+Shutdown Date: 2025-07-15
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
 
-Released gemini-2.5-flash , our first stable 2.5 Flash model. To learn
-more, see Gemini 2.5 Flash . gemini-2.5-flash-preview-04-17 will be deprecated on July 15, 2025.</description>
-      <pubDate>Fri, 05 Dec 2025 16:52:41 GMT</pubDate>
-      <guid isPermaLink="false">Google-gemini-2.5-flash-preview-04-17-e3b0c442</guid>
-    </item>
-    <item>
-      <title>Google: gemini-1.5-flash</title>
-      <link>https://ai.google.dev/gemini-api/docs/changelog#20250527</link>
-      <description>Provider: Google
-Model ID: gemini-1.5-flash
-Deprecation Date: 2025-05-27
-First Observed: 2025-12-05
-Last Observed: 2025-12-05
-
-The last available tuning model, Gemini 1.5 Flash 001, has been shut down.
-Tuning is no longer supported on any models.
-SeeFine tuning with the Gemini API.</description>
-      <pubDate>Fri, 05 Dec 2025 16:52:41 GMT</pubDate>
-      <guid isPermaLink="false">Google-gemini-1.5-flash-e3b0c442</guid>
+Released gemini-2.5-flash , our first stable 2.5 Flash model. To learn more, see Gemini 2.5 Flash . gemini-2.5-flash-preview-04-17 will be deprecated on July 15, 2025.</description>
+      <pubDate>Fri, 01 May 2026 21:41:37 GMT</pubDate>
+      <guid isPermaLink="false">Google-gemini-2.5-flash-preview-04-17-2025-07-15-e3b0c442</guid>
     </item>
     <item>
       <title>Google: gemini-1.0-pro</title>
@@ -2327,12 +2668,13 @@ SeeFine tuning with the Gemini API.</description>
       <description>Provider: Google
 Model ID: gemini-1.0-pro
 Deprecation Date: 2025-02-18
-First Observed: 2025-12-05
-Last Observed: 2025-12-05
+Shutdown Date: 2025-02-18
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
 
-Gemini 1.0 Pro is no longer supported. For the list of supported models, seeGemini models.</description>
-      <pubDate>Fri, 05 Dec 2025 16:52:41 GMT</pubDate>
-      <guid isPermaLink="false">Google-gemini-1.0-pro-e3b0c442</guid>
+Gemini 1.0 Pro is no longer supported. For the list of supported models, see Gemini models .</description>
+      <pubDate>Fri, 01 May 2026 21:41:37 GMT</pubDate>
+      <guid isPermaLink="false">Google-gemini-1.0-pro-2025-02-18-e3b0c442</guid>
     </item>
     <item>
       <title>Google: gemini-1.0-pro-vision</title>
@@ -2340,12 +2682,13 @@ Gemini 1.0 Pro is no longer supported. For the list of supported models, seeGemi
       <description>Provider: Google
 Model ID: gemini-1.0-pro-vision
 Deprecation Date: 2024-07-12
-First Observed: 2025-12-05
-Last Observed: 2025-12-05
+Shutdown Date: 2024-07-12
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
 
 Support for Gemini 1.0 Pro Vision removed from Google AI services and tools.</description>
-      <pubDate>Fri, 05 Dec 2025 16:52:41 GMT</pubDate>
-      <guid isPermaLink="false">Google-gemini-1.0-pro-vision-e3b0c442</guid>
+      <pubDate>Fri, 01 May 2026 21:41:37 GMT</pubDate>
+      <guid isPermaLink="false">Google-gemini-1.0-pro-vision-2024-07-12-e3b0c442</guid>
     </item>
     <item>
       <title>Google Vertex: claude-3-haiku</title>
@@ -2793,6 +3136,182 @@ Model ID meta.llama3-2-90b-instruct-v1:0. (Llama 3.2 90B Instruct). entered lega
       <guid isPermaLink="false">AWS_Bedrock-meta.llama3-2-90b-instruct-v10-2026-07-07-e3b0c442</guid>
     </item>
     <item>
+      <title>Cohere: embed-english-v2.0</title>
+      <link>https://docs.cohere.com/docs/deprecations#2026-04-04-embed-v2-0-aya-expanse-8b</link>
+      <description>Provider: Cohere
+Model ID: embed-english-v2.0
+Deprecation Date: 2026-04-04
+Shutdown Date: 2026-04-04
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
+
+Effective April 4th, 2026, the following models will be retired: * `embed-english-v2.0` * `embed-english-light-v2.0` * `embed-multilingual-v2.0` * `c4ai-aya-expanse-8b` * `c4ai-aya-vision-8b` We encourage you to migrate to our latest models, which offer enhanced performance, improved accuracy, and expanded capabilities: * Embedding tasks alternatives: * `embed-english-v3.0` * `embed-multilingual-v3.0` * `embed-v4.0` * Chat tasks alternatives: * `command-r7b-12-2024` * `command-a-03-2025` * `comm...</description>
+      <pubDate>Fri, 01 May 2026 21:39:32 GMT</pubDate>
+      <guid isPermaLink="false">Cohere-embed-english-v2.0-2026-04-04-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Cohere: embed-english-light-v2.0</title>
+      <link>https://docs.cohere.com/docs/deprecations#2026-04-04-embed-v2-0-aya-expanse-8b</link>
+      <description>Provider: Cohere
+Model ID: embed-english-light-v2.0
+Deprecation Date: 2026-04-04
+Shutdown Date: 2026-04-04
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
+
+Effective April 4th, 2026, the following models will be retired: * `embed-english-v2.0` * `embed-english-light-v2.0` * `embed-multilingual-v2.0` * `c4ai-aya-expanse-8b` * `c4ai-aya-vision-8b` We encourage you to migrate to our latest models, which offer enhanced performance, improved accuracy, and expanded capabilities: * Embedding tasks alternatives: * `embed-english-v3.0` * `embed-multilingual-v3.0` * `embed-v4.0` * Chat tasks alternatives: * `command-r7b-12-2024` * `command-a-03-2025` * `comm...</description>
+      <pubDate>Fri, 01 May 2026 21:39:32 GMT</pubDate>
+      <guid isPermaLink="false">Cohere-embed-english-light-v2.0-2026-04-04-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Cohere: embed-multilingual-v2.0</title>
+      <link>https://docs.cohere.com/docs/deprecations#2026-04-04-embed-v2-0-aya-expanse-8b</link>
+      <description>Provider: Cohere
+Model ID: embed-multilingual-v2.0
+Deprecation Date: 2026-04-04
+Shutdown Date: 2026-04-04
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
+
+Effective April 4th, 2026, the following models will be retired: * `embed-english-v2.0` * `embed-english-light-v2.0` * `embed-multilingual-v2.0` * `c4ai-aya-expanse-8b` * `c4ai-aya-vision-8b` We encourage you to migrate to our latest models, which offer enhanced performance, improved accuracy, and expanded capabilities: * Embedding tasks alternatives: * `embed-english-v3.0` * `embed-multilingual-v3.0` * `embed-v4.0` * Chat tasks alternatives: * `command-r7b-12-2024` * `command-a-03-2025` * `comm...</description>
+      <pubDate>Fri, 01 May 2026 21:39:32 GMT</pubDate>
+      <guid isPermaLink="false">Cohere-embed-multilingual-v2.0-2026-04-04-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Cohere: c4ai-aya-expanse-8b</title>
+      <link>https://docs.cohere.com/docs/deprecations#2026-04-04-embed-v2-0-aya-expanse-8b</link>
+      <description>Provider: Cohere
+Model ID: c4ai-aya-expanse-8b
+Deprecation Date: 2026-04-04
+Shutdown Date: 2026-04-04
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
+
+Effective April 4th, 2026, the following models will be retired: * `embed-english-v2.0` * `embed-english-light-v2.0` * `embed-multilingual-v2.0` * `c4ai-aya-expanse-8b` * `c4ai-aya-vision-8b` We encourage you to migrate to our latest models, which offer enhanced performance, improved accuracy, and expanded capabilities: * Embedding tasks alternatives: * `embed-english-v3.0` * `embed-multilingual-v3.0` * `embed-v4.0` * Chat tasks alternatives: * `command-r7b-12-2024` * `command-a-03-2025` * `comm...</description>
+      <pubDate>Fri, 01 May 2026 21:39:32 GMT</pubDate>
+      <guid isPermaLink="false">Cohere-c4ai-aya-expanse-8b-2026-04-04-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Cohere: c4ai-aya-vision-8b</title>
+      <link>https://docs.cohere.com/docs/deprecations#2026-04-04-embed-v2-0-aya-expanse-8b</link>
+      <description>Provider: Cohere
+Model ID: c4ai-aya-vision-8b
+Deprecation Date: 2026-04-04
+Shutdown Date: 2026-04-04
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
+
+Effective April 4th, 2026, the following models will be retired: * `embed-english-v2.0` * `embed-english-light-v2.0` * `embed-multilingual-v2.0` * `c4ai-aya-expanse-8b` * `c4ai-aya-vision-8b` We encourage you to migrate to our latest models, which offer enhanced performance, improved accuracy, and expanded capabilities: * Embedding tasks alternatives: * `embed-english-v3.0` * `embed-multilingual-v3.0` * `embed-v4.0` * Chat tasks alternatives: * `command-r7b-12-2024` * `command-a-03-2025` * `comm...</description>
+      <pubDate>Fri, 01 May 2026 21:39:32 GMT</pubDate>
+      <guid isPermaLink="false">Cohere-c4ai-aya-vision-8b-2026-04-04-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Cohere: command-r-03-2024</title>
+      <link>https://docs.cohere.com/docs/deprecations#2025-09-15-various-older-command-models-a-number-of-endpoints-all-of-fine-tuning</link>
+      <description>Provider: Cohere
+Model ID: command-r-03-2024
+Deprecation Date: 2025-09-15
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
+
+Effective September 15, 2025, the following deprecations will roll out. Deprecated Models: * `command-r-03-2024`  (and the alias `command-r`) * `command-r-plus-04-2024`  (and the alias `command-r-plus`) * `command-light` * `command` * `summarize` (Refer to [the migration guide](https://docs.cohere.com/docs/summarizing-text#migration-from-summarize-to-chat-endpoint) for alternatives). For command model replacements, we recommend you use `command-r-08-2024`, `command-r-plus-08-2024`, or `command-a...</description>
+      <pubDate>Fri, 01 May 2026 21:39:32 GMT</pubDate>
+      <guid isPermaLink="false">Cohere-command-r-03-2024-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Cohere: command-r</title>
+      <link>https://docs.cohere.com/docs/deprecations#2025-09-15-various-older-command-models-a-number-of-endpoints-all-of-fine-tuning</link>
+      <description>Provider: Cohere
+Model ID: command-r
+Deprecation Date: 2025-09-15
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
+
+Effective September 15, 2025, the following deprecations will roll out. Deprecated Models: * `command-r-03-2024`  (and the alias `command-r`) * `command-r-plus-04-2024`  (and the alias `command-r-plus`) * `command-light` * `command` * `summarize` (Refer to [the migration guide](https://docs.cohere.com/docs/summarizing-text#migration-from-summarize-to-chat-endpoint) for alternatives). For command model replacements, we recommend you use `command-r-08-2024`, `command-r-plus-08-2024`, or `command-a...</description>
+      <pubDate>Fri, 01 May 2026 21:39:32 GMT</pubDate>
+      <guid isPermaLink="false">Cohere-command-r-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Cohere: command-r-plus-04-2024</title>
+      <link>https://docs.cohere.com/docs/deprecations#2025-09-15-various-older-command-models-a-number-of-endpoints-all-of-fine-tuning</link>
+      <description>Provider: Cohere
+Model ID: command-r-plus-04-2024
+Deprecation Date: 2025-09-15
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
+
+Effective September 15, 2025, the following deprecations will roll out. Deprecated Models: * `command-r-03-2024`  (and the alias `command-r`) * `command-r-plus-04-2024`  (and the alias `command-r-plus`) * `command-light` * `command` * `summarize` (Refer to [the migration guide](https://docs.cohere.com/docs/summarizing-text#migration-from-summarize-to-chat-endpoint) for alternatives). For command model replacements, we recommend you use `command-r-08-2024`, `command-r-plus-08-2024`, or `command-a...</description>
+      <pubDate>Fri, 01 May 2026 21:39:32 GMT</pubDate>
+      <guid isPermaLink="false">Cohere-command-r-plus-04-2024-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Cohere: command-r-plus</title>
+      <link>https://docs.cohere.com/docs/deprecations#2025-09-15-various-older-command-models-a-number-of-endpoints-all-of-fine-tuning</link>
+      <description>Provider: Cohere
+Model ID: command-r-plus
+Deprecation Date: 2025-09-15
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
+
+Effective September 15, 2025, the following deprecations will roll out. Deprecated Models: * `command-r-03-2024`  (and the alias `command-r`) * `command-r-plus-04-2024`  (and the alias `command-r-plus`) * `command-light` * `command` * `summarize` (Refer to [the migration guide](https://docs.cohere.com/docs/summarizing-text#migration-from-summarize-to-chat-endpoint) for alternatives). For command model replacements, we recommend you use `command-r-08-2024`, `command-r-plus-08-2024`, or `command-a...</description>
+      <pubDate>Fri, 01 May 2026 21:39:32 GMT</pubDate>
+      <guid isPermaLink="false">Cohere-command-r-plus-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Cohere: command-light</title>
+      <link>https://docs.cohere.com/docs/deprecations#2025-09-15-various-older-command-models-a-number-of-endpoints-all-of-fine-tuning</link>
+      <description>Provider: Cohere
+Model ID: command-light
+Deprecation Date: 2025-09-15
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
+
+Effective September 15, 2025, the following deprecations will roll out. Deprecated Models: * `command-r-03-2024`  (and the alias `command-r`) * `command-r-plus-04-2024`  (and the alias `command-r-plus`) * `command-light` * `command` * `summarize` (Refer to [the migration guide](https://docs.cohere.com/docs/summarizing-text#migration-from-summarize-to-chat-endpoint) for alternatives). For command model replacements, we recommend you use `command-r-08-2024`, `command-r-plus-08-2024`, or `command-a...</description>
+      <pubDate>Fri, 01 May 2026 21:39:32 GMT</pubDate>
+      <guid isPermaLink="false">Cohere-command-light-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Cohere: command</title>
+      <link>https://docs.cohere.com/docs/deprecations#2025-09-15-various-older-command-models-a-number-of-endpoints-all-of-fine-tuning</link>
+      <description>Provider: Cohere
+Model ID: command
+Deprecation Date: 2025-09-15
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
+
+Effective September 15, 2025, the following deprecations will roll out. Deprecated Models: * `command-r-03-2024`  (and the alias `command-r`) * `command-r-plus-04-2024`  (and the alias `command-r-plus`) * `command-light` * `command` * `summarize` (Refer to [the migration guide](https://docs.cohere.com/docs/summarizing-text#migration-from-summarize-to-chat-endpoint) for alternatives). For command model replacements, we recommend you use `command-r-08-2024`, `command-r-plus-08-2024`, or `command-a...</description>
+      <pubDate>Fri, 01 May 2026 21:39:32 GMT</pubDate>
+      <guid isPermaLink="false">Cohere-command-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Cohere: rerank-english-v2.0</title>
+      <link>https://docs.cohere.com/docs/deprecations#2024-12-02-rerank-v2-0</link>
+      <description>Provider: Cohere
+Model ID: rerank-english-v2.0
+Deprecation Date: 2024-12-02
+Shutdown Date: 2025-04-30
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
+
+On December 2nd, 2024, we announced the release of Rerank-v3.5 along with the deprecation of the Rerank-v2.0 model family. Fine-tuned models created from these base models are not affected by this deprecation. | Shutdown Date | Deprecated Model           | Deprecated Model Price | Recommended Replacement | | ------------- | -------------------------- | ---------------------- | ----------------------- | | 2025-04-30    | `rerank-english-v2.0`      | \$1.00 / 1K searches   | `rerank-v3.5`         ...</description>
+      <pubDate>Fri, 01 May 2026 21:39:32 GMT</pubDate>
+      <guid isPermaLink="false">Cohere-rerank-english-v2.0-2025-04-30-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Cohere: rerank-multilingual-v2.0</title>
+      <link>https://docs.cohere.com/docs/deprecations#2024-12-02-rerank-v2-0</link>
+      <description>Provider: Cohere
+Model ID: rerank-multilingual-v2.0
+Deprecation Date: 2024-12-02
+Shutdown Date: 2025-04-30
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
+
+On December 2nd, 2024, we announced the release of Rerank-v3.5 along with the deprecation of the Rerank-v2.0 model family. Fine-tuned models created from these base models are not affected by this deprecation. | Shutdown Date | Deprecated Model           | Deprecated Model Price | Recommended Replacement | | ------------- | -------------------------- | ---------------------- | ----------------------- | | 2025-04-30    | `rerank-english-v2.0`      | \$1.00 / 1K searches   | `rerank-v3.5`         ...</description>
+      <pubDate>Fri, 01 May 2026 21:39:32 GMT</pubDate>
+      <guid isPermaLink="false">Cohere-rerank-multilingual-v2.0-2025-04-30-e3b0c442</guid>
+    </item>
+    <item>
       <title>Azure: codex-mini</title>
       <link>https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models</link>
       <description>Provider: Azure
@@ -2923,14 +3442,14 @@ Azure OpenAI</description>
       <link>https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models</link>
       <description>Provider: Azure
 Model ID: gpt-4o-transcribe-diarize
-Deprecation Date: 2027-04-16
-Shutdown Date: 2027-04-16
+Deprecation Date: 2026-10-15
+Shutdown Date: 2026-10-15
 First Observed: 2026-04-25
-Last Observed: 2026-04-25
+Last Observed: 2026-05-01
 
 Azure OpenAI</description>
-      <pubDate>Sat, 25 Apr 2026 04:37:34 GMT</pubDate>
-      <guid isPermaLink="false">Azure-gpt-4o-transcribe-diarize-2027-04-16-e3b0c442</guid>
+      <pubDate>Fri, 01 May 2026 21:39:32 GMT</pubDate>
+      <guid isPermaLink="false">Azure-gpt-4o-transcribe-diarize-2026-10-15-e3b0c442</guid>
     </item>
     <item>
       <title>Azure: gpt-5</title>
@@ -2951,14 +3470,14 @@ Azure OpenAI</description>
       <link>https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models</link>
       <description>Provider: Azure
 Model ID: gpt-5-chat
-Deprecation Date: 2026-05-13
-Shutdown Date: 2026-05-13
+Deprecation Date: 2026-06-09
+Shutdown Date: 2026-06-09
 First Observed: 2026-04-25
-Last Observed: 2026-04-25
+Last Observed: 2026-05-01
 
 Azure OpenAI</description>
-      <pubDate>Sat, 25 Apr 2026 04:37:34 GMT</pubDate>
-      <guid isPermaLink="false">Azure-gpt-5-chat-2026-05-13-e3b0c442</guid>
+      <pubDate>Fri, 01 May 2026 21:39:32 GMT</pubDate>
+      <guid isPermaLink="false">Azure-gpt-5-chat-2026-06-09-e3b0c442</guid>
     </item>
     <item>
       <title>Azure: gpt-5-codex</title>
@@ -3035,14 +3554,14 @@ Azure OpenAI</description>
       <link>https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models</link>
       <description>Provider: Azure
 Model ID: gpt-5.1-chat
-Deprecation Date: 2026-05-13
-Shutdown Date: 2026-05-13
+Deprecation Date: 2026-06-09
+Shutdown Date: 2026-06-09
 First Observed: 2026-04-25
-Last Observed: 2026-04-25
+Last Observed: 2026-05-01
 
 Azure OpenAI</description>
-      <pubDate>Sat, 25 Apr 2026 04:37:34 GMT</pubDate>
-      <guid isPermaLink="false">Azure-gpt-5.1-chat-2026-05-13-e3b0c442</guid>
+      <pubDate>Fri, 01 May 2026 21:39:32 GMT</pubDate>
+      <guid isPermaLink="false">Azure-gpt-5.1-chat-2026-06-09-e3b0c442</guid>
     </item>
     <item>
       <title>Azure: gpt-5.1-codex</title>
@@ -3105,14 +3624,14 @@ Azure OpenAI</description>
       <link>https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models</link>
       <description>Provider: Azure
 Model ID: gpt-5.2-chat
-Deprecation Date: 2026-05-13
-Shutdown Date: 2026-05-13
+Deprecation Date: 2026-06-09
+Shutdown Date: 2026-06-09
 First Observed: 2026-04-25
-Last Observed: 2026-04-25
+Last Observed: 2026-05-01
 
 Azure OpenAI</description>
-      <pubDate>Sat, 25 Apr 2026 04:37:34 GMT</pubDate>
-      <guid isPermaLink="false">Azure-gpt-5.2-chat-2026-05-13-e3b0c442</guid>
+      <pubDate>Fri, 01 May 2026 21:39:32 GMT</pubDate>
+      <guid isPermaLink="false">Azure-gpt-5.2-chat-2026-06-09-e3b0c442</guid>
     </item>
     <item>
       <title>Azure: gpt-5.2-codex</title>
@@ -3133,14 +3652,14 @@ Azure OpenAI</description>
       <link>https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models</link>
       <description>Provider: Azure
 Model ID: gpt-5.3-chat
-Deprecation Date: 2026-06-03
-Shutdown Date: 2026-06-03
+Deprecation Date: 2026-06-09
+Shutdown Date: 2026-06-09
 First Observed: 2026-04-25
-Last Observed: 2026-04-25
+Last Observed: 2026-05-01
 
 Azure OpenAI</description>
-      <pubDate>Sat, 25 Apr 2026 04:37:34 GMT</pubDate>
-      <guid isPermaLink="false">Azure-gpt-5.3-chat-2026-06-03-e3b0c442</guid>
+      <pubDate>Fri, 01 May 2026 21:39:32 GMT</pubDate>
+      <guid isPermaLink="false">Azure-gpt-5.3-chat-2026-06-09-e3b0c442</guid>
     </item>
     <item>
       <title>Azure: gpt-5.3-codex</title>
@@ -3259,14 +3778,14 @@ Azure OpenAI</description>
       <link>https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models</link>
       <description>Provider: Azure
 Model ID: gpt-audio-mini
-Deprecation Date: 2027-04-07
-Shutdown Date: 2027-04-07
+Deprecation Date: 2026-07-23
+Shutdown Date: 2026-07-23
 First Observed: 2026-04-25
-Last Observed: 2026-04-25
+Last Observed: 2026-05-01
 
 Azure OpenAI</description>
-      <pubDate>Sat, 25 Apr 2026 04:37:34 GMT</pubDate>
-      <guid isPermaLink="false">Azure-gpt-audio-mini-2027-04-07-e3b0c442</guid>
+      <pubDate>Fri, 01 May 2026 21:39:32 GMT</pubDate>
+      <guid isPermaLink="false">Azure-gpt-audio-mini-2026-07-23-e3b0c442</guid>
     </item>
     <item>
       <title>Azure: gpt-image-1</title>
@@ -3357,14 +3876,14 @@ Azure OpenAI</description>
       <link>https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models</link>
       <description>Provider: Azure
 Model ID: gpt-realtime-mini
-Deprecation Date: 2027-04-07
-Shutdown Date: 2027-04-07
+Deprecation Date: 2026-07-23
+Shutdown Date: 2026-07-23
 First Observed: 2026-04-25
-Last Observed: 2026-04-25
+Last Observed: 2026-05-01
 
 Azure OpenAI</description>
-      <pubDate>Sat, 25 Apr 2026 04:37:34 GMT</pubDate>
-      <guid isPermaLink="false">Azure-gpt-realtime-mini-2027-04-07-e3b0c442</guid>
+      <pubDate>Fri, 01 May 2026 21:39:32 GMT</pubDate>
+      <guid isPermaLink="false">Azure-gpt-realtime-mini-2026-07-23-e3b0c442</guid>
     </item>
     <item>
       <title>Azure: o1</title>
@@ -3511,42 +4030,42 @@ Azure OpenAI</description>
       <link>https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models</link>
       <description>Provider: Azure
 Model ID: tts
-Deprecation Date: 2026-06-18
-Shutdown Date: 2026-06-18
+Deprecation Date: 2026-12-15
+Shutdown Date: 2026-12-15
 First Observed: 2026-04-25
-Last Observed: 2026-04-25
+Last Observed: 2026-05-01
 
 Azure OpenAI</description>
-      <pubDate>Sat, 25 Apr 2026 04:37:34 GMT</pubDate>
-      <guid isPermaLink="false">Azure-tts-2026-06-18-e3b0c442</guid>
+      <pubDate>Fri, 01 May 2026 21:39:32 GMT</pubDate>
+      <guid isPermaLink="false">Azure-tts-2026-12-15-e3b0c442</guid>
     </item>
     <item>
       <title>Azure: tts-hd</title>
       <link>https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models</link>
       <description>Provider: Azure
 Model ID: tts-hd
-Deprecation Date: 2026-06-18
-Shutdown Date: 2026-06-18
+Deprecation Date: 2026-12-15
+Shutdown Date: 2026-12-15
 First Observed: 2026-04-25
-Last Observed: 2026-04-25
+Last Observed: 2026-05-01
 
 Azure OpenAI</description>
-      <pubDate>Sat, 25 Apr 2026 04:37:34 GMT</pubDate>
-      <guid isPermaLink="false">Azure-tts-hd-2026-06-18-e3b0c442</guid>
+      <pubDate>Fri, 01 May 2026 21:39:32 GMT</pubDate>
+      <guid isPermaLink="false">Azure-tts-hd-2026-12-15-e3b0c442</guid>
     </item>
     <item>
       <title>Azure: whisper</title>
       <link>https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models</link>
       <description>Provider: Azure
 Model ID: whisper
-Deprecation Date: 2026-06-18
-Shutdown Date: 2026-06-18
+Deprecation Date: 2026-12-15
+Shutdown Date: 2026-12-15
 First Observed: 2026-04-25
-Last Observed: 2026-04-25
+Last Observed: 2026-05-01
 
 Azure OpenAI</description>
-      <pubDate>Sat, 25 Apr 2026 04:37:34 GMT</pubDate>
-      <guid isPermaLink="false">Azure-whisper-2026-06-18-e3b0c442</guid>
+      <pubDate>Fri, 01 May 2026 21:39:32 GMT</pubDate>
+      <guid isPermaLink="false">Azure-whisper-2026-12-15-e3b0c442</guid>
     </item>
     <item>
       <title>Azure: model-router</title>
@@ -3717,6 +4236,20 @@ Anthropic</description>
       <guid isPermaLink="false">Azure-claude-opus-4-6-2027-02-02-e3b0c442</guid>
     </item>
     <item>
+      <title>Azure: claude-opus-4-7</title>
+      <link>https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models</link>
+      <description>Provider: Azure
+Model ID: claude-opus-4-7
+Deprecation Date: 2027-04-06
+Shutdown Date: 2027-04-06
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
+
+Anthropic</description>
+      <pubDate>Fri, 01 May 2026 21:39:32 GMT</pubDate>
+      <guid isPermaLink="false">Azure-claude-opus-4-7-2027-04-06-e3b0c442</guid>
+    </item>
+    <item>
       <title>Azure: claude-sonnet-4-5</title>
       <link>https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models</link>
       <description>Provider: Azure
@@ -3785,6 +4318,188 @@ Last Observed: 2026-04-25
 Cohere</description>
       <pubDate>Sat, 25 Apr 2026 04:37:34 GMT</pubDate>
       <guid isPermaLink="false">Azure-Cohere-rerank-v3.5-2026-05-14-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Azure: FW-DeepSeek-V3.1</title>
+      <link>https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models</link>
+      <description>Provider: Azure
+Model ID: FW-DeepSeek-V3.1
+Deprecation Date: 2026-07-01
+Shutdown Date: 2026-07-01
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
+
+Fireworks</description>
+      <pubDate>Fri, 01 May 2026 21:39:32 GMT</pubDate>
+      <guid isPermaLink="false">Azure-FW-DeepSeek-V3.1-2026-07-01-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Azure: FW-DeepSeek-V3.2</title>
+      <link>https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models</link>
+      <description>Provider: Azure
+Model ID: FW-DeepSeek-V3.2
+Deprecation Date: 2026-07-01
+Shutdown Date: 2026-07-01
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
+
+Fireworks</description>
+      <pubDate>Fri, 01 May 2026 21:39:32 GMT</pubDate>
+      <guid isPermaLink="false">Azure-FW-DeepSeek-V3.2-2026-07-01-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Azure: FW-GLM-4.7</title>
+      <link>https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models</link>
+      <description>Provider: Azure
+Model ID: FW-GLM-4.7
+Deprecation Date: 2026-07-01
+Shutdown Date: 2026-07-01
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
+
+Fireworks</description>
+      <pubDate>Fri, 01 May 2026 21:39:32 GMT</pubDate>
+      <guid isPermaLink="false">Azure-FW-GLM-4.7-2026-07-01-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Azure: FW-GLM-5</title>
+      <link>https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models</link>
+      <description>Provider: Azure
+Model ID: FW-GLM-5
+Deprecation Date: 2026-07-01
+Shutdown Date: 2026-07-01
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
+
+Fireworks</description>
+      <pubDate>Fri, 01 May 2026 21:39:32 GMT</pubDate>
+      <guid isPermaLink="false">Azure-FW-GLM-5-2026-07-01-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Azure: FW-GLM-5.1</title>
+      <link>https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models</link>
+      <description>Provider: Azure
+Model ID: FW-GLM-5.1
+Deprecation Date: 2026-08-01
+Shutdown Date: 2026-08-01
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
+
+Fireworks</description>
+      <pubDate>Fri, 01 May 2026 21:39:32 GMT</pubDate>
+      <guid isPermaLink="false">Azure-FW-GLM-5.1-2026-08-01-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Azure: FW-GPT-OSS-120B</title>
+      <link>https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models</link>
+      <description>Provider: Azure
+Model ID: FW-GPT-OSS-120B
+Deprecation Date: 2026-07-01
+Shutdown Date: 2026-07-01
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
+
+Fireworks</description>
+      <pubDate>Fri, 01 May 2026 21:39:32 GMT</pubDate>
+      <guid isPermaLink="false">Azure-FW-GPT-OSS-120B-2026-07-01-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Azure: FW-Kimi-K2-Instruct-0905</title>
+      <link>https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models</link>
+      <description>Provider: Azure
+Model ID: FW-Kimi-K2-Instruct-0905
+Deprecation Date: 2026-07-01
+Shutdown Date: 2026-07-01
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
+
+Fireworks</description>
+      <pubDate>Fri, 01 May 2026 21:39:32 GMT</pubDate>
+      <guid isPermaLink="false">Azure-FW-Kimi-K2-Instruct-0905-2026-07-01-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Azure: FW-Kimi-K2-Thinking</title>
+      <link>https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models</link>
+      <description>Provider: Azure
+Model ID: FW-Kimi-K2-Thinking
+Deprecation Date: 2026-07-01
+Shutdown Date: 2026-07-01
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
+
+Fireworks</description>
+      <pubDate>Fri, 01 May 2026 21:39:32 GMT</pubDate>
+      <guid isPermaLink="false">Azure-FW-Kimi-K2-Thinking-2026-07-01-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Azure: FW-Kimi-K2.5</title>
+      <link>https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models</link>
+      <description>Provider: Azure
+Model ID: FW-Kimi-K2.5
+Deprecation Date: 2026-07-01
+Shutdown Date: 2026-07-01
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
+
+Fireworks</description>
+      <pubDate>Fri, 01 May 2026 21:39:32 GMT</pubDate>
+      <guid isPermaLink="false">Azure-FW-Kimi-K2.5-2026-07-01-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Azure: FW-MiniMax-M2.5</title>
+      <link>https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models</link>
+      <description>Provider: Azure
+Model ID: FW-MiniMax-M2.5
+Deprecation Date: 2026-07-01
+Shutdown Date: 2026-07-01
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
+
+Fireworks</description>
+      <pubDate>Fri, 01 May 2026 21:39:32 GMT</pubDate>
+      <guid isPermaLink="false">Azure-FW-MiniMax-M2.5-2026-07-01-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Azure: FW-Qwen3-14B</title>
+      <link>https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models</link>
+      <description>Provider: Azure
+Model ID: FW-Qwen3-14B
+Deprecation Date: 2026-07-01
+Shutdown Date: 2026-07-01
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
+
+Fireworks</description>
+      <pubDate>Fri, 01 May 2026 21:39:32 GMT</pubDate>
+      <guid isPermaLink="false">Azure-FW-Qwen3-14B-2026-07-01-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Azure: FW-Qwen3.5-122B-A10B</title>
+      <link>https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models</link>
+      <description>Provider: Azure
+Model ID: FW-Qwen3.5-122B-A10B
+Deprecation Date: 2026-08-01
+Shutdown Date: 2026-08-01
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
+
+Fireworks</description>
+      <pubDate>Fri, 01 May 2026 21:39:32 GMT</pubDate>
+      <guid isPermaLink="false">Azure-FW-Qwen3.5-122B-A10B-2026-08-01-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Azure: FW-Qwen3.5-397B-A17B</title>
+      <link>https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models</link>
+      <description>Provider: Azure
+Model ID: FW-Qwen3.5-397B-A17B
+Deprecation Date: 2026-08-01
+Shutdown Date: 2026-08-01
+First Observed: 2026-05-01
+Last Observed: 2026-05-01
+
+Fireworks</description>
+      <pubDate>Fri, 01 May 2026 21:39:32 GMT</pubDate>
+      <guid isPermaLink="false">Azure-FW-Qwen3.5-397B-A17B-2026-08-01-e3b0c442</guid>
     </item>
     <item>
       <title>Azure: Llama-3.2-11B-Vision-Instruct</title>

--- a/docs/v1/providers.json
+++ b/docs/v1/providers.json
@@ -12,7 +12,7 @@
   {
     "provider": "Google",
     "label": "Google AI/Gemini Deprecations",
-    "url": "https://ai.google.dev/gemini-api/docs/changelog"
+    "url": "https://ai.google.dev/gemini-api/docs/deprecations"
   },
   {
     "provider": "Google Vertex",

--- a/src/markdown_utils.py
+++ b/src/markdown_utils.py
@@ -17,9 +17,16 @@ def is_markdown(content: str) -> bool:
     stripped = content.lstrip()
     if not stripped:
         return False
-    if stripped.startswith("<!doctype html") or stripped.startswith("<html"):
+
+    lowered = stripped[:200].lower()
+    if lowered.startswith("<!doctype html") or lowered.startswith("<html"):
         return False
-    return stripped.startswith(("#", "***", "---", "####", "###"))
+
+    return bool(
+        stripped.startswith(("#", "***", "---", "####", "###"))
+        or re.search(r"^#{1,6}\s+\S", content, re.MULTILINE)
+        or re.search(r"^\s*>\s*For clean Markdown", content, re.MULTILINE)
+    )
 
 
 def slugify_heading(text: str) -> str:
@@ -77,7 +84,30 @@ def parse_markdown_table(block_lines: list[str]) -> tuple[list[str], list[list[s
 
     def split_row(row: str) -> list[str]:
         stripped = row.strip().strip("|")
-        return [cell.strip() for cell in stripped.split("|")]
+        cells: list[str] = []
+        current: list[str] = []
+        index = 0
+
+        while index < len(stripped):
+            char = stripped[index]
+            if (
+                char == "\\"
+                and index + 1 < len(stripped)
+                and stripped[index + 1] == "|"
+            ):
+                current.append("|")
+                index += 2
+                continue
+            if char == "|":
+                cells.append("".join(current).strip())
+                current = []
+                index += 1
+                continue
+            current.append(char)
+            index += 1
+
+        cells.append("".join(current).strip())
+        return cells
 
     headers = split_row(block_lines[0])
     rows = [split_row(row) for row in block_lines[2:] if row.strip()]

--- a/src/scrapers/azure_foundry_scraper.py
+++ b/src/scrapers/azure_foundry_scraper.py
@@ -33,6 +33,14 @@ class AzureFoundryScraper(EnhancedBaseScraper):
                 headers.append(th.get_text(strip=True).upper())
 
             header_text = " ".join(headers).upper()
+            if (
+                "TRAINING RETIREMENT" in header_text
+                and "DEPLOYMENT RETIREMENT" in header_text
+            ):
+                # This table describes fine-tuning lifecycle for base model families,
+                # not retirement of the base models themselves.
+                continue
+
             keywords = ["MODEL", "RETIREMENT", "DEPRECATION", "LEGACY"]
             if not any(keyword in header_text for keyword in keywords):
                 continue
@@ -107,7 +115,7 @@ class AzureFoundryScraper(EnhancedBaseScraper):
                     )
                 )
 
-        return items
+        return self._merge_duplicate_models(items)
 
     def _extract_model_id_from_cell(self, cell: Any) -> str:
         """Extract a stable model identifier from a model table cell."""
@@ -190,6 +198,44 @@ class AzureFoundryScraper(EnhancedBaseScraper):
         if context:
             return context
         return f"Model lifecycle retirement information for {model_id}"
+
+    def _merge_duplicate_models(
+        self, items: list[DeprecationItem]
+    ) -> list[DeprecationItem]:
+        """Collapse Azure rows to one record per model using earliest dates."""
+        by_model: dict[str, DeprecationItem] = {}
+
+        for item in items:
+            existing = by_model.get(item.model_id)
+            if existing is None:
+                by_model[item.model_id] = item
+                continue
+
+            existing.announcement_date = self._earliest_date(
+                existing.announcement_date, item.announcement_date
+            )
+            existing.shutdown_date = self._earliest_date(
+                existing.shutdown_date, item.shutdown_date
+            )
+            existing.deprecation_date = existing.announcement_date
+
+            if item.deprecation_context not in existing.deprecation_context:
+                existing.deprecation_context += (
+                    f" Additional Azure row collapsed: {item.deprecation_context}"
+                )
+
+            if not existing.replacement_models and item.replacement_models:
+                existing.replacement_models = item.replacement_models
+
+        return list(by_model.values())
+
+    def _earliest_date(self, left: str, right: str) -> str:
+        """Return the earliest non-empty ISO date."""
+        if not left:
+            return right
+        if not right:
+            return left
+        return left if left <= right else right
 
     def extract_unstructured_deprecations(self, html: str) -> List[DeprecationItem]:
         """Azure AI Foundry page has structured tables, so this is not needed."""

--- a/src/scrapers/google_scraper.py
+++ b/src/scrapers/google_scraper.py
@@ -1,7 +1,10 @@
-"""Google AI/Gemini deprecations scraper with individual model extraction."""
+"""Google AI/Gemini deprecations scraper."""
+
+from __future__ import annotations
 
 import re
 from typing import List
+
 from bs4 import BeautifulSoup
 
 from ..base_scraper import EnhancedBaseScraper
@@ -9,205 +12,385 @@ from ..models import DeprecationItem
 
 
 class GoogleScraper(EnhancedBaseScraper):
-    """Scraper for Google AI/Gemini deprecations page."""
+    """Scraper for the Google AI/Gemini model deprecations table."""
 
     provider_name = "Google"
-    url = "https://ai.google.dev/gemini-api/docs/changelog"
-    requires_playwright = False  # Static content, httpx is fine
+    url = "https://ai.google.dev/gemini-api/docs/deprecations"
+    changelog_url = "https://ai.google.dev/gemini-api/docs/changelog"
+    requires_playwright = False
+
+    _NO_SHUTDOWN_MARKERS = {
+        "no shutdown date announced",
+        "no shut down date announced",
+        "no shutdown announced",
+    }
+
+    def scrape(self) -> List[DeprecationItem]:
+        """Combine current deprecation tables with older explicit changelog notices."""
+        table_html = self.fetch_html(self.url)
+        changelog_html = self.fetch_html(self.changelog_url)
+        table_items = self.extract_structured_deprecations(table_html)
+        changelog_items = self._extract_changelog_deprecations(changelog_html)
+
+        by_model = {item.model_id: item for item in table_items}
+        for item in changelog_items:
+            by_model.setdefault(item.model_id, item)
+        return list(by_model.values())
 
     def extract_structured_deprecations(self, html: str) -> List[DeprecationItem]:
-        """Extract deprecations from Google AI changelog format."""
-        items = []
+        """Extract only rows with concrete shutdown dates from Gemini tables."""
         soup = BeautifulSoup(html, "html.parser")
-
-        # Find main content
         content = soup.find("article") or soup.find(
             "div", class_="devsite-article-body"
         )
         if not content:
-            return items
+            return []
 
-        # Google AI uses date-based sections with h2 headers
-        sections = content.find_all(["h2", "h3"])
-
-        for section_header in sections:
-            section_title = section_header.get_text(strip=True)
-
-            # Skip non-date sections
-            date_match = re.search(r"(\w+ \d+, \d{4})", section_title)
-            if not date_match:
+        items: list[DeprecationItem] = []
+        for table in content.find_all("table"):
+            headers = self._table_headers(table)
+            header_map = {header.lower(): idx for idx, header in enumerate(headers)}
+            model_idx = header_map.get("model")
+            release_idx = header_map.get("release date")
+            shutdown_idx = header_map.get("shutdown date")
+            replacement_idx = header_map.get("recommended replacement")
+            if model_idx is None or shutdown_idx is None:
                 continue
 
-            section_date = self.parse_date(date_match.group(1))
+            section_name, section_url = self._table_section(table)
+            for row in table.find_all("tr")[1:]:
+                cells = row.find_all(["td", "th"])
+                if len(cells) <= max(model_idx, shutdown_idx):
+                    continue
 
-            # Look for deprecation info after the header
-            next_elem = section_header.next_sibling
+                model_id = cells[model_idx].get_text(" ", strip=True)
+                if not self._looks_like_model_id(model_id):
+                    continue
 
-            while next_elem:
-                if hasattr(next_elem, "name"):
-                    if next_elem.name in ["h2", "h3"]:
-                        # Next section
-                        break
+                shutdown_text = cells[shutdown_idx].get_text(" ", strip=True)
+                if self._is_non_actionable_shutdown(shutdown_text):
+                    continue
 
-                    text = next_elem.get_text(strip=True)
+                shutdown_date = self.parse_date(shutdown_text)
+                if not shutdown_date:
+                    # Rows like "Coming soon" are lifecycle warnings but not dated
+                    # deprecations. Exclude them from the feed until a date lands.
+                    continue
 
-                    # Look for deprecation patterns
-                    if any(
-                        keyword in text.lower()
-                        for keyword in [
-                            "deprecated",
-                            "deprecation",
-                            "no longer supported",
-                            "removed",
-                            "will be deprecated",
-                            "retirement",
-                        ]
-                    ):
-                        # Find all <code> tags that contain model IDs
-                        code_tags = next_elem.find_all("code")
+                release_date = ""
+                if release_idx is not None and release_idx < len(cells):
+                    release_date = self.parse_date(
+                        cells[release_idx].get_text(" ", strip=True)
+                    )
 
-                        if code_tags:
-                            for code_tag in code_tags:
-                                model_id = code_tag.get_text(strip=True).lower()
+                replacement_models = None
+                if replacement_idx is not None and replacement_idx < len(cells):
+                    replacement_models = self._parse_replacements(
+                        cells[replacement_idx]
+                    )
 
-                                # Verify it's a valid model ID pattern
-                                if not re.match(
-                                    r"^gemini-[a-zA-Z0-9\-\.]+$", model_id
-                                ) and not re.match(
-                                    r"^(veo|imagen)-[a-zA-Z0-9\-\.]+$", model_id
-                                ):
-                                    continue
+                items.append(
+                    DeprecationItem(
+                        provider=self.provider_name,
+                        model_id=model_id,
+                        announcement_date=shutdown_date,
+                        shutdown_date=shutdown_date,
+                        deprecation_date=shutdown_date,
+                        replacement_models=replacement_models,
+                        deprecation_context=self._build_context(
+                            section_name,
+                            release_date,
+                            shutdown_date,
+                            replacement_models,
+                        ),
+                        url=section_url,
+                    )
+                )
 
-                                # Get context from the parent list item or paragraph
-                                context_elem = code_tag.find_parent(["li", "p"])
-                                if context_elem:
-                                    # Use the immediate parent's text as primary context
-                                    deprecation_context = context_elem.get_text(
-                                        " ", strip=True
-                                    )
+        return self._dedupe_items(items)
 
-                                    # If context is too short, try grandparent
-                                    if len(deprecation_context) < 30:
-                                        grandparent = context_elem.find_parent(
-                                            ["li", "p"]
-                                        )
-                                        if grandparent:
-                                            deprecation_context = grandparent.get_text(
-                                                " ", strip=True
-                                            )
-                                else:
-                                    deprecation_context = text
+    def _table_headers(self, table) -> list[str]:
+        header_row = table.find("tr")
+        if not header_row:
+            return []
+        return [
+            cell.get_text(" ", strip=True) for cell in header_row.find_all(["th", "td"])
+        ]
 
-                                # Look for shutdown date in context
-                                future_date_match = re.search(
-                                    r"(\w+ \d+(?:st|nd|rd|th)?)[:\s]",
-                                    deprecation_context,
-                                )
-                                deprecation_date = ""
-                                if future_date_match:
-                                    date_str = future_date_match.group(1).rstrip(
-                                        "stndrdth"
-                                    )
-                                    # Try to parse with current year
-                                    try:
-                                        parsed_date = self.parse_date(
-                                            f"{date_str}, {section_date[:4]}"
-                                        )
-                                        if parsed_date and parsed_date >= section_date:
-                                            deprecation_date = parsed_date
-                                    except (ValueError, AttributeError):
-                                        pass
+    def _table_section(self, table) -> tuple[str, str]:
+        heading = table.find_previous(["h2", "h3", "h4"])
+        if not heading:
+            return "Gemini deprecations", self.url
+        heading_text = heading.get_text(" ", strip=True)
+        heading_id = heading.get("id", "")
+        return heading_text, f"{self.url}#{heading_id}" if heading_id else self.url
 
-                                if not deprecation_date:
-                                    deprecation_date = section_date
+    def _looks_like_model_id(self, value: str) -> bool:
+        normalized = value.strip()
+        if not normalized or normalized.lower() == "preview models":
+            return False
+        return bool(
+            re.match(
+                r"^(gemini|embedding|text-embedding|imagen|veo|lyria)-[A-Za-z0-9_.-]+$",
+                normalized,
+            )
+        )
 
-                                # Look for replacement models in context
-                                replacement_str = None
-                                repl_patterns = [
-                                    r"redirect(?:ing)?\s+to\s+(gemini-[a-zA-Z0-9\-\.]+)",
-                                    r"use\s+([a-z]+\s+\d+)",
-                                    r"use\s+(gemini-[a-zA-Z0-9\-\.]+)",
-                                    r"replaced\s+(?:by|with)\s+(gemini-[a-zA-Z0-9\-\.]+)",
-                                ]
-                                for pattern in repl_patterns:
-                                    repl_match = re.search(
-                                        pattern, deprecation_context.lower()
-                                    )
-                                    if repl_match:
-                                        replacement_str = repl_match.group(1)
-                                        break
+    def _is_non_actionable_shutdown(self, shutdown_text: str) -> bool:
+        normalized = shutdown_text.strip().lower()
+        return not normalized or normalized in self._NO_SHUTDOWN_MARKERS
 
-                                replacement_models = (
-                                    self.parse_replacements(replacement_str)
-                                    if replacement_str
-                                    else None
-                                )
+    def _parse_replacements(self, cell) -> list[str] | None:
+        text = cell.get_text(" ", strip=True)
+        if not text or text in {"—", "-", "---", "N/A"}:
+            return None
+        replacements = [
+            replacement
+            for replacement in self.parse_replacements(text) or []
+            if self._looks_like_model_id(replacement)
+        ]
+        return replacements or None
 
-                                item = DeprecationItem(
-                                    provider=self.provider_name,
-                                    model_id=model_id,
-                                    announcement_date=section_date,
-                                    shutdown_date=deprecation_date
-                                    if deprecation_date != section_date
-                                    else "",
-                                    replacement_models=replacement_models,
-                                    deprecation_context=deprecation_context,
-                                    url=f"{self.url}#{section_date.replace('-', '')}",
-                                )
-                                items.append(item)
-                        else:
-                            # Fallback: extract from text if no code tags
-                            if "gemini" in text.lower():
-                                general_model_patterns = [
-                                    r"gemini\s+1\.0\s+pro\s+vision",
-                                    r"gemini\s+1\.0\s+pro",
-                                    r"gemini\s+1\.5\s+(?:pro|flash)",
-                                ]
+    def _build_context(
+        self,
+        section_name: str,
+        release_date: str,
+        shutdown_date: str,
+        replacement_models: list[str] | None,
+    ) -> str:
+        parts = [f"Gemini deprecations table: {section_name}."]
+        if release_date:
+            parts.append(f"Release date: {release_date}.")
+        parts.append(f"Shutdown date: {shutdown_date}.")
+        if replacement_models:
+            parts.append(f"Recommended replacement: {', '.join(replacement_models)}.")
+        return " ".join(parts)
 
-                                for pattern in general_model_patterns:
-                                    if re.search(pattern, text.lower()):
-                                        matched_model = re.search(
-                                            pattern, text.lower()
-                                        ).group(0)
-                                        model_id = matched_model.lower().replace(
-                                            " ", "-"
-                                        )
+    def _dedupe_items(self, items: list[DeprecationItem]) -> list[DeprecationItem]:
+        by_model: dict[str, DeprecationItem] = {}
+        for item in items:
+            existing = by_model.get(item.model_id)
+            if existing is None or item.shutdown_date < existing.shutdown_date:
+                by_model[item.model_id] = item
+        return list(by_model.values())
 
-                                        future_date_match = re.search(
-                                            r"(\w+ \d+, \d{4})", text
-                                        )
-                                        deprecation_date = ""
-                                        if future_date_match:
-                                            parsed_date = self.parse_date(
-                                                future_date_match.group(1)
-                                            )
-                                            if (
-                                                parsed_date
-                                                and parsed_date > section_date
-                                            ):
-                                                deprecation_date = parsed_date
+    def _extract_changelog_deprecations(self, html: str) -> list[DeprecationItem]:
+        """Extract explicit historical notices omitted from the lifecycle tables."""
+        soup = BeautifulSoup(html, "html.parser")
+        content = soup.find("article") or soup.find(
+            "div", class_="devsite-article-body"
+        )
+        if not content:
+            return []
 
-                                        if not deprecation_date:
-                                            deprecation_date = section_date
+        items: list[DeprecationItem] = []
+        for section_header in content.find_all(["h2", "h3"]):
+            section_title = section_header.get_text(" ", strip=True)
+            section_date_match = re.search(r"(\w+ \d{1,2}, \d{4})", section_title)
+            if not section_date_match:
+                continue
+            section_date = self.parse_date(section_date_match.group(1))
+            if not section_date:
+                continue
 
-                                        item = DeprecationItem(
-                                            provider=self.provider_name,
-                                            model_id=model_id,
-                                            announcement_date=section_date,
-                                            shutdown_date=deprecation_date
-                                            if deprecation_date != section_date
-                                            else "",
-                                            replacement_models=None,
-                                            deprecation_context=text,
-                                            url=f"{self.url}#{section_date.replace('-', '')}",
-                                        )
-                                        items.append(item)
-                                        break
+            for notice_text in self._section_notice_texts(section_header):
+                items.extend(self._items_from_notice_text(notice_text, section_date))
 
-                next_elem = next_elem.next_sibling
+        return self._dedupe_items(items)
+
+    def _section_notice_texts(self, section_header) -> list[str]:
+        notices: list[str] = []
+        sibling = section_header.next_sibling
+        while sibling:
+            if getattr(sibling, "name", None) in ["h2", "h3"]:
+                break
+            if getattr(sibling, "name", None) in ["p", "li"]:
+                text = sibling.get_text(" ", strip=True)
+                if self._has_deprecation_language(text):
+                    notices.append(text)
+            if getattr(sibling, "name", None) in ["ul", "ol"]:
+                for item in sibling.find_all("li", recursive=False):
+                    text = item.get_text(" ", strip=True)
+                    if self._has_deprecation_language(text):
+                        notices.append(text)
+            sibling = sibling.next_sibling
+        return notices
+
+    def _has_deprecation_language(self, text: str) -> bool:
+        lowered = text.lower()
+        return any(
+            phrase in lowered
+            for phrase in [
+                "deprecation announcement",
+                "will be shut down",
+                "has been shut down",
+                "are shut down",
+                "is shut down",
+                "now shut down",
+                "no longer supported",
+                "removed",
+                "will be deprecated",
+            ]
+        )
+
+    def _items_from_notice_text(
+        self, text: str, section_date: str
+    ) -> list[DeprecationItem]:
+        items: list[DeprecationItem] = []
+        normalized = " ".join(text.split())
+
+        items.extend(self._extract_grouped_shutdowns(normalized, section_date))
+        items.extend(self._extract_single_shutdowns(normalized, section_date))
+        items.extend(self._extract_shutdown_lists(normalized, section_date))
+        items.extend(self._extract_no_longer_supported(normalized, section_date))
+
+        return self._dedupe_items(items)
+
+    def _extract_grouped_shutdowns(
+        self, text: str, section_date: str
+    ) -> list[DeprecationItem]:
+        items: list[DeprecationItem] = []
+        if "following models will be shut down:" not in text.lower():
+            return []
+
+        year = section_date[:4]
+        group_re = re.compile(
+            r"([A-Z][a-z]+\s+\d{1,2})(?:st|nd|rd|th)?:\s*(.*?)(?=(?:[A-Z][a-z]+\s+\d{1,2}(?:st|nd|rd|th)?:)|$)"
+        )
+        for match in group_re.finditer(text):
+            shutdown_date = self.parse_date(f"{match.group(1)}, {year}")
+            if not shutdown_date:
+                continue
+            for model_id in self._model_ids_before_replacement_text(match.group(2)):
+                items.append(
+                    self._changelog_item(model_id, section_date, shutdown_date, text)
+                )
+        return items
+
+    def _extract_single_shutdowns(
+        self, text: str, section_date: str
+    ) -> list[DeprecationItem]:
+        items: list[DeprecationItem] = []
+        date_pattern = r"(?P<date>[A-Z][a-z]+\s+\d{1,2}(?:st|nd|rd|th)?(?:,\s*\d{4})?)"
+        model_pattern = r"(?P<model>(?:gemini|embedding|text-embedding|imagen|veo|lyria)-[A-Za-z0-9_.-]+)"
+
+        list_patterns = [
+            rf"following models will be shut down(?: on)?\s+{date_pattern}:\s*(?P<models>.*)$",
+            rf"shut down for\s+(?P<models>.*?)\s+coming\s+{date_pattern}",
+        ]
+        for pattern in list_patterns:
+            for match in re.finditer(pattern, text, re.IGNORECASE):
+                shutdown_date = self._parse_notice_date(
+                    match.group("date"), section_date
+                )
+                if not shutdown_date:
+                    continue
+                for model_id in self._model_ids_before_replacement_text(
+                    match.group("models")
+                ):
+                    items.append(
+                        self._changelog_item(
+                            model_id, section_date, shutdown_date, text
+                        )
+                    )
+
+        direct_patterns = [
+            rf"{model_pattern}[^.;:]{{0,80}}\bwill be shut down(?: on)?\s+{date_pattern}",
+            rf"{model_pattern}[^.;:]{{0,80}}\bwill be deprecated on\s+{date_pattern}",
+        ]
+        for pattern in direct_patterns:
+            for match in re.finditer(pattern, text, re.IGNORECASE):
+                shutdown_date = self._parse_notice_date(
+                    match.group("date"), section_date
+                )
+                model_id = match.group("model")
+                if shutdown_date and self._looks_like_model_id(model_id):
+                    items.append(
+                        self._changelog_item(
+                            model_id, section_date, shutdown_date, text
+                        )
+                    )
 
         return items
 
+    def _extract_shutdown_lists(
+        self, text: str, section_date: str
+    ) -> list[DeprecationItem]:
+        lowered = text.lower()
+        if not any(
+            phrase in lowered
+            for phrase in [
+                "following models are shut down",
+                "following model is shut down",
+                "models are now shut down",
+                "is shut down",
+                "has been shut down",
+            ]
+        ):
+            return []
+
+        if "will be shut down" in lowered or "will be deprecated" in lowered:
+            return []
+
+        model_text = text
+        for separator in [" Use ", " See ", " Refer "]:
+            model_text = model_text.split(separator, 1)[0]
+        return [
+            self._changelog_item(model_id, section_date, section_date, text)
+            for model_id in self._model_ids_before_replacement_text(model_text)
+        ]
+
+    def _extract_no_longer_supported(
+        self, text: str, section_date: str
+    ) -> list[DeprecationItem]:
+        lowered = text.lower()
+        model_ids: list[str] = []
+        if "gemini 1.0 pro vision" in lowered and (
+            "removed" in lowered or "deprecated" in lowered
+        ):
+            model_ids.append("gemini-1.0-pro-vision")
+        elif "gemini 1.0 pro" in lowered and "no longer supported" in lowered:
+            model_ids.append("gemini-1.0-pro")
+
+        return [
+            self._changelog_item(model_id, section_date, section_date, text)
+            for model_id in model_ids
+        ]
+
+    def _parse_notice_date(self, raw_date: str, section_date: str) -> str:
+        if not re.search(r"\d{4}", raw_date):
+            raw_date = f"{raw_date}, {section_date[:4]}"
+        return self.parse_date(raw_date)
+
+    def _model_ids_before_replacement_text(self, text: str) -> list[str]:
+        model_text = re.split(
+            r"\b(?:Use|See|Refer|instead|now points to|redirected to)\b",
+            text,
+            maxsplit=1,
+            flags=re.IGNORECASE,
+        )[0]
+        return [
+            model_id
+            for model_id in re.findall(
+                r"\b(?:gemini|embedding|text-embedding|imagen|veo|lyria)-[A-Za-z0-9_.-]+\b",
+                model_text,
+            )
+            if self._looks_like_model_id(model_id)
+        ]
+
+    def _changelog_item(
+        self, model_id: str, announcement_date: str, shutdown_date: str, context: str
+    ) -> DeprecationItem:
+        return DeprecationItem(
+            provider=self.provider_name,
+            model_id=model_id,
+            announcement_date=announcement_date,
+            shutdown_date=shutdown_date,
+            replacement_models=None,
+            deprecation_context=context,
+            url=f"{self.changelog_url}#{announcement_date.replace('-', '')}",
+        )
+
     def extract_unstructured_deprecations(self, html: str) -> List[DeprecationItem]:
-        """Google AI uses structured changelog, so no unstructured extraction needed."""
+        """Gemini deprecations are extracted from official structured sources."""
         return []

--- a/src/scrapers/openai_scraper.py
+++ b/src/scrapers/openai_scraper.py
@@ -114,13 +114,17 @@ class OpenAIScraper(EnhancedBaseScraper):
         for idx, header in enumerate(header_text):
             if "SHUTDOWN" in header or "EOL" in header:
                 shutdown_idx = idx
+            elif (
+                "REPLACEMENT" in header
+                or "RECOMMENDED" in header
+                or "SUBSTITUTE" in header
+            ):
+                replacement_idx = idx
             elif "DEPRECATED MODEL" in header and "PRICE" not in header:
                 model_idx = idx
             elif ("MODEL" in header or "SYSTEM" in header) and "PRICE" not in header:
                 if model_idx is None:
                     model_idx = idx
-            elif "REPLACEMENT" in header or "RECOMMENDED" in header:
-                replacement_idx = idx
 
         if shutdown_idx is None and model_idx is None and len(header_text) >= 3:
             shutdown_idx = 0
@@ -205,7 +209,7 @@ class OpenAIScraper(EnhancedBaseScraper):
 
     def _parse_markdown_replacements(self, replacement_cell: str) -> list[str] | None:
         """Parse replacement model IDs from markdown cell text."""
-        if not replacement_cell or replacement_cell in {"—", "-", "N/A"}:
+        if not replacement_cell or replacement_cell.strip() in {"—", "-", "---", "N/A"}:
             return None
 
         code_spans = [

--- a/tests/fixtures/google_deprecations.html
+++ b/tests/fixtures/google_deprecations.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html>
+  <body>
+    <article>
+      <h1>Gemini deprecations</h1>
+      <h2 id="gemini-2-5-pro">Gemini 2.5 Pro</h2>
+      <table>
+        <tr><th>Model</th><th>Release date</th><th>Shutdown date</th><th>Recommended replacement</th></tr>
+        <tr><td>gemini-3.1-pro-preview</td><td>February 19, 2026</td><td>No shutdown date announced</td><td></td></tr>
+        <tr><td>gemini-2.5-pro</td><td>June 17, 2025</td><td>June 17, 2026</td><td>gemini-3.1-pro-preview</td></tr>
+        <tr><td>gemini-2.5-pro-preview-05-06</td><td>May 6, 2025</td><td>December 2, 2025</td><td>gemini-3.1-pro-preview</td></tr>
+      </table>
+      <h2 id="image-generation">Image generation</h2>
+      <table>
+        <tr><th>Model</th><th>Release date</th><th>Shutdown date</th><th>Recommended replacement</th></tr>
+        <tr><td>imagen-4.0-generate-001</td><td>June 24, 2025</td><td>June 24, 2026</td><td>gemini-3-pro-image-preview or gemini-2.5-flash-image</td></tr>
+        <tr><td>veo-3.0-generate-001</td><td>September 9, 2025</td><td>Coming soon</td><td>veo-3.1-generate-preview</td></tr>
+        <tr><td>Preview models</td></tr>
+      </table>
+    </article>
+  </body>
+</html>

--- a/tests/test_google_scraper.py
+++ b/tests/test_google_scraper.py
@@ -5,116 +5,61 @@ from pathlib import Path
 from src.scrapers.google_scraper import GoogleScraper
 
 
-def test_extracts_models_with_proper_separation():
-    """Each model ID should be extracted separately, not concatenated."""
-    fixture_path = Path(__file__).parent / "fixtures" / "google_changelog.html"
-    html_content = fixture_path.read_text()
+def load_fixture() -> str:
+    fixture_path = Path(__file__).parent / "fixtures" / "google_deprecations.html"
+    return fixture_path.read_text()
 
+
+def test_extracts_only_rows_with_concrete_shutdown_dates():
+    """Rows without dated shutdowns are lifecycle notes, not feed items."""
     scraper = GoogleScraper()
-    items = scraper.extract_structured_deprecations(html_content)
+    items = scraper.extract_structured_deprecations(load_fixture())
+    model_ids = {item.model_id for item in items}
 
-    model_ids = [item.model_id for item in items]
+    assert model_ids == {
+        "gemini-2.5-pro",
+        "gemini-2.5-pro-preview-05-06",
+        "imagen-4.0-generate-001",
+    }
+    assert "gemini-3.1-pro-preview" not in model_ids
+    assert "veo-3.0-generate-001" not in model_ids
 
-    assert len(model_ids) > 0, "Should extract at least one model"
 
-    for model_id in model_ids:
-        # Models should not have concatenated gemini/veo/imagen names
-        if "gemini" in model_id:
-            assert model_id.count("gemini") == 1, (
-                f"Model ID '{model_id}' appears to be concatenated"
-            )
-        if "veo" in model_id:
-            assert model_id.count("veo") == 1, (
-                f"Model ID '{model_id}' appears to be concatenated"
-            )
-        if "imagen" in model_id:
-            assert model_id.count("imagen") == 1, (
-                f"Model ID '{model_id}' appears to be concatenated"
-            )
+def test_extracts_shutdown_dates_and_replacements():
+    """Google deprecation table fields should map cleanly to output fields."""
+    scraper = GoogleScraper()
+    items = {
+        item.model_id: item
+        for item in scraper.extract_structured_deprecations(load_fixture())
+    }
 
-    expected_models = [
-        "gemini-2.5-flash-lite-preview-06-17",
-        "gemini-2.5-flash-preview-05-20",
+    assert items["gemini-2.5-pro"].shutdown_date == "2026-06-17"
+    assert items["gemini-2.5-pro"].replacement_models == ["gemini-3.1-pro-preview"]
+    assert items["imagen-4.0-generate-001"].replacement_models == [
+        "gemini-3-pro-image-preview",
+        "gemini-2.5-flash-image",
     ]
 
-    for expected_model in expected_models:
-        assert expected_model in model_ids, (
-            f"Expected model '{expected_model}' not found in results"
-        )
 
-
-def test_creates_separate_deprecation_items_for_each_model():
-    """Each model should get its own DeprecationItem."""
-    fixture_path = Path(__file__).parent / "fixtures" / "google_changelog.html"
-    html_content = fixture_path.read_text()
-
+def test_preserves_table_section_context_and_url():
+    """Context should identify the source table without changelog noise."""
     scraper = GoogleScraper()
-    items = scraper.extract_structured_deprecations(html_content)
+    items = {
+        item.model_id: item
+        for item in scraper.extract_structured_deprecations(load_fixture())
+    }
 
-    nov_4_items = [item for item in items if item.announcement_date == "2025-11-04"]
-
-    assert len(nov_4_items) >= 2, (
-        f"Expected at least 2 items from Nov 4, got {len(nov_4_items)}"
-    )
-
-    nov_4_model_ids = [item.model_id for item in nov_4_items]
-    assert len(nov_4_model_ids) == len(set(nov_4_model_ids)), (
-        "Model IDs should be unique"
-    )
+    pro_item = items["gemini-2.5-pro"]
+    assert "Gemini deprecations table: Gemini 2.5 Pro" in pro_item.deprecation_context
+    assert pro_item.url.endswith("#gemini-2-5-pro")
 
 
-def test_extracts_model_ids_correctly():
-    """Model IDs should be properly formatted and not concatenated."""
-    fixture_path = Path(__file__).parent / "fixtures" / "google_changelog.html"
-    html_content = fixture_path.read_text()
-
+def test_model_ids_are_not_concatenated():
+    """Each table row should create a clean single model ID."""
     scraper = GoogleScraper()
-    items = scraper.extract_structured_deprecations(html_content)
+    items = scraper.extract_structured_deprecations(load_fixture())
 
     for item in items:
-        assert len(item.model_id) < 100, (
-            f"Model ID '{item.model_id}' appears to be concatenated"
-        )
-
-        if "gemini" in item.model_id:
-            assert item.model_id.count("gemini") == 1, (
-                f"Model ID '{item.model_id}' has duplicate 'gemini'"
-            )
-
-
-def test_handles_code_tags_in_lists():
-    """Model IDs in <code> tags within <li> should be extracted separately."""
-    fixture_path = Path(__file__).parent / "fixtures" / "google_changelog.html"
-    html_content = fixture_path.read_text()
-
-    scraper = GoogleScraper()
-    items = scraper.extract_structured_deprecations(html_content)
-
-    model_ids = [item.model_id for item in items]
-
-    assert "gemini-2.5-flash-lite-preview-06-17" in model_ids
-    assert "gemini-2.5-flash-preview-05-20" in model_ids
-
-
-def test_preserves_deprecation_context():
-    """Context should be preserved for each model without concatenation."""
-    fixture_path = Path(__file__).parent / "fixtures" / "google_changelog.html"
-    html_content = fixture_path.read_text()
-
-    scraper = GoogleScraper()
-    items = scraper.extract_structured_deprecations(html_content)
-
-    # Filter to items that were extracted from code tags (not fallback patterns)
-    code_based_items = [
-        item
-        for item in items
-        if any(
-            keyword in item.deprecation_context.lower()
-            for keyword in ["deprecated", "will be deprecated"]
-        )
-    ]
-
-    for item in code_based_items:
-        assert len(item.deprecation_context) > 0, (
-            f"Model {item.model_id} has no context"
-        )
+        assert len(item.model_id) < 100
+        assert item.model_id.count("gemini") <= 1
+        assert item.model_id.count("imagen") <= 1

--- a/tests/test_markdown_scrapers.py
+++ b/tests/test_markdown_scrapers.py
@@ -57,6 +57,29 @@ def test_openai_extracts_aliases_and_strips_replacement_footnotes():
         assert item.replacement_models == ["gpt-5", "gpt-4.1"]
 
 
+def test_openai_extracts_escaped_pipe_aliases_and_substitute_models():
+    """OpenAI markdown tables can use escaped pipes and Substitute model headers."""
+    markdown = """
+# Deprecations
+
+## Deprecation history
+
+### 2026-04-22: Legacy GPT model snapshots
+
+| Shutdown date | Model snapshot | Substitute model |
+| ------------- | -------------- | ---------------- |
+| 2026-10-23 | `gpt-4-0613` \\| `gpt-4`, `gpt-4-completions` | `gpt-4.1` |
+"""
+
+    items = OpenAIScraper().extract_structured_deprecations(markdown)
+    by_model = {item.model_id: item for item in items}
+
+    assert set(by_model) == {"gpt-4-0613", "gpt-4", "gpt-4-completions"}
+    for item in by_model.values():
+        assert item.shutdown_date == "2026-10-23"
+        assert item.replacement_models == ["gpt-4.1"]
+
+
 def test_anthropic_extracts_from_markdown_history():
     """Anthropic markdown history tables should produce correct dates and replacements."""
     markdown = """
@@ -86,6 +109,31 @@ On October 28, 2025, Anthropic notified developers using Claude Sonnet 3.7 model
     assert items[0].announcement_date == "2025-10-28"
     assert items[0].shutdown_date == "2026-02-19"
     assert items[0].replacement_models == ["claude-opus-4-6"]
+
+
+def test_cohere_detects_readme_style_markdown_preamble():
+    """ReadMe markdown can start with advisory blockquotes before the H1."""
+    markdown = """
+> For clean Markdown of any page, append .md to the page URL.
+> For a complete documentation index, see https://docs.cohere.com/llms.txt.
+
+# Deprecations
+
+### 2026-04-04: Embed v2.0, Aya Expanse 8B
+
+Effective April 4th, 2026, the following models will be retired:
+
+* `embed-english-v2.0`
+
+* Embedding tasks alternatives:
+  * `embed-v4.0`
+"""
+
+    items = CohereScraper().extract_structured_deprecations(markdown)
+
+    assert len(items) == 1
+    assert items[0].model_id == "embed-english-v2.0"
+    assert items[0].replacement_models == ["embed-v4.0"]
 
 
 def test_cohere_extracts_concrete_models_without_llm():


### PR DESCRIPTION
## Summary
- Fix provider scraper correctness issues found during the manual source audit.
- Regenerate `data.json` and `docs/v1/*` from the corrected scrapers.
- Move Google primary source to the official Gemini deprecations table while still mining explicit historical changelog-only notices.
- Keep Azure collapsed at provider/model grain and explicitly ignore the fine-tuned-model lifecycle table.

## Expected vs generated counts

| Provider | Before | Expected from source after fix | After | Notes |
|---|---:|---:|---:|---|
| OpenAI | 106 | 121 | 121 | Escaped-pipe aliases included; `Substitute model` replacements parsed. |
| Anthropic | 18 | 18 | 18 | No scraper change; still matches source. |
| Google | 45 | 53 | 53 | 36 dated lifecycle table rows + 17 explicit changelog-only historical notices; 3 false positives removed. |
| Google Vertex | 8 | 8 | 8 | No scraper change; still matches source. |
| AWS Bedrock | 22 | 22 | 22 | No scraper change; still matches source. |
| Cohere | 0 | 13 | 13 | ReadMe `.md` page parsed correctly. |
| xAI | 0 | 0 | 0 | No explicit model-level deprecations found. |
| Azure | 77 | 91 | 91 | Current source rows collapsed to provider/model grain; fine-tune lifecycle table excluded. |
| **Total** | **276** | **326** | **326** |  |

## Notable data differences
- **OpenAI:** adds 15 alias model IDs from escaped-pipe rows and backfills replacement models for 40 rows.
- **Google:** removes false positives: `gemini-2.5-flash-native-audio-preview-09-2025`, `gemini-embedding-2-preview`, `gemini-robotics-er-1.6-preview`.
- **Google:** backfills shutdown dates/replacements from the official deprecations table while keeping explicit older changelog notices that are absent from that table.
- **Cohere:** restores 13 model deprecations from `https://docs.cohere.com/docs/deprecations.md`.
- **Azure:** adds current source rows discovered since `main`, while dropping fine-tune lifecycle rows from base-model deprecation semantics.

## Testing
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest -q` (`74 passed`)
- `SCRAPE_STATUS_FILE=$(mktemp) uv run python -m src.main` (`326 deprecations`, all feeds generated)
