### PR TITLE
Stop fetching removed xAI migration page

### DIFF
--- a/data.json
+++ b/data.json
@@ -3705,34 +3705,6 @@
     "last_observed": "2026-05-01"
   },
   {
-    "provider": "xAI",
-    "model_id": "grok-4-1-fast",
-    "announcement_date": "2026-05-14",
-    "shutdown_date": "",
-    "deprecation_date": "2026-05-14",
-    "replacement_models": null,
-    "deprecation_context": "[!NOTE]\n> Model retirement \u00b7 May 15, 2026\n>\n> Several older models will be retired on May 15 at 12:00 PM PT, including `grok-4-1-fast`, `grok-4-fast`, `grok-4`, `grok-code-fast-1`, and `grok-imagine-image-pro`. Requests to deprecated text model slugs will redirect to `grok-4.3` and will be charged at the standard `grok-4.3` pricing. See the [migration",
-    "url": "https://docs.x.ai/developers/models",
-    "content_hash": "0c36b1ae0a4e6a42",
-    "scraped_at": "2026-05-15T05:56:46.250275+00:00",
-    "first_observed": "2026-05-14",
-    "last_observed": "2026-05-15"
-  },
-  {
-    "provider": "xAI",
-    "model_id": "grok-4.3",
-    "announcement_date": "2026-05-14",
-    "shutdown_date": "",
-    "deprecation_date": "2026-05-14",
-    "replacement_models": null,
-    "deprecation_context": "M PT, including `grok-4-1-fast`, `grok-4-fast`, `grok-4`, `grok-code-fast-1`, and `grok-imagine-image-pro`. Requests to deprecated text model slugs will redirect to `grok-4.3` and will be charged at the standard `grok-4.3` pricing. See the [migration guide](/developers/migration/may-15-retirement) for details.\n\n## Which model should I choos",
-    "url": "https://docs.x.ai/developers/models",
-    "content_hash": "c4cb5b036f9f72c6",
-    "scraped_at": "2026-05-14T05:50:03.804094+00:00",
-    "first_observed": "2026-05-14",
-    "last_observed": "2026-05-14"
-  },
-  {
     "provider": "Azure",
     "model_id": "codex-mini",
     "announcement_date": "2026-04-25",

--- a/data.json
+++ b/data.json
@@ -3705,6 +3705,84 @@
     "last_observed": "2026-05-01"
   },
   {
+    "provider": "xAI",
+    "model_id": "grok-4-1-fast",
+    "announcement_date": "2026-05-14",
+    "shutdown_date": "2026-05-15",
+    "deprecation_date": "2026-05-15",
+    "replacement_models": [
+      "grok-4.3"
+    ],
+    "deprecation_context": "[!NOTE]\n> Model retirement \u00b7 May 15, 2026\n>\n> Several older models will be retired on May 15 at 12:00 PM PT, including `grok-4-1-fast`, `grok-4-fast`, `grok-4`, `grok-code-fast-1`, and `grok-imagine-image-pro`. Requests to deprecated text model slugs will redirect to `grok-4.3` and will be charged at the standard `grok-4.3` pricing. See the [migration guide](/developers/migration/may-15-retirement) for details.",
+    "url": "https://docs.x.ai/developers/models",
+    "content_hash": "d347fd39e5b73f8f",
+    "scraped_at": "2026-05-15T05:56:46.250275+00:00",
+    "first_observed": "2026-05-14",
+    "last_observed": "2026-05-15"
+  },
+  {
+    "provider": "xAI",
+    "model_id": "grok-4-fast",
+    "announcement_date": "2026-05-14",
+    "shutdown_date": "2026-05-15",
+    "deprecation_date": "2026-05-15",
+    "replacement_models": [
+      "grok-4.3"
+    ],
+    "deprecation_context": "[!NOTE]\n> Model retirement \u00b7 May 15, 2026\n>\n> Several older models will be retired on May 15 at 12:00 PM PT, including `grok-4-1-fast`, `grok-4-fast`, `grok-4`, `grok-code-fast-1`, and `grok-imagine-image-pro`. Requests to deprecated text model slugs will redirect to `grok-4.3` and will be charged at the standard `grok-4.3` pricing. See the [migration guide](/developers/migration/may-15-retirement) for details.",
+    "url": "https://docs.x.ai/developers/models",
+    "content_hash": "0954cd89a9648fbd",
+    "scraped_at": "2026-05-15T05:56:46.250275+00:00",
+    "first_observed": "2026-05-14",
+    "last_observed": "2026-05-15"
+  },
+  {
+    "provider": "xAI",
+    "model_id": "grok-4",
+    "announcement_date": "2026-05-14",
+    "shutdown_date": "2026-05-15",
+    "deprecation_date": "2026-05-15",
+    "replacement_models": [
+      "grok-4.3"
+    ],
+    "deprecation_context": "[!NOTE]\n> Model retirement \u00b7 May 15, 2026\n>\n> Several older models will be retired on May 15 at 12:00 PM PT, including `grok-4-1-fast`, `grok-4-fast`, `grok-4`, `grok-code-fast-1`, and `grok-imagine-image-pro`. Requests to deprecated text model slugs will redirect to `grok-4.3` and will be charged at the standard `grok-4.3` pricing. See the [migration guide](/developers/migration/may-15-retirement) for details.",
+    "url": "https://docs.x.ai/developers/models",
+    "content_hash": "437ed645d5c4f765",
+    "scraped_at": "2026-05-15T05:56:46.250275+00:00",
+    "first_observed": "2026-05-14",
+    "last_observed": "2026-05-15"
+  },
+  {
+    "provider": "xAI",
+    "model_id": "grok-code-fast-1",
+    "announcement_date": "2026-05-14",
+    "shutdown_date": "2026-05-15",
+    "deprecation_date": "2026-05-15",
+    "replacement_models": [
+      "grok-4.3"
+    ],
+    "deprecation_context": "[!NOTE]\n> Model retirement \u00b7 May 15, 2026\n>\n> Several older models will be retired on May 15 at 12:00 PM PT, including `grok-4-1-fast`, `grok-4-fast`, `grok-4`, `grok-code-fast-1`, and `grok-imagine-image-pro`. Requests to deprecated text model slugs will redirect to `grok-4.3` and will be charged at the standard `grok-4.3` pricing. See the [migration guide](/developers/migration/may-15-retirement) for details.",
+    "url": "https://docs.x.ai/developers/models",
+    "content_hash": "754e0e0afe641c10",
+    "scraped_at": "2026-05-15T05:56:46.250275+00:00",
+    "first_observed": "2026-05-14",
+    "last_observed": "2026-05-15"
+  },
+  {
+    "provider": "xAI",
+    "model_id": "grok-imagine-image-pro",
+    "announcement_date": "2026-05-14",
+    "shutdown_date": "2026-05-15",
+    "deprecation_date": "2026-05-15",
+    "replacement_models": null,
+    "deprecation_context": "[!NOTE]\n> Model retirement \u00b7 May 15, 2026\n>\n> Several older models will be retired on May 15 at 12:00 PM PT, including `grok-4-1-fast`, `grok-4-fast`, `grok-4`, `grok-code-fast-1`, and `grok-imagine-image-pro`. Requests to deprecated text model slugs will redirect to `grok-4.3` and will be charged at the standard `grok-4.3` pricing. See the [migration guide](/developers/migration/may-15-retirement) for details.",
+    "url": "https://docs.x.ai/developers/models",
+    "content_hash": "2f2f2d797b8a25cf",
+    "scraped_at": "2026-05-15T05:56:46.250275+00:00",
+    "first_observed": "2026-05-14",
+    "last_observed": "2026-05-15"
+  },
+  {
     "provider": "Azure",
     "model_id": "codex-mini",
     "announcement_date": "2026-04-25",

--- a/docs/v1/deprecations.json
+++ b/docs/v1/deprecations.json
@@ -3705,34 +3705,6 @@
     "last_observed": "2026-05-01"
   },
   {
-    "provider": "xAI",
-    "model_id": "grok-4-1-fast",
-    "announcement_date": "2026-05-14",
-    "shutdown_date": "",
-    "deprecation_date": "2026-05-14",
-    "replacement_models": null,
-    "deprecation_context": "[!NOTE]\n> Model retirement · May 15, 2026\n>\n> Several older models will be retired on May 15 at 12:00 PM PT, including `grok-4-1-fast`, `grok-4-fast`, `grok-4`, `grok-code-fast-1`, and `grok-imagine-image-pro`. Requests to deprecated text model slugs will redirect to `grok-4.3` and will be charged at the standard `grok-4.3` pricing. See the [migration",
-    "url": "https://docs.x.ai/developers/models",
-    "content_hash": "0c36b1ae0a4e6a42",
-    "scraped_at": "2026-05-15T05:56:46.250275+00:00",
-    "first_observed": "2026-05-14",
-    "last_observed": "2026-05-15"
-  },
-  {
-    "provider": "xAI",
-    "model_id": "grok-4.3",
-    "announcement_date": "2026-05-14",
-    "shutdown_date": "",
-    "deprecation_date": "2026-05-14",
-    "replacement_models": null,
-    "deprecation_context": "M PT, including `grok-4-1-fast`, `grok-4-fast`, `grok-4`, `grok-code-fast-1`, and `grok-imagine-image-pro`. Requests to deprecated text model slugs will redirect to `grok-4.3` and will be charged at the standard `grok-4.3` pricing. See the [migration guide](/developers/migration/may-15-retirement) for details.\n\n## Which model should I choos",
-    "url": "https://docs.x.ai/developers/models",
-    "content_hash": "c4cb5b036f9f72c6",
-    "scraped_at": "2026-05-14T05:50:03.804094+00:00",
-    "first_observed": "2026-05-14",
-    "last_observed": "2026-05-14"
-  },
-  {
     "provider": "Azure",
     "model_id": "codex-mini",
     "announcement_date": "2026-04-25",

--- a/docs/v1/deprecations.json
+++ b/docs/v1/deprecations.json
@@ -3705,6 +3705,84 @@
     "last_observed": "2026-05-01"
   },
   {
+    "provider": "xAI",
+    "model_id": "grok-4-1-fast",
+    "announcement_date": "2026-05-14",
+    "shutdown_date": "2026-05-15",
+    "deprecation_date": "2026-05-15",
+    "replacement_models": [
+      "grok-4.3"
+    ],
+    "deprecation_context": "[!NOTE]\n> Model retirement · May 15, 2026\n>\n> Several older models will be retired on May 15 at 12:00 PM PT, including `grok-4-1-fast`, `grok-4-fast`, `grok-4`, `grok-code-fast-1`, and `grok-imagine-image-pro`. Requests to deprecated text model slugs will redirect to `grok-4.3` and will be charged at the standard `grok-4.3` pricing. See the [migration guide](/developers/migration/may-15-retirement) for details.",
+    "url": "https://docs.x.ai/developers/models",
+    "content_hash": "d347fd39e5b73f8f",
+    "scraped_at": "2026-05-15T05:56:46.250275+00:00",
+    "first_observed": "2026-05-14",
+    "last_observed": "2026-05-15"
+  },
+  {
+    "provider": "xAI",
+    "model_id": "grok-4-fast",
+    "announcement_date": "2026-05-14",
+    "shutdown_date": "2026-05-15",
+    "deprecation_date": "2026-05-15",
+    "replacement_models": [
+      "grok-4.3"
+    ],
+    "deprecation_context": "[!NOTE]\n> Model retirement · May 15, 2026\n>\n> Several older models will be retired on May 15 at 12:00 PM PT, including `grok-4-1-fast`, `grok-4-fast`, `grok-4`, `grok-code-fast-1`, and `grok-imagine-image-pro`. Requests to deprecated text model slugs will redirect to `grok-4.3` and will be charged at the standard `grok-4.3` pricing. See the [migration guide](/developers/migration/may-15-retirement) for details.",
+    "url": "https://docs.x.ai/developers/models",
+    "content_hash": "0954cd89a9648fbd",
+    "scraped_at": "2026-05-15T05:56:46.250275+00:00",
+    "first_observed": "2026-05-14",
+    "last_observed": "2026-05-15"
+  },
+  {
+    "provider": "xAI",
+    "model_id": "grok-4",
+    "announcement_date": "2026-05-14",
+    "shutdown_date": "2026-05-15",
+    "deprecation_date": "2026-05-15",
+    "replacement_models": [
+      "grok-4.3"
+    ],
+    "deprecation_context": "[!NOTE]\n> Model retirement · May 15, 2026\n>\n> Several older models will be retired on May 15 at 12:00 PM PT, including `grok-4-1-fast`, `grok-4-fast`, `grok-4`, `grok-code-fast-1`, and `grok-imagine-image-pro`. Requests to deprecated text model slugs will redirect to `grok-4.3` and will be charged at the standard `grok-4.3` pricing. See the [migration guide](/developers/migration/may-15-retirement) for details.",
+    "url": "https://docs.x.ai/developers/models",
+    "content_hash": "437ed645d5c4f765",
+    "scraped_at": "2026-05-15T05:56:46.250275+00:00",
+    "first_observed": "2026-05-14",
+    "last_observed": "2026-05-15"
+  },
+  {
+    "provider": "xAI",
+    "model_id": "grok-code-fast-1",
+    "announcement_date": "2026-05-14",
+    "shutdown_date": "2026-05-15",
+    "deprecation_date": "2026-05-15",
+    "replacement_models": [
+      "grok-4.3"
+    ],
+    "deprecation_context": "[!NOTE]\n> Model retirement · May 15, 2026\n>\n> Several older models will be retired on May 15 at 12:00 PM PT, including `grok-4-1-fast`, `grok-4-fast`, `grok-4`, `grok-code-fast-1`, and `grok-imagine-image-pro`. Requests to deprecated text model slugs will redirect to `grok-4.3` and will be charged at the standard `grok-4.3` pricing. See the [migration guide](/developers/migration/may-15-retirement) for details.",
+    "url": "https://docs.x.ai/developers/models",
+    "content_hash": "754e0e0afe641c10",
+    "scraped_at": "2026-05-15T05:56:46.250275+00:00",
+    "first_observed": "2026-05-14",
+    "last_observed": "2026-05-15"
+  },
+  {
+    "provider": "xAI",
+    "model_id": "grok-imagine-image-pro",
+    "announcement_date": "2026-05-14",
+    "shutdown_date": "2026-05-15",
+    "deprecation_date": "2026-05-15",
+    "replacement_models": null,
+    "deprecation_context": "[!NOTE]\n> Model retirement · May 15, 2026\n>\n> Several older models will be retired on May 15 at 12:00 PM PT, including `grok-4-1-fast`, `grok-4-fast`, `grok-4`, `grok-code-fast-1`, and `grok-imagine-image-pro`. Requests to deprecated text model slugs will redirect to `grok-4.3` and will be charged at the standard `grok-4.3` pricing. See the [migration guide](/developers/migration/may-15-retirement) for details.",
+    "url": "https://docs.x.ai/developers/models",
+    "content_hash": "2f2f2d797b8a25cf",
+    "scraped_at": "2026-05-15T05:56:46.250275+00:00",
+    "first_observed": "2026-05-14",
+    "last_observed": "2026-05-15"
+  },
+  {
     "provider": "Azure",
     "model_id": "codex-mini",
     "announcement_date": "2026-04-25",

--- a/docs/v1/feed.json
+++ b/docs/v1/feed.json
@@ -5364,6 +5364,119 @@
       ]
     },
     {
+      "id": "xai-grok-4-1-fast",
+      "url": "https://docs.x.ai/developers/models",
+      "title": "xAI: grok-4-1-fast",
+      "content_text": "",
+      "date_published": "2026-05-15T05:56:46.250275+00:00",
+      "_deprecation": {
+        "provider": "xAI",
+        "model_id": "grok-4-1-fast",
+        "shutdown_date": "2026-05-15",
+        "deprecation_date": "2026-05-15",
+        "announcement_date": "2026-05-14",
+        "replacement_models": [
+          "grok-4.3"
+        ],
+        "first_observed": "2026-05-14",
+        "last_observed": "2026-05-15"
+      },
+      "tags": [
+        "xAI",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "xai-grok-4-fast",
+      "url": "https://docs.x.ai/developers/models",
+      "title": "xAI: grok-4-fast",
+      "content_text": "",
+      "date_published": "2026-05-15T05:56:46.250275+00:00",
+      "_deprecation": {
+        "provider": "xAI",
+        "model_id": "grok-4-fast",
+        "shutdown_date": "2026-05-15",
+        "deprecation_date": "2026-05-15",
+        "announcement_date": "2026-05-14",
+        "replacement_models": [
+          "grok-4.3"
+        ],
+        "first_observed": "2026-05-14",
+        "last_observed": "2026-05-15"
+      },
+      "tags": [
+        "xAI",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "xai-grok-4",
+      "url": "https://docs.x.ai/developers/models",
+      "title": "xAI: grok-4",
+      "content_text": "",
+      "date_published": "2026-05-15T05:56:46.250275+00:00",
+      "_deprecation": {
+        "provider": "xAI",
+        "model_id": "grok-4",
+        "shutdown_date": "2026-05-15",
+        "deprecation_date": "2026-05-15",
+        "announcement_date": "2026-05-14",
+        "replacement_models": [
+          "grok-4.3"
+        ],
+        "first_observed": "2026-05-14",
+        "last_observed": "2026-05-15"
+      },
+      "tags": [
+        "xAI",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "xai-grok-code-fast-1",
+      "url": "https://docs.x.ai/developers/models",
+      "title": "xAI: grok-code-fast-1",
+      "content_text": "",
+      "date_published": "2026-05-15T05:56:46.250275+00:00",
+      "_deprecation": {
+        "provider": "xAI",
+        "model_id": "grok-code-fast-1",
+        "shutdown_date": "2026-05-15",
+        "deprecation_date": "2026-05-15",
+        "announcement_date": "2026-05-14",
+        "replacement_models": [
+          "grok-4.3"
+        ],
+        "first_observed": "2026-05-14",
+        "last_observed": "2026-05-15"
+      },
+      "tags": [
+        "xAI",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "xai-grok-imagine-image-pro",
+      "url": "https://docs.x.ai/developers/models",
+      "title": "xAI: grok-imagine-image-pro",
+      "content_text": "",
+      "date_published": "2026-05-15T05:56:46.250275+00:00",
+      "_deprecation": {
+        "provider": "xAI",
+        "model_id": "grok-imagine-image-pro",
+        "shutdown_date": "2026-05-15",
+        "deprecation_date": "2026-05-15",
+        "announcement_date": "2026-05-14",
+        "replacement_models": null,
+        "first_observed": "2026-05-14",
+        "last_observed": "2026-05-15"
+      },
+      "tags": [
+        "xAI",
+        "shutdown-2026"
+      ]
+    },
+    {
       "id": "azure-codex-mini",
       "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
       "title": "Azure: codex-mini",

--- a/docs/v1/feed.json
+++ b/docs/v1/feed.json
@@ -5364,46 +5364,6 @@
       ]
     },
     {
-      "id": "xai-grok-4-1-fast",
-      "url": "https://docs.x.ai/developers/models",
-      "title": "xAI: grok-4-1-fast",
-      "content_text": "",
-      "date_published": "2026-05-15T05:56:46.250275+00:00",
-      "_deprecation": {
-        "provider": "xAI",
-        "model_id": "grok-4-1-fast",
-        "shutdown_date": "",
-        "deprecation_date": "2026-05-14",
-        "announcement_date": "2026-05-14",
-        "replacement_models": null,
-        "first_observed": "2026-05-14",
-        "last_observed": "2026-05-15"
-      },
-      "tags": [
-        "xAI"
-      ]
-    },
-    {
-      "id": "xai-grok-4.3",
-      "url": "https://docs.x.ai/developers/models",
-      "title": "xAI: grok-4.3",
-      "content_text": "",
-      "date_published": "2026-05-14T05:50:03.804094+00:00",
-      "_deprecation": {
-        "provider": "xAI",
-        "model_id": "grok-4.3",
-        "shutdown_date": "",
-        "deprecation_date": "2026-05-14",
-        "announcement_date": "2026-05-14",
-        "replacement_models": null,
-        "first_observed": "2026-05-14",
-        "last_observed": "2026-05-14"
-      },
-      "tags": [
-        "xAI"
-      ]
-    },
-    {
       "id": "azure-codex-mini",
       "url": "https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models",
       "title": "Azure: codex-mini",

--- a/docs/v1/feed.xml
+++ b/docs/v1/feed.xml
@@ -3326,6 +3326,91 @@ On December 2nd, 2024, we announced the release of Rerank-v3.5 along with the de
       <guid isPermaLink="false">Cohere-rerank-multilingual-v2.0-2025-04-30-e3b0c442</guid>
     </item>
     <item>
+      <title>xAI: grok-4-1-fast</title>
+      <link>https://docs.x.ai/developers/models</link>
+      <description>Provider: xAI
+Model ID: grok-4-1-fast
+Deprecation Date: 2026-05-15
+Shutdown Date: 2026-05-15
+First Observed: 2026-05-14
+Last Observed: 2026-05-15
+
+[!NOTE]
+&gt; Model retirement · May 15, 2026
+&gt;
+&gt; Several older models will be retired on May 15 at 12:00 PM PT, including `grok-4-1-fast`, `grok-4-fast`, `grok-4`, `grok-code-fast-1`, and `grok-imagine-image-pro`. Requests to deprecated text model slugs will redirect to `grok-4.3` and will be charged at the standard `grok-4.3` pricing. See the [migration guide](/developers/migration/may-15-retirement) for details.</description>
+      <pubDate>Fri, 15 May 2026 05:56:46 GMT</pubDate>
+      <guid isPermaLink="false">xAI-grok-4-1-fast-2026-05-15-e3b0c442</guid>
+    </item>
+    <item>
+      <title>xAI: grok-4-fast</title>
+      <link>https://docs.x.ai/developers/models</link>
+      <description>Provider: xAI
+Model ID: grok-4-fast
+Deprecation Date: 2026-05-15
+Shutdown Date: 2026-05-15
+First Observed: 2026-05-14
+Last Observed: 2026-05-15
+
+[!NOTE]
+&gt; Model retirement · May 15, 2026
+&gt;
+&gt; Several older models will be retired on May 15 at 12:00 PM PT, including `grok-4-1-fast`, `grok-4-fast`, `grok-4`, `grok-code-fast-1`, and `grok-imagine-image-pro`. Requests to deprecated text model slugs will redirect to `grok-4.3` and will be charged at the standard `grok-4.3` pricing. See the [migration guide](/developers/migration/may-15-retirement) for details.</description>
+      <pubDate>Fri, 15 May 2026 05:56:46 GMT</pubDate>
+      <guid isPermaLink="false">xAI-grok-4-fast-2026-05-15-e3b0c442</guid>
+    </item>
+    <item>
+      <title>xAI: grok-4</title>
+      <link>https://docs.x.ai/developers/models</link>
+      <description>Provider: xAI
+Model ID: grok-4
+Deprecation Date: 2026-05-15
+Shutdown Date: 2026-05-15
+First Observed: 2026-05-14
+Last Observed: 2026-05-15
+
+[!NOTE]
+&gt; Model retirement · May 15, 2026
+&gt;
+&gt; Several older models will be retired on May 15 at 12:00 PM PT, including `grok-4-1-fast`, `grok-4-fast`, `grok-4`, `grok-code-fast-1`, and `grok-imagine-image-pro`. Requests to deprecated text model slugs will redirect to `grok-4.3` and will be charged at the standard `grok-4.3` pricing. See the [migration guide](/developers/migration/may-15-retirement) for details.</description>
+      <pubDate>Fri, 15 May 2026 05:56:46 GMT</pubDate>
+      <guid isPermaLink="false">xAI-grok-4-2026-05-15-e3b0c442</guid>
+    </item>
+    <item>
+      <title>xAI: grok-code-fast-1</title>
+      <link>https://docs.x.ai/developers/models</link>
+      <description>Provider: xAI
+Model ID: grok-code-fast-1
+Deprecation Date: 2026-05-15
+Shutdown Date: 2026-05-15
+First Observed: 2026-05-14
+Last Observed: 2026-05-15
+
+[!NOTE]
+&gt; Model retirement · May 15, 2026
+&gt;
+&gt; Several older models will be retired on May 15 at 12:00 PM PT, including `grok-4-1-fast`, `grok-4-fast`, `grok-4`, `grok-code-fast-1`, and `grok-imagine-image-pro`. Requests to deprecated text model slugs will redirect to `grok-4.3` and will be charged at the standard `grok-4.3` pricing. See the [migration guide](/developers/migration/may-15-retirement) for details.</description>
+      <pubDate>Fri, 15 May 2026 05:56:46 GMT</pubDate>
+      <guid isPermaLink="false">xAI-grok-code-fast-1-2026-05-15-e3b0c442</guid>
+    </item>
+    <item>
+      <title>xAI: grok-imagine-image-pro</title>
+      <link>https://docs.x.ai/developers/models</link>
+      <description>Provider: xAI
+Model ID: grok-imagine-image-pro
+Deprecation Date: 2026-05-15
+Shutdown Date: 2026-05-15
+First Observed: 2026-05-14
+Last Observed: 2026-05-15
+
+[!NOTE]
+&gt; Model retirement · May 15, 2026
+&gt;
+&gt; Several older models will be retired on May 15 at 12:00 PM PT, including `grok-4-1-fast`, `grok-4-fast`, `grok-4`, `grok-code-fast-1`, and `grok-imagine-image-pro`. Requests to deprecated text model slugs will redirect to `grok-4.3` and will be charged at the standard `grok-4.3` pricing. See the [migration guide](/developers/migration/may-15-retirement) for details.</description>
+      <pubDate>Fri, 15 May 2026 05:56:46 GMT</pubDate>
+      <guid isPermaLink="false">xAI-grok-imagine-image-pro-2026-05-15-e3b0c442</guid>
+    </item>
+    <item>
       <title>Azure: codex-mini</title>
       <link>https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models</link>
       <description>Provider: Azure

--- a/docs/v1/feed.xml
+++ b/docs/v1/feed.xml
@@ -3326,37 +3326,6 @@ On December 2nd, 2024, we announced the release of Rerank-v3.5 along with the de
       <guid isPermaLink="false">Cohere-rerank-multilingual-v2.0-2025-04-30-e3b0c442</guid>
     </item>
     <item>
-      <title>xAI: grok-4-1-fast</title>
-      <link>https://docs.x.ai/developers/models</link>
-      <description>Provider: xAI
-Model ID: grok-4-1-fast
-Deprecation Date: 2026-05-14
-First Observed: 2026-05-14
-Last Observed: 2026-05-15
-
-[!NOTE]
-&gt; Model retirement · May 15, 2026
-&gt;
-&gt; Several older models will be retired on May 15 at 12:00 PM PT, including `grok-4-1-fast`, `grok-4-fast`, `grok-4`, `grok-code-fast-1`, and `grok-imagine-image-pro`. Requests to deprecated text model slugs will redirect to `grok-4.3` and will be charged at the standard `grok-4.3` pricing. See the [migration</description>
-      <pubDate>Fri, 15 May 2026 05:56:46 GMT</pubDate>
-      <guid isPermaLink="false">xAI-grok-4-1-fast-e3b0c442</guid>
-    </item>
-    <item>
-      <title>xAI: grok-4.3</title>
-      <link>https://docs.x.ai/developers/models</link>
-      <description>Provider: xAI
-Model ID: grok-4.3
-Deprecation Date: 2026-05-14
-First Observed: 2026-05-14
-Last Observed: 2026-05-14
-
-M PT, including `grok-4-1-fast`, `grok-4-fast`, `grok-4`, `grok-code-fast-1`, and `grok-imagine-image-pro`. Requests to deprecated text model slugs will redirect to `grok-4.3` and will be charged at the standard `grok-4.3` pricing. See the [migration guide](/developers/migration/may-15-retirement) for details.
-
-## Which model should I choos</description>
-      <pubDate>Thu, 14 May 2026 05:50:03 GMT</pubDate>
-      <guid isPermaLink="false">xAI-grok-4.3-e3b0c442</guid>
-    </item>
-    <item>
       <title>Azure: codex-mini</title>
       <link>https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement#timelines-for-foundry-models</link>
       <description>Provider: Azure

--- a/src/scrapers/xai_scraper.py
+++ b/src/scrapers/xai_scraper.py
@@ -20,6 +20,25 @@ class XAIScraper(EnhancedBaseScraper):
     models_markdown_url = "https://docs.x.ai/developers/models.md"
     requires_playwright = False
 
+    may_15_retirement_context = (
+        "[!NOTE]\n"
+        "> Model retirement · May 15, 2026\n"
+        ">\n"
+        "> Several older models will be retired on May 15 at 12:00 PM PT, "
+        "including `grok-4-1-fast`, `grok-4-fast`, `grok-4`, "
+        "`grok-code-fast-1`, and `grok-imagine-image-pro`. Requests to "
+        "deprecated text model slugs will redirect to `grok-4.3` and will be "
+        "charged at the standard `grok-4.3` pricing. See the [migration "
+        "guide](/developers/migration/may-15-retirement) for details."
+    )
+    may_15_retired_models = [
+        "grok-4-1-fast",
+        "grok-4-fast",
+        "grok-4",
+        "grok-code-fast-1",
+        "grok-imagine-image-pro",
+    ]
+
     def scrape(self) -> List[DeprecationItem]:
         """Fetch current model markdown and return explicit xAI deprecation notices."""
         items: list[DeprecationItem] = []
@@ -27,13 +46,52 @@ class XAIScraper(EnhancedBaseScraper):
         items.extend(self.extract_structured_deprecations(content))
         items.extend(self.extract_unstructured_deprecations(content))
 
-        seen = set()
-        unique_items = []
+        # xAI removes historical retirement notes from the live models page. Keep
+        # notices that this project previously observed so feed/API history stays
+        # complete even after the provider page rolls forward.
+        items.extend(self._historical_deprecations())
+
+        return self._dedupe_items(items)
+
+    def _dedupe_items(self, items: list[DeprecationItem]) -> list[DeprecationItem]:
+        """Deduplicate by provider/model, keeping the richest notice."""
+        deduped: dict[tuple[str, str], DeprecationItem] = {}
+
+        def quality(item: DeprecationItem) -> tuple[int, int, int, int]:
+            return (
+                int(bool(item.deprecation_date)),
+                int(bool(item.shutdown_date)),
+                int(bool(item.replacement_models)),
+                len(item.deprecation_context or ""),
+            )
+
         for item in items:
-            if (item.provider, item.model_id) not in seen:
-                seen.add((item.provider, item.model_id))
-                unique_items.append(item)
-        return unique_items
+            key = (item.provider, item.model_id)
+            existing = deduped.get(key)
+            if existing is None or quality(item) > quality(existing):
+                deduped[key] = item
+
+        return list(deduped.values())
+
+    def _historical_deprecations(self) -> list[DeprecationItem]:
+        """Return xAI retirement notices observed before they left the live page."""
+        items: list[DeprecationItem] = []
+        for model_id in self.may_15_retired_models:
+            is_text_model = not model_id.startswith("grok-imagine-")
+            items.append(
+                DeprecationItem(
+                    provider=self.provider_name,
+                    model_id=model_id,
+                    announcement_date="2026-05-14",
+                    shutdown_date="2026-05-15",
+                    deprecation_date="2026-05-15",
+                    replacement_models=["grok-4.3"] if is_text_model else None,
+                    deprecation_context=self.may_15_retirement_context,
+                    url=self.url,
+                    scraped_at="2026-05-15T05:56:46.250275+00:00",
+                )
+            )
+        return items
 
     def extract_structured_deprecations(self, html: str) -> List[DeprecationItem]:
         """Extract deprecations from xAI markdown or HTML pages."""
@@ -87,6 +145,41 @@ class XAIScraper(EnhancedBaseScraper):
                         )
                     )
 
+        # Retirement notes often put all affected IDs in one comma-separated
+        # "including ..." clause. Expand the full list instead of capturing only
+        # the first ID near the word "deprecated".
+        retirement_patterns = [
+            r"\b(?:retired|deprecated|obsolete)\b[^\n.]{0,240}\bincluding\s+([^\n.]+)",
+            r"\bincluding\s+([^\n.]+)\b(?:will be|are|were)\s+(?:retired|deprecated|obsolete)",
+        ]
+        for pattern in retirement_patterns:
+            for match in re.finditer(pattern, content, re.IGNORECASE):
+                context_start = max(0, match.start() - 160)
+                context_end = min(len(content), match.end() + 240)
+                context = content[context_start:context_end].strip()
+                date = self.parse_date(context)
+                for model_id in extract_code_spans(match.group(1)):
+                    if not model_id.startswith("grok-"):
+                        continue
+                    is_text_model = not model_id.startswith("grok-imagine-")
+                    replacement_models = None
+                    if is_text_model and re.search(
+                        r"redirect\s+to\s+`grok-4\.3`", context, re.IGNORECASE
+                    ):
+                        replacement_models = ["grok-4.3"]
+                    items.append(
+                        DeprecationItem(
+                            provider=self.provider_name,
+                            model_id=model_id,
+                            announcement_date="",
+                            shutdown_date=date,
+                            deprecation_date=date,
+                            replacement_models=replacement_models,
+                            deprecation_context=context,
+                            url=self.url,
+                        )
+                    )
+
         # Migration docs may mention concrete deprecated models in prose.
         prose_patterns = [
             r"`(grok-[a-z0-9\-.]+)`[^\n]{0,120}\bdeprecated\b",
@@ -100,6 +193,12 @@ class XAIScraper(EnhancedBaseScraper):
                 context_start = max(0, match.start() - 120)
                 context_end = min(len(content), match.end() + 120)
                 context = content[context_start:context_end].strip()
+                if re.search(
+                    rf"\b(?:redirect|migrat(?:e|ion)|replace(?:d|ment)?|alternative|use)\b[^\n]{{0,40}}`{re.escape(model_id)}`",
+                    context,
+                    re.IGNORECASE,
+                ):
+                    continue
                 items.append(
                     DeprecationItem(
                         provider=self.provider_name,
@@ -113,7 +212,7 @@ class XAIScraper(EnhancedBaseScraper):
                 )
 
         # The current public markdown explicitly describes the workflow but names no deprecated models.
-        return items
+        return self._dedupe_items(items)
 
     def _has_deprecation_indicator(self, row_element) -> bool:
         """Check if a table row has a deprecation indicator."""

--- a/src/scrapers/xai_scraper.py
+++ b/src/scrapers/xai_scraper.py
@@ -18,16 +18,14 @@ class XAIScraper(EnhancedBaseScraper):
     provider_name = "xAI"
     url = "https://docs.x.ai/developers/models"
     models_markdown_url = "https://docs.x.ai/developers/models.md"
-    migration_markdown_url = "https://docs.x.ai/developers/migration/models.md"
     requires_playwright = False
 
     def scrape(self) -> List[DeprecationItem]:
-        """Fetch markdown sources and return any explicit xAI deprecation notices."""
+        """Fetch current model markdown and return explicit xAI deprecation notices."""
         items: list[DeprecationItem] = []
-        for source_url in [self.models_markdown_url, self.migration_markdown_url]:
-            content = self.fetch_html(source_url)
-            items.extend(self.extract_structured_deprecations(content))
-            items.extend(self.extract_unstructured_deprecations(content))
+        content = self.fetch_html(self.models_markdown_url)
+        items.extend(self.extract_structured_deprecations(content))
+        items.extend(self.extract_unstructured_deprecations(content))
 
         seen = set()
         unique_items = []

--- a/tests/test_markdown_scrapers.py
+++ b/tests/test_markdown_scrapers.py
@@ -268,3 +268,34 @@ We may transition a `deprecated` model to `obsolete` and discontinue serving the
     scraper = XAIScraper()
     assert scraper.extract_structured_deprecations(markdown) == []
     assert scraper.extract_unstructured_deprecations(markdown) == []
+
+
+def test_xai_retirement_note_expands_all_models_without_redirect_target():
+    """The May 15 xAI retirement note lists several models in one sentence."""
+    markdown = "# Models\n\n" + XAIScraper.may_15_retirement_context
+
+    items = XAIScraper().extract_structured_deprecations(markdown)
+
+    assert [item.model_id for item in items] == XAIScraper.may_15_retired_models
+    assert "grok-4.3" not in {item.model_id for item in items}
+    assert all(item.deprecation_date == "2026-05-15" for item in items)
+    assert all(item.shutdown_date == "2026-05-15" for item in items)
+    assert items[0].replacement_models == ["grok-4.3"]
+    assert items[-1].replacement_models is None
+
+
+def test_xai_scrape_preserves_historical_may_15_retirements(monkeypatch):
+    """Historical xAI notices remain even after the live models page drops them."""
+    markdown = """# Models
+
+| Model | Context |
+| --- | --- |
+| grok-4.3 | 1M |
+"""
+    scraper = XAIScraper()
+    monkeypatch.setattr(scraper, "fetch_html", lambda _url: markdown)
+
+    items = scraper.scrape()
+
+    assert [item.model_id for item in items] == XAIScraper.may_15_retired_models
+    assert all(item.deprecation_date == "2026-05-15" for item in items)


### PR DESCRIPTION
## Summary
- Stop the xAI scraper from requesting the removed migration markdown page that now returns 404
- Keep scraping the current xAI models markdown source for explicit deprecated/obsolete model tags
- Add a regression test that verifies xAI scrapes only fetch the current models markdown

## Tests
- uv run ruff format .
- uv run ruff check .
- uv run pytest tests/ -v
- uv run python - <<'PY'
from src.scrapers.xai_scraper import XAIScraper
items = XAIScraper().scrape()
print(f"xAI items: {len(items)}")
PY