### PR TITLE
Add Groq provider scraper

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -8,7 +8,7 @@ run:
     uv run python -m src.main
 
 server:
-    cd docs && python -m http.server {{port}}
+    cd docs && uv run python -m http.server {{port}}
 
 test:
     uv run pytest .

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ We check these pages daily:
 - [Google Vertex AI Deprecations](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/deprecations/partner-models)
 - [AWS Bedrock Model Lifecycle](https://docs.aws.amazon.com/bedrock/latest/userguide/model-lifecycle.html)
 - [Cohere Deprecations](https://docs.cohere.com/docs/deprecations)
+- [Groq Model Deprecations](https://console.groq.com/docs/deprecations)
 - [xAI Models](https://docs.x.ai/docs/models)
 - [Azure AI Foundry Retirements](https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/model-lifecycle-retirement)
 

--- a/data.json
+++ b/data.json
@@ -3705,6 +3705,526 @@
     "last_observed": "2026-05-01"
   },
   {
+    "provider": "Groq",
+    "model_id": "moonshotai/kimi-k2-instruct-0905",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2026-04-15",
+    "deprecation_date": "2026-03-23",
+    "replacement_models": [
+      "openai/gpt-oss-120b"
+    ],
+    "deprecation_context": "In line with our commitment to bringing you cutting-edge models, on March 23, 2026, we emailed users to announce the deprecation of `moonshotai/kimi-k2-instruct-0905` in favor of`openai/gpt-oss-120b`. The GPT-OSS 120B model delivers exceptional reasoning performance with faster inference, enabling your applications to harness state-of-the-art AI capabilities with unparalleled speed on our platform.",
+    "url": "https://console.groq.com/docs/deprecations#april-15-2026-moonshotaikimik2instruct0905",
+    "content_hash": "2488f2cd1668f7dd",
+    "scraped_at": "2026-05-22T16:30:40.109049+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "meta-llama/llama-4-maverick-17b-128e-instruct",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2026-03-09",
+    "deprecation_date": "2026-02-20",
+    "replacement_models": [
+      "openai/gpt-oss-120b"
+    ],
+    "deprecation_context": "In line with our commitment to bringing you cutting-edge models, on February 20, 2026, we emailed users to announce the deprecation of `meta-llama/llama-4-maverick-17b-128e-instruct` in favor of`openai/gpt-oss-120b`. The GPT-OSS 120B model delivers exceptional reasoning performance with faster inference, enabling your applications to harness state-of-the-art AI capabilities with unparalleled speed on our platform.",
+    "url": "https://console.groq.com/docs/deprecations#march-9-2026-metallamallama4maverick17b128einstruct",
+    "content_hash": "000ade64d4b6a876",
+    "scraped_at": "2026-05-22T16:30:40.109215+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "meta-llama/llama-guard-4-12b",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2026-03-05",
+    "deprecation_date": "2026-02-10",
+    "replacement_models": [
+      "openai/gpt-oss-safeguard-20b"
+    ],
+    "deprecation_context": "In line with our commitment to bringing you cutting-edge models, on February 10, 2026, we emailed users to announce the deprecation of `meta-llama/llama-guard-4-12b` in favor of`openai/gpt-oss-safeguard-20b`. The new GPT-OSS-Safeguard model delivers policy-following reasoning capabilities for Trust & Safety workflows, enabling customizable content moderation with bring-your-own-policy support.",
+    "url": "https://console.groq.com/docs/deprecations#march-5-2026-metallamallamaguard412b",
+    "content_hash": "dc90a2036d6aaa88",
+    "scraped_at": "2026-05-22T16:30:40.109338+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "playai-tts",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2025-12-31",
+    "deprecation_date": "2025-12-23",
+    "replacement_models": [
+      "canopylabs/orpheus-v1-english"
+    ],
+    "deprecation_context": "In line with our commitment to bringing you cutting-edge models, on December 23, 2025, we emailed users to announce the deprecation of `playai-tts` and `playai-tts-arabic` in favor of the newer Orpheus text-to-speech models from Canopy Labs. The new Orpheus models deliver enhanced expressiveness with vocal direction controls, faster inference, and improved audio quality for your text-to-speech applications.",
+    "url": "https://console.groq.com/docs/deprecations#december-31-2025-playaitts-and-playaittsarabic",
+    "content_hash": "0f0294cc8500fc2d",
+    "scraped_at": "2026-05-22T16:30:40.109464+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "playai-tts-arabic",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2025-12-31",
+    "deprecation_date": "2025-12-23",
+    "replacement_models": [
+      "canopylabs/orpheus-arabic-saudi"
+    ],
+    "deprecation_context": "In line with our commitment to bringing you cutting-edge models, on December 23, 2025, we emailed users to announce the deprecation of `playai-tts` and `playai-tts-arabic` in favor of the newer Orpheus text-to-speech models from Canopy Labs. The new Orpheus models deliver enhanced expressiveness with vocal direction controls, faster inference, and improved audio quality for your text-to-speech applications.",
+    "url": "https://console.groq.com/docs/deprecations#december-31-2025-playaitts-and-playaittsarabic",
+    "content_hash": "e7d7e785f08286f4",
+    "scraped_at": "2026-05-22T16:30:40.109504+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "moonshotai/kimi-k2-instruct",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2025-10-10",
+    "deprecation_date": "2025-09-10",
+    "replacement_models": [
+      "openai/gpt-oss-120b"
+    ],
+    "deprecation_context": "In line with our commitment to bringing you cutting-edge models, on September 10, 2025, we emailed users to announce the deprecation of `moonshotai/kimi-k2-instruct` in favor of `moonshotai/kimi-k2-instruct-0905`. The newer Kimi K2 0905 model delivers a 256K context window and improved agentic coding capabilities at the same speed and price as the original Kimi K2 model.",
+    "url": "https://console.groq.com/docs/deprecations#october-10-2025-moonshotaikimik2instruct",
+    "content_hash": "97921977a38666e5",
+    "scraped_at": "2026-05-22T16:30:40.109617+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "gemma2-9b-it",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2025-10-08",
+    "deprecation_date": "2025-08-08",
+    "replacement_models": [
+      "llama-3.1-8b-instant"
+    ],
+    "deprecation_context": "In line with our commitment to bringing you cutting-edge models, on August 8, 2025, we emailed users to announce the deprecation of `gemma2-9b-it` in favor of `llama-3.1-8b-instant`. The newer Llama 3.1 8B model delivers exceptional price-performance at the same speed as the Gemma 2 9B model.",
+    "url": "https://console.groq.com/docs/deprecations#october-8-2025-gemma29bit",
+    "content_hash": "04f05498eac79365",
+    "scraped_at": "2026-05-22T16:30:40.109726+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "deepseek-r1-distill-llama-70b",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2025-10-02",
+    "deprecation_date": "2025-09-02",
+    "replacement_models": [
+      "llama-3.3-70b-versatile",
+      "openai/gpt-oss-120b"
+    ],
+    "deprecation_context": "In line with our commitment to bringing you cutting-edge models, on September 2, 2025, we emailed users to announce the deprecation of `deepseek-r1-distill-llama-70b` in favor of `llama-3.3-70b-versatile` or `openai/gpt-oss-120b`. The Llama 3.3 70B and GPT-OSS 120B models deliver exceptional performance, enabling your applications to harness state-of-the-art text generation with unparalleled speed on our platform.",
+    "url": "https://console.groq.com/docs/deprecations#october-2-2025-deepseekr1distillllama70b",
+    "content_hash": "f0b40793ae880dfc",
+    "scraped_at": "2026-05-22T16:30:40.109846+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "llama3-70b-8192",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2025-08-30",
+    "deprecation_date": "2025-05-31",
+    "replacement_models": [
+      "llama-3.3-70b-versatile"
+    ],
+    "deprecation_context": "In line with our commitment to bringing you cutting-edge models, on May 31, 2025, we emailed users to announce the deprecation of `llama3-70b-8192` and `llama3-8b-8192` in favor of`llama-3.3-70b-versatile` and `llama-3.1-8b-instant` respectively. The newer Llama 3.3 70B and Llama 3.1 8B models deliver exceptional performance, enabling your applications to harness state-of-the-art text generation with unparalleled speed on our platform.",
+    "url": "https://console.groq.com/docs/deprecations#august-30-2025-llama370b8192-and-llama38b8192",
+    "content_hash": "d35146aa749de59a",
+    "scraped_at": "2026-05-22T16:30:40.109963+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "llama3-8b-8192",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2025-08-30",
+    "deprecation_date": "2025-05-31",
+    "replacement_models": [
+      "llama-3.1-8b-instant"
+    ],
+    "deprecation_context": "In line with our commitment to bringing you cutting-edge models, on May 31, 2025, we emailed users to announce the deprecation of `llama3-70b-8192` and `llama3-8b-8192` in favor of`llama-3.3-70b-versatile` and `llama-3.1-8b-instant` respectively. The newer Llama 3.3 70B and Llama 3.1 8B models deliver exceptional performance, enabling your applications to harness state-of-the-art text generation with unparalleled speed on our platform.",
+    "url": "https://console.groq.com/docs/deprecations#august-30-2025-llama370b8192-and-llama38b8192",
+    "content_hash": "7ae66418342e9de5",
+    "scraped_at": "2026-05-22T16:30:40.110002+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "distil-whisper-large-v3-en",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2025-08-23",
+    "deprecation_date": "2026-05-22",
+    "replacement_models": [
+      "whisper-large-v3-turbo"
+    ],
+    "deprecation_context": "In line with our commitment to bringing you cutting-edge models, we are announcing the deprecation of `distil-whisper-large-v3-en` in favor of`whisper-large-v3-turbo`. Whisper Large V3 Turbo is a more performant model for speech recognition and transcription tasks, and supports more languages.",
+    "url": "https://console.groq.com/docs/deprecations#august-23-2025-distil-whisper-large-v3-english",
+    "content_hash": "f0ea43ae75d76697",
+    "scraped_at": "2026-05-22T16:30:40.110235+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "mistral-saba-24b",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2025-07-30",
+    "deprecation_date": "2026-05-22",
+    "replacement_models": [
+      "qwen/qwen3-32b"
+    ],
+    "deprecation_context": "In line with our commitment to bringing you cutting-edge models, we are announcing the deprecation of `mistral-saba-24b` in favor of`qwen/qwen3-32b`. The new Qwen 3 32B model delivers exceptional performance, enabling your applications to harness state-of-the-art text generation with unparalleled speed on our platform.",
+    "url": "https://console.groq.com/docs/deprecations#july-30-2025-mistral-saba-24b",
+    "content_hash": "cf25ad1bfa1b4671",
+    "scraped_at": "2026-05-22T16:30:40.110341+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "qwen-qwq-32b",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2025-07-14",
+    "deprecation_date": "2026-05-22",
+    "replacement_models": [
+      "qwen/qwen3-32b"
+    ],
+    "deprecation_context": "In line with our commitment to bringing you cutting-edge models, we are announcing the deprecation of `qwen-qwq-32b` in favor of`qwen/qwen3-32b`. The new Qwen 3 32B model delivers exceptional performance, enabling your applications to harness state-of-the-art text generation with unparalleled speed on our platform.",
+    "url": "https://console.groq.com/docs/deprecations#july-14-2025-qwen-qwq-32b",
+    "content_hash": "abf61ce04a206d1c",
+    "scraped_at": "2026-05-22T16:30:40.110438+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "llama-guard-3-8b",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2025-06-06",
+    "deprecation_date": "2025-05-09",
+    "replacement_models": [
+      "meta-llama/llama-guard-4-12b"
+    ],
+    "deprecation_context": "In line with our commitment to bringing you cutting-edge models, on May 9, 2025, we emailed users to announce the deprecation of `llama-guard-3-8b` in favor of`meta-llama/llama-guard-4-12b`. The new Llama Guard 4 model delivers exceptional multimodal performance, enabling your applications to harness state-of-the-art AI content moderation with unparalleled speed on our platform.",
+    "url": "https://console.groq.com/docs/deprecations#june-6-2025-llama-guard-3",
+    "content_hash": "5941b2e28d008b7b",
+    "scraped_at": "2026-05-22T16:30:40.110542+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "llama-3.2-1b-preview",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2025-04-14",
+    "deprecation_date": "2025-04-07",
+    "replacement_models": [
+      "llama-3.1-8b-instant"
+    ],
+    "deprecation_context": "In line with our commitment to bringing you cutting-edge models, on April 7, 2025, we emailed users to announce the deprecation of several older preview models in favor of Meta's Llama 4 suite. The new Llama 4 Scout and Maverick models deliver exceptional multimodal performance that outpaces our previous offerings, enabling your applications to harness state-of-the-art AI capabilities with unparalleled speed on our platform.",
+    "url": "https://console.groq.com/docs/deprecations#april-14-2025-multiple-model-deprecations",
+    "content_hash": "919afe0da5b94371",
+    "scraped_at": "2026-05-22T16:30:40.110825+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "llama-3.2-3b-preview",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2025-04-14",
+    "deprecation_date": "2025-04-07",
+    "replacement_models": [
+      "llama-3.1-8b-instant"
+    ],
+    "deprecation_context": "In line with our commitment to bringing you cutting-edge models, on April 7, 2025, we emailed users to announce the deprecation of several older preview models in favor of Meta's Llama 4 suite. The new Llama 4 Scout and Maverick models deliver exceptional multimodal performance that outpaces our previous offerings, enabling your applications to harness state-of-the-art AI capabilities with unparalleled speed on our platform.",
+    "url": "https://console.groq.com/docs/deprecations#april-14-2025-multiple-model-deprecations",
+    "content_hash": "8f12e45c3aaf8af7",
+    "scraped_at": "2026-05-22T16:30:40.110867+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "llama-3.2-11b-vision-preview",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2025-04-14",
+    "deprecation_date": "2025-04-07",
+    "replacement_models": [
+      "meta-llama/llama-4-scout-17b-16e-instruct"
+    ],
+    "deprecation_context": "In line with our commitment to bringing you cutting-edge models, on April 7, 2025, we emailed users to announce the deprecation of several older preview models in favor of Meta's Llama 4 suite. The new Llama 4 Scout and Maverick models deliver exceptional multimodal performance that outpaces our previous offerings, enabling your applications to harness state-of-the-art AI capabilities with unparalleled speed on our platform.",
+    "url": "https://console.groq.com/docs/deprecations#april-14-2025-multiple-model-deprecations",
+    "content_hash": "0a65937408f442c4",
+    "scraped_at": "2026-05-22T16:30:40.110908+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "llama-3.2-90b-vision-preview",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2025-04-14",
+    "deprecation_date": "2025-04-07",
+    "replacement_models": [
+      "meta-llama/llama-4-scout-17b-16e-instruct"
+    ],
+    "deprecation_context": "In line with our commitment to bringing you cutting-edge models, on April 7, 2025, we emailed users to announce the deprecation of several older preview models in favor of Meta's Llama 4 suite. The new Llama 4 Scout and Maverick models deliver exceptional multimodal performance that outpaces our previous offerings, enabling your applications to harness state-of-the-art AI capabilities with unparalleled speed on our platform.",
+    "url": "https://console.groq.com/docs/deprecations#april-14-2025-multiple-model-deprecations",
+    "content_hash": "d1bd189c127ec5ae",
+    "scraped_at": "2026-05-22T16:30:40.110947+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "deepseek-r1-distill-qwen-32b",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2025-04-14",
+    "deprecation_date": "2025-04-07",
+    "replacement_models": [
+      "qwen-qwq-32b"
+    ],
+    "deprecation_context": "In line with our commitment to bringing you cutting-edge models, on April 7, 2025, we emailed users to announce the deprecation of several older preview models in favor of Meta's Llama 4 suite. The new Llama 4 Scout and Maverick models deliver exceptional multimodal performance that outpaces our previous offerings, enabling your applications to harness state-of-the-art AI capabilities with unparalleled speed on our platform.",
+    "url": "https://console.groq.com/docs/deprecations#april-14-2025-multiple-model-deprecations",
+    "content_hash": "8d85a5500ff722b3",
+    "scraped_at": "2026-05-22T16:30:40.110986+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "qwen-2.5-32b",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2025-04-14",
+    "deprecation_date": "2025-04-07",
+    "replacement_models": [
+      "qwen-qwq-32b",
+      "meta-llama/llama-4-scout-17b-16e-instruct"
+    ],
+    "deprecation_context": "In line with our commitment to bringing you cutting-edge models, on April 7, 2025, we emailed users to announce the deprecation of several older preview models in favor of Meta's Llama 4 suite. The new Llama 4 Scout and Maverick models deliver exceptional multimodal performance that outpaces our previous offerings, enabling your applications to harness state-of-the-art AI capabilities with unparalleled speed on our platform.",
+    "url": "https://console.groq.com/docs/deprecations#april-14-2025-multiple-model-deprecations",
+    "content_hash": "b2c5b01b5f090db3",
+    "scraped_at": "2026-05-22T16:30:40.111029+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "qwen-2.5-coder-32b",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2025-04-14",
+    "deprecation_date": "2025-04-07",
+    "replacement_models": [
+      "qwen-qwq-32b",
+      "openai/gpt-oss-120b"
+    ],
+    "deprecation_context": "In line with our commitment to bringing you cutting-edge models, on April 7, 2025, we emailed users to announce the deprecation of several older preview models in favor of Meta's Llama 4 suite. The new Llama 4 Scout and Maverick models deliver exceptional multimodal performance that outpaces our previous offerings, enabling your applications to harness state-of-the-art AI capabilities with unparalleled speed on our platform.",
+    "url": "https://console.groq.com/docs/deprecations#april-14-2025-multiple-model-deprecations",
+    "content_hash": "1fde5cbdc2352167",
+    "scraped_at": "2026-05-22T16:30:40.111069+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "llama-3.3-70b-specdec",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2025-04-14",
+    "deprecation_date": "2025-04-07",
+    "replacement_models": [
+      "meta-llama/llama-4-scout-17b-16e-instruct",
+      "llama-3.3-70b-versatile"
+    ],
+    "deprecation_context": "In line with our commitment to bringing you cutting-edge models, on April 7, 2025, we emailed users to announce the deprecation of several older preview models in favor of Meta's Llama 4 suite. The new Llama 4 Scout and Maverick models deliver exceptional multimodal performance that outpaces our previous offerings, enabling your applications to harness state-of-the-art AI capabilities with unparalleled speed on our platform.",
+    "url": "https://console.groq.com/docs/deprecations#april-14-2025-multiple-model-deprecations",
+    "content_hash": "b61c2d96c1c7ccd7",
+    "scraped_at": "2026-05-22T16:30:40.111112+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "deepseek-r1-distill-llama-70b-specdec",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2025-04-14",
+    "deprecation_date": "2025-04-07",
+    "replacement_models": [
+      "deepseek-r1-distill-llama-70b",
+      "deepseek-r1-distill-qwen-32b"
+    ],
+    "deprecation_context": "In line with our commitment to bringing you cutting-edge models, on April 7, 2025, we emailed users to announce the deprecation of several older preview models in favor of Meta's Llama 4 suite. The new Llama 4 Scout and Maverick models deliver exceptional multimodal performance that outpaces our previous offerings, enabling your applications to harness state-of-the-art AI capabilities with unparalleled speed on our platform.",
+    "url": "https://console.groq.com/docs/deprecations#april-14-2025-multiple-model-deprecations",
+    "content_hash": "41f9f039689b8e62",
+    "scraped_at": "2026-05-22T16:30:40.111156+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "mixtral-8x7b-32768",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2025-03-20",
+    "deprecation_date": "2026-05-22",
+    "replacement_models": [
+      "mistral-saba-24b",
+      "llama-3.3-70b-versatile"
+    ],
+    "deprecation_context": "On March 5, 2025, we emailed all users of the `mixtral-8x7b-32768` model that we would be deprecating this model ID in favor of newer, more performant models. The recommended replacement models offer superior multilingual capabilities and performance for various tasks from text generation to translation.",
+    "url": "https://console.groq.com/docs/deprecations#march-20-2025-mixtral-8x7b",
+    "content_hash": "3cec3e1a94b12098",
+    "scraped_at": "2026-05-22T16:30:40.111383+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "llama-3.1-70b-versatile",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2025-01-24",
+    "deprecation_date": "2026-05-22",
+    "replacement_models": [
+      "llama-3.3-70b-versatile"
+    ],
+    "deprecation_context": "On December 6, 2024, in partnership with Meta, we released `llama-3.3-70b-versatile` and `llama-3.3-70b-specdec`, and notified users that we would deprecate their 3.1 counterparts in favor of hosting Llama 3.3 with significant quality improvements for a better experience. To facilitate a smooth transition, we will maintain the current `llama-3.1-70b-versatile` and `llama-3.1-70b-specdec` model IDs until December 20, 2024\\. At that time, requests to these model IDs will automatically upgrade to their respective 3.3 versions. Beginning January 24, 2025, requests to both 3.1 model IDs will return errors. While these new models deliver improved quality, they may produce different responses than their predecessors. We recommend migrating to explicitly using `llama-3.3-70b-versatile` and `llama-3.3-70b-specdec` before December 20, 2024, for testing.",
+    "url": "https://console.groq.com/docs/deprecations#january-24-2025-llama-31-70b-and-llama-31-70b-speculative-decoding",
+    "content_hash": "dbe42318dcaf0b75",
+    "scraped_at": "2026-05-22T16:30:40.111517+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "llama-3.1-70b-specdec",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2025-01-24",
+    "deprecation_date": "2026-05-22",
+    "replacement_models": [
+      "llama-3.3-70b-specdec"
+    ],
+    "deprecation_context": "On December 6, 2024, in partnership with Meta, we released `llama-3.3-70b-versatile` and `llama-3.3-70b-specdec`, and notified users that we would deprecate their 3.1 counterparts in favor of hosting Llama 3.3 with significant quality improvements for a better experience. To facilitate a smooth transition, we will maintain the current `llama-3.1-70b-versatile` and `llama-3.1-70b-specdec` model IDs until December 20, 2024\\. At that time, requests to these model IDs will automatically upgrade to their respective 3.3 versions. Beginning January 24, 2025, requests to both 3.1 model IDs will return errors. While these new models deliver improved quality, they may produce different responses than their predecessors. We recommend migrating to explicitly using `llama-3.3-70b-versatile` and `llama-3.3-70b-specdec` before December 20, 2024, for testing.",
+    "url": "https://console.groq.com/docs/deprecations#january-24-2025-llama-31-70b-and-llama-31-70b-speculative-decoding",
+    "content_hash": "ded2d32ce5958284",
+    "scraped_at": "2026-05-22T16:30:40.111554+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "llama3-groq-8b-8192-tool-use-preview",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2025-01-06",
+    "deprecation_date": "2026-05-22",
+    "replacement_models": [
+      "llama-3.3-70b-versatile"
+    ],
+    "deprecation_context": "On January 6th, we deprecated our preview versions of Llama 3 fine-tuned for tool use, `llama3-groq-8b-8192-tool-use-preview` and `llama3-groq-70b-8192-tool-use-preview`, from GroqCloud\u2122 in favor of transitioning users to our production-ready `llama-3.30-70b-versatile` model. Users of the tool use models were notified about the upcoming deprecation via email. The recommended replacement model, `llama-3.3-70b-versatile`, offers superior tool use capabilities and we strongly encourage users to migrate applications to this model for improved reliability and performance.",
+    "url": "https://console.groq.com/docs/deprecations#january-6-2025-llama-3-groq-tool-use-models",
+    "content_hash": "e8a65433d8f8fb9e",
+    "scraped_at": "2026-05-22T16:30:40.111717+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "llama3-groq-70b-8192-tool-use-preview",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2025-01-06",
+    "deprecation_date": "2026-05-22",
+    "replacement_models": [
+      "llama-3.3-70b-versatile"
+    ],
+    "deprecation_context": "On January 6th, we deprecated our preview versions of Llama 3 fine-tuned for tool use, `llama3-groq-8b-8192-tool-use-preview` and `llama3-groq-70b-8192-tool-use-preview`, from GroqCloud\u2122 in favor of transitioning users to our production-ready `llama-3.30-70b-versatile` model. Users of the tool use models were notified about the upcoming deprecation via email. The recommended replacement model, `llama-3.3-70b-versatile`, offers superior tool use capabilities and we strongly encourage users to migrate applications to this model for improved reliability and performance.",
+    "url": "https://console.groq.com/docs/deprecations#january-6-2025-llama-3-groq-tool-use-models",
+    "content_hash": "515db4ba1ae3373b",
+    "scraped_at": "2026-05-22T16:30:40.111762+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "gemma-7b-it",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2024-12-18",
+    "deprecation_date": "2026-05-22",
+    "replacement_models": [
+      "gemma2-9b-it"
+    ],
+    "deprecation_context": "On December 11, 2024, we emailed all Gemma 7B users that we would deprecate it in favor of keeping the Gemma 9B model as it offers better performance.",
+    "url": "https://console.groq.com/docs/deprecations#december-18-2024-gemma-7b",
+    "content_hash": "05f0ae9cc95fafba",
+    "scraped_at": "2026-05-22T16:30:40.111869+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "llama-3.2-90b-text-preview",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2024-11-25",
+    "deprecation_date": "2026-05-22",
+    "replacement_models": [
+      "llama-3.2-90b-vision-preview",
+      "llama-3.1-70b-versatile"
+    ],
+    "deprecation_context": "In November 2024, we emailed all Llama 3.2 90B Text Preview users that we would deprecate it in favor of hosting the Llama 3.2 90B Vision Preview model for vision capabilities.",
+    "url": "https://console.groq.com/docs/deprecations#november-25-2024-llama-32-90b-text-preview",
+    "content_hash": "4a3ed3a489b9db52",
+    "scraped_at": "2026-05-22T16:30:40.112013+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "llava-v1.5-7b-4096-preview",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2024-10-28",
+    "deprecation_date": "2026-05-22",
+    "replacement_models": [
+      "llama-3.2-11b-vision-preview"
+    ],
+    "deprecation_context": "In September 2024, we made Meta's Llama 3.2 vision models available on GroqCloud and emailed all LLaVA 1.5 7B and Llama 3.2 11B Text Preview users that we would deprecate it in favor of hosting Llama 3.2 11B Vision for better performance and more robust vision capabilities.",
+    "url": "https://console.groq.com/docs/deprecations#october-18-2024-llava-15-7b-and-llama-32-11b-text-preview",
+    "content_hash": "2bd5dd00c3a7f9fd",
+    "scraped_at": "2026-05-22T16:30:40.112165+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "llama-3.2-11b-text-preview",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2024-10-28",
+    "deprecation_date": "2026-05-22",
+    "replacement_models": [
+      "llama-3.2-11b-vision-preview",
+      "llama-3.1-8b-instant"
+    ],
+    "deprecation_context": "In September 2024, we made Meta's Llama 3.2 vision models available on GroqCloud and emailed all LLaVA 1.5 7B and Llama 3.2 11B Text Preview users that we would deprecate it in favor of hosting Llama 3.2 11B Vision for better performance and more robust vision capabilities.",
+    "url": "https://console.groq.com/docs/deprecations#october-18-2024-llava-15-7b-and-llama-32-11b-text-preview",
+    "content_hash": "bedb432071dd6aed",
+    "scraped_at": "2026-05-22T16:30:40.112222+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
     "provider": "xAI",
     "model_id": "grok-4-1-fast",
     "announcement_date": "2026-05-14",

--- a/docs/index.html
+++ b/docs/index.html
@@ -21,7 +21,7 @@
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://deprecations.info/">
     <meta property="og:title" content="AI Deprecations Feeds - Never miss an AI model shutdown again">
-    <meta property="og:description" content="Track AI model deprecations from OpenAI, Anthropic, Google Vertex AI, AWS Bedrock, and Cohere. Available as JSON API, JSON Feed, and RSS.">
+    <meta property="og:description" content="Track AI model deprecations from OpenAI, Anthropic, Google, AWS Bedrock, Cohere, Groq, xAI, Azure, and more. Available as JSON API, JSON Feed, and RSS.">
     <meta property="og:image" content="https://deprecations.info/social-card.jpeg">
     <meta property="og:image:type" content="image/jpeg">
     <meta property="og:image:width" content="1731">
@@ -66,7 +66,7 @@
 
         <section class="intro">
             <p class="lead">
-                Track AI model deprecations from OpenAI, Anthropic, Google AI/Gemini, Google Vertex AI, AWS Bedrock, Cohere, and xAI.
+                Track AI model deprecations from OpenAI, Anthropic, Google AI/Gemini, Google Vertex AI, AWS Bedrock, Cohere, Groq, xAI, and Azure.
                 Available as <strong>JSON API</strong>, <strong>JSON Feed</strong>, and <strong>RSS</strong> - perfect
                 for programmatic access and automation.
                 When they announce a model is being shut down, it shows up here. That's it.
@@ -154,6 +154,7 @@ t19 -45.5t-18.5 -45t-44.5 -19.5zM551 477q-27 0 -46 19t-19 45.5t19 45.5t45.5 19t4
                 <button class="filter-badge anthropic" data-filter="anthropic">ANT</button>
                 <button class="filter-badge google" data-filter="google">GOO</button>
                 <button class="filter-badge cohere" data-filter="cohere">COH</button>
+                <button class="filter-badge groq" data-filter="groq">GRQ</button>
                 <button class="filter-badge google-vertex" data-filter="google-vertex">GCP</button>
                 <button class="filter-badge aws" data-filter="aws">AWS</button>
                 <button class="filter-badge xai" data-filter="xai">xAI</button>
@@ -269,6 +270,7 @@ t19 -45.5t-18.5 -45t-44.5 -19.5zM551 477q-27 0 -46 19t-19 45.5t19 45.5t45.5 19t4
                         'googlevertex': 'Google Vertex',
                         'googlevertexai': 'Google Vertex AI',
                         'cohere': 'Cohere',
+                        'groq': 'Groq',
                         'aws': 'AWS',
                         'awsbedrock': 'AWS Bedrock',
                         'xai': 'xAI',
@@ -384,6 +386,7 @@ t19 -45.5t-18.5 -45t-44.5 -19.5zM551 477q-27 0 -46 19t-19 45.5t19 45.5t45.5 19t4
                                 'googlevertex': 'google-vertex',
                                 'googlevertexai': 'google-vertex',
                                 'cohere': 'cohere',
+                                'groq': 'groq',
                                 'aws': 'aws',
                                 'awsbedrock': 'aws',
                                 'xai': 'xai',
@@ -1315,6 +1318,7 @@ end</code></pre>
                     'Google Vertex': { className: 'google-vertex', short: 'GCP' },
                     'AWS Bedrock': { className: 'aws', short: 'AWS' },
                     'Cohere': { className: 'cohere', short: 'COH' },
+                    'Groq': { className: 'groq', short: 'GRQ' },
                     'xAI': { className: 'xai', short: 'xAI' },
                     'Azure': { className: 'azure', short: 'AZR' },
                 };

--- a/docs/social-card.html
+++ b/docs/social-card.html
@@ -78,6 +78,7 @@
         .provider-badge.google { background: #4285F4; }
         .provider-badge.aws { background: #FF9900; color: #000; }
         .provider-badge.cohere { background: #39594d; }
+        .provider-badge.groq { background: #f43e01; }
         .provider-badge.azure { background: #0078D4; }
 
         .url {
@@ -134,6 +135,7 @@
             <span class="provider-badge openai">OpenAI</span>
             <span class="provider-badge anthropic">Anthropic</span>
             <span class="provider-badge cohere">Cohere</span>
+            <span class="provider-badge groq">Groq</span>
             <span class="provider-badge google">Google</span>
             <span class="provider-badge aws">AWS</span>
             <span class="provider-badge azure">Azure</span>

--- a/docs/social-card.svg
+++ b/docs/social-card.svg
@@ -55,28 +55,32 @@
     <!-- Provider badges -->
     <g transform="translate(600, 350)">
       <!-- OpenAI -->
-      <rect x="-300" y="-15" width="80" height="30" rx="6" fill="#412991" />
-      <text x="-260" y="2" font-family="JetBrains Mono, monospace" font-size="14" font-weight="600" fill="white">OpenAI</text>
+      <rect x="-350" y="-15" width="80" height="30" rx="6" fill="#412991" />
+      <text x="-310" y="2" font-family="JetBrains Mono, monospace" font-size="14" font-weight="600" fill="white">OpenAI</text>
       
       <!-- Anthropic -->
-      <rect x="-200" y="-15" width="90" height="30" rx="6" fill="#d4a373" />
-      <text x="-155" y="2" font-family="JetBrains Mono, monospace" font-size="14" font-weight="600" fill="black">Anthropic</text>
+      <rect x="-250" y="-15" width="90" height="30" rx="6" fill="#d4a373" />
+      <text x="-205" y="2" font-family="JetBrains Mono, monospace" font-size="14" font-weight="600" fill="black">Anthropic</text>
       
       <!-- Cohere -->
-      <rect x="-90" y="-15" width="70" height="30" rx="6" fill="#39594d" />
-      <text x="-55" y="2" font-family="JetBrains Mono, monospace" font-size="14" font-weight="600" fill="white">Cohere</text>
+      <rect x="-140" y="-15" width="70" height="30" rx="6" fill="#39594d" />
+      <text x="-105" y="2" font-family="JetBrains Mono, monospace" font-size="14" font-weight="600" fill="white">Cohere</text>
+      
+      <!-- Groq -->
+      <rect x="-50" y="-15" width="60" height="30" rx="6" fill="#f43e01" />
+      <text x="-20" y="2" font-family="JetBrains Mono, monospace" font-size="14" font-weight="600" fill="white">Groq</text>
       
       <!-- Google -->
-      <rect x="0" y="-15" width="70" height="30" rx="6" fill="#4285F4" />
-      <text x="35" y="2" font-family="JetBrains Mono, monospace" font-size="14" font-weight="600" fill="white">Google</text>
+      <rect x="30" y="-15" width="70" height="30" rx="6" fill="#4285F4" />
+      <text x="65" y="2" font-family="JetBrains Mono, monospace" font-size="14" font-weight="600" fill="white">Google</text>
       
       <!-- AWS -->
-      <rect x="90" y="-15" width="60" height="30" rx="6" fill="#FF9900" />
-      <text x="120" y="2" font-family="JetBrains Mono, monospace" font-size="14" font-weight="600" fill="black">AWS</text>
+      <rect x="120" y="-15" width="60" height="30" rx="6" fill="#FF9900" />
+      <text x="150" y="2" font-family="JetBrains Mono, monospace" font-size="14" font-weight="600" fill="black">AWS</text>
       
       <!-- Azure -->
-      <rect x="170" y="-15" width="60" height="30" rx="6" fill="#0078D4" />
-      <text x="200" y="2" font-family="JetBrains Mono, monospace" font-size="14" font-weight="600" fill="white">Azure</text>
+      <rect x="200" y="-15" width="60" height="30" rx="6" fill="#0078D4" />
+      <text x="230" y="2" font-family="JetBrains Mono, monospace" font-size="14" font-weight="600" fill="white">Azure</text>
     </g>
     
     <!-- URL -->

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -96,6 +96,10 @@ header {
     background: #39594d;
 }
 
+.provider-badge.groq {
+    background: #f43e01;
+}
+
 .provider-badge.azure {
     background: #0078D4;
 }
@@ -911,6 +915,10 @@ footer a:hover {
     background: #39594d;
 }
 
+.filter-badge.groq {
+    background: #f43e01;
+}
+
 .filter-badge.azure {
     background: #0078D4;
 }
@@ -998,6 +1006,10 @@ footer a:hover {
 
 .provider.cohere {
     color: #b19cd9;
+}
+
+.provider.groq {
+    color: #f43e01;
 }
 
 .provider.aws {

--- a/docs/v1/deprecations.json
+++ b/docs/v1/deprecations.json
@@ -3705,6 +3705,526 @@
     "last_observed": "2026-05-01"
   },
   {
+    "provider": "Groq",
+    "model_id": "moonshotai/kimi-k2-instruct-0905",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2026-04-15",
+    "deprecation_date": "2026-03-23",
+    "replacement_models": [
+      "openai/gpt-oss-120b"
+    ],
+    "deprecation_context": "In line with our commitment to bringing you cutting-edge models, on March 23, 2026, we emailed users to announce the deprecation of `moonshotai/kimi-k2-instruct-0905` in favor of`openai/gpt-oss-120b`. The GPT-OSS 120B model delivers exceptional reasoning performance with faster inference, enabling your applications to harness state-of-the-art AI capabilities with unparalleled speed on our platform.",
+    "url": "https://console.groq.com/docs/deprecations#april-15-2026-moonshotaikimik2instruct0905",
+    "content_hash": "2488f2cd1668f7dd",
+    "scraped_at": "2026-05-22T16:30:40.109049+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "meta-llama/llama-4-maverick-17b-128e-instruct",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2026-03-09",
+    "deprecation_date": "2026-02-20",
+    "replacement_models": [
+      "openai/gpt-oss-120b"
+    ],
+    "deprecation_context": "In line with our commitment to bringing you cutting-edge models, on February 20, 2026, we emailed users to announce the deprecation of `meta-llama/llama-4-maverick-17b-128e-instruct` in favor of`openai/gpt-oss-120b`. The GPT-OSS 120B model delivers exceptional reasoning performance with faster inference, enabling your applications to harness state-of-the-art AI capabilities with unparalleled speed on our platform.",
+    "url": "https://console.groq.com/docs/deprecations#march-9-2026-metallamallama4maverick17b128einstruct",
+    "content_hash": "000ade64d4b6a876",
+    "scraped_at": "2026-05-22T16:30:40.109215+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "meta-llama/llama-guard-4-12b",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2026-03-05",
+    "deprecation_date": "2026-02-10",
+    "replacement_models": [
+      "openai/gpt-oss-safeguard-20b"
+    ],
+    "deprecation_context": "In line with our commitment to bringing you cutting-edge models, on February 10, 2026, we emailed users to announce the deprecation of `meta-llama/llama-guard-4-12b` in favor of`openai/gpt-oss-safeguard-20b`. The new GPT-OSS-Safeguard model delivers policy-following reasoning capabilities for Trust & Safety workflows, enabling customizable content moderation with bring-your-own-policy support.",
+    "url": "https://console.groq.com/docs/deprecations#march-5-2026-metallamallamaguard412b",
+    "content_hash": "dc90a2036d6aaa88",
+    "scraped_at": "2026-05-22T16:30:40.109338+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "playai-tts",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2025-12-31",
+    "deprecation_date": "2025-12-23",
+    "replacement_models": [
+      "canopylabs/orpheus-v1-english"
+    ],
+    "deprecation_context": "In line with our commitment to bringing you cutting-edge models, on December 23, 2025, we emailed users to announce the deprecation of `playai-tts` and `playai-tts-arabic` in favor of the newer Orpheus text-to-speech models from Canopy Labs. The new Orpheus models deliver enhanced expressiveness with vocal direction controls, faster inference, and improved audio quality for your text-to-speech applications.",
+    "url": "https://console.groq.com/docs/deprecations#december-31-2025-playaitts-and-playaittsarabic",
+    "content_hash": "0f0294cc8500fc2d",
+    "scraped_at": "2026-05-22T16:30:40.109464+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "playai-tts-arabic",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2025-12-31",
+    "deprecation_date": "2025-12-23",
+    "replacement_models": [
+      "canopylabs/orpheus-arabic-saudi"
+    ],
+    "deprecation_context": "In line with our commitment to bringing you cutting-edge models, on December 23, 2025, we emailed users to announce the deprecation of `playai-tts` and `playai-tts-arabic` in favor of the newer Orpheus text-to-speech models from Canopy Labs. The new Orpheus models deliver enhanced expressiveness with vocal direction controls, faster inference, and improved audio quality for your text-to-speech applications.",
+    "url": "https://console.groq.com/docs/deprecations#december-31-2025-playaitts-and-playaittsarabic",
+    "content_hash": "e7d7e785f08286f4",
+    "scraped_at": "2026-05-22T16:30:40.109504+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "moonshotai/kimi-k2-instruct",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2025-10-10",
+    "deprecation_date": "2025-09-10",
+    "replacement_models": [
+      "openai/gpt-oss-120b"
+    ],
+    "deprecation_context": "In line with our commitment to bringing you cutting-edge models, on September 10, 2025, we emailed users to announce the deprecation of `moonshotai/kimi-k2-instruct` in favor of `moonshotai/kimi-k2-instruct-0905`. The newer Kimi K2 0905 model delivers a 256K context window and improved agentic coding capabilities at the same speed and price as the original Kimi K2 model.",
+    "url": "https://console.groq.com/docs/deprecations#october-10-2025-moonshotaikimik2instruct",
+    "content_hash": "97921977a38666e5",
+    "scraped_at": "2026-05-22T16:30:40.109617+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "gemma2-9b-it",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2025-10-08",
+    "deprecation_date": "2025-08-08",
+    "replacement_models": [
+      "llama-3.1-8b-instant"
+    ],
+    "deprecation_context": "In line with our commitment to bringing you cutting-edge models, on August 8, 2025, we emailed users to announce the deprecation of `gemma2-9b-it` in favor of `llama-3.1-8b-instant`. The newer Llama 3.1 8B model delivers exceptional price-performance at the same speed as the Gemma 2 9B model.",
+    "url": "https://console.groq.com/docs/deprecations#october-8-2025-gemma29bit",
+    "content_hash": "04f05498eac79365",
+    "scraped_at": "2026-05-22T16:30:40.109726+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "deepseek-r1-distill-llama-70b",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2025-10-02",
+    "deprecation_date": "2025-09-02",
+    "replacement_models": [
+      "llama-3.3-70b-versatile",
+      "openai/gpt-oss-120b"
+    ],
+    "deprecation_context": "In line with our commitment to bringing you cutting-edge models, on September 2, 2025, we emailed users to announce the deprecation of `deepseek-r1-distill-llama-70b` in favor of `llama-3.3-70b-versatile` or `openai/gpt-oss-120b`. The Llama 3.3 70B and GPT-OSS 120B models deliver exceptional performance, enabling your applications to harness state-of-the-art text generation with unparalleled speed on our platform.",
+    "url": "https://console.groq.com/docs/deprecations#october-2-2025-deepseekr1distillllama70b",
+    "content_hash": "f0b40793ae880dfc",
+    "scraped_at": "2026-05-22T16:30:40.109846+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "llama3-70b-8192",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2025-08-30",
+    "deprecation_date": "2025-05-31",
+    "replacement_models": [
+      "llama-3.3-70b-versatile"
+    ],
+    "deprecation_context": "In line with our commitment to bringing you cutting-edge models, on May 31, 2025, we emailed users to announce the deprecation of `llama3-70b-8192` and `llama3-8b-8192` in favor of`llama-3.3-70b-versatile` and `llama-3.1-8b-instant` respectively. The newer Llama 3.3 70B and Llama 3.1 8B models deliver exceptional performance, enabling your applications to harness state-of-the-art text generation with unparalleled speed on our platform.",
+    "url": "https://console.groq.com/docs/deprecations#august-30-2025-llama370b8192-and-llama38b8192",
+    "content_hash": "d35146aa749de59a",
+    "scraped_at": "2026-05-22T16:30:40.109963+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "llama3-8b-8192",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2025-08-30",
+    "deprecation_date": "2025-05-31",
+    "replacement_models": [
+      "llama-3.1-8b-instant"
+    ],
+    "deprecation_context": "In line with our commitment to bringing you cutting-edge models, on May 31, 2025, we emailed users to announce the deprecation of `llama3-70b-8192` and `llama3-8b-8192` in favor of`llama-3.3-70b-versatile` and `llama-3.1-8b-instant` respectively. The newer Llama 3.3 70B and Llama 3.1 8B models deliver exceptional performance, enabling your applications to harness state-of-the-art text generation with unparalleled speed on our platform.",
+    "url": "https://console.groq.com/docs/deprecations#august-30-2025-llama370b8192-and-llama38b8192",
+    "content_hash": "7ae66418342e9de5",
+    "scraped_at": "2026-05-22T16:30:40.110002+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "distil-whisper-large-v3-en",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2025-08-23",
+    "deprecation_date": "2026-05-22",
+    "replacement_models": [
+      "whisper-large-v3-turbo"
+    ],
+    "deprecation_context": "In line with our commitment to bringing you cutting-edge models, we are announcing the deprecation of `distil-whisper-large-v3-en` in favor of`whisper-large-v3-turbo`. Whisper Large V3 Turbo is a more performant model for speech recognition and transcription tasks, and supports more languages.",
+    "url": "https://console.groq.com/docs/deprecations#august-23-2025-distil-whisper-large-v3-english",
+    "content_hash": "f0ea43ae75d76697",
+    "scraped_at": "2026-05-22T16:30:40.110235+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "mistral-saba-24b",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2025-07-30",
+    "deprecation_date": "2026-05-22",
+    "replacement_models": [
+      "qwen/qwen3-32b"
+    ],
+    "deprecation_context": "In line with our commitment to bringing you cutting-edge models, we are announcing the deprecation of `mistral-saba-24b` in favor of`qwen/qwen3-32b`. The new Qwen 3 32B model delivers exceptional performance, enabling your applications to harness state-of-the-art text generation with unparalleled speed on our platform.",
+    "url": "https://console.groq.com/docs/deprecations#july-30-2025-mistral-saba-24b",
+    "content_hash": "cf25ad1bfa1b4671",
+    "scraped_at": "2026-05-22T16:30:40.110341+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "qwen-qwq-32b",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2025-07-14",
+    "deprecation_date": "2026-05-22",
+    "replacement_models": [
+      "qwen/qwen3-32b"
+    ],
+    "deprecation_context": "In line with our commitment to bringing you cutting-edge models, we are announcing the deprecation of `qwen-qwq-32b` in favor of`qwen/qwen3-32b`. The new Qwen 3 32B model delivers exceptional performance, enabling your applications to harness state-of-the-art text generation with unparalleled speed on our platform.",
+    "url": "https://console.groq.com/docs/deprecations#july-14-2025-qwen-qwq-32b",
+    "content_hash": "abf61ce04a206d1c",
+    "scraped_at": "2026-05-22T16:30:40.110438+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "llama-guard-3-8b",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2025-06-06",
+    "deprecation_date": "2025-05-09",
+    "replacement_models": [
+      "meta-llama/llama-guard-4-12b"
+    ],
+    "deprecation_context": "In line with our commitment to bringing you cutting-edge models, on May 9, 2025, we emailed users to announce the deprecation of `llama-guard-3-8b` in favor of`meta-llama/llama-guard-4-12b`. The new Llama Guard 4 model delivers exceptional multimodal performance, enabling your applications to harness state-of-the-art AI content moderation with unparalleled speed on our platform.",
+    "url": "https://console.groq.com/docs/deprecations#june-6-2025-llama-guard-3",
+    "content_hash": "5941b2e28d008b7b",
+    "scraped_at": "2026-05-22T16:30:40.110542+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "llama-3.2-1b-preview",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2025-04-14",
+    "deprecation_date": "2025-04-07",
+    "replacement_models": [
+      "llama-3.1-8b-instant"
+    ],
+    "deprecation_context": "In line with our commitment to bringing you cutting-edge models, on April 7, 2025, we emailed users to announce the deprecation of several older preview models in favor of Meta's Llama 4 suite. The new Llama 4 Scout and Maverick models deliver exceptional multimodal performance that outpaces our previous offerings, enabling your applications to harness state-of-the-art AI capabilities with unparalleled speed on our platform.",
+    "url": "https://console.groq.com/docs/deprecations#april-14-2025-multiple-model-deprecations",
+    "content_hash": "919afe0da5b94371",
+    "scraped_at": "2026-05-22T16:30:40.110825+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "llama-3.2-3b-preview",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2025-04-14",
+    "deprecation_date": "2025-04-07",
+    "replacement_models": [
+      "llama-3.1-8b-instant"
+    ],
+    "deprecation_context": "In line with our commitment to bringing you cutting-edge models, on April 7, 2025, we emailed users to announce the deprecation of several older preview models in favor of Meta's Llama 4 suite. The new Llama 4 Scout and Maverick models deliver exceptional multimodal performance that outpaces our previous offerings, enabling your applications to harness state-of-the-art AI capabilities with unparalleled speed on our platform.",
+    "url": "https://console.groq.com/docs/deprecations#april-14-2025-multiple-model-deprecations",
+    "content_hash": "8f12e45c3aaf8af7",
+    "scraped_at": "2026-05-22T16:30:40.110867+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "llama-3.2-11b-vision-preview",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2025-04-14",
+    "deprecation_date": "2025-04-07",
+    "replacement_models": [
+      "meta-llama/llama-4-scout-17b-16e-instruct"
+    ],
+    "deprecation_context": "In line with our commitment to bringing you cutting-edge models, on April 7, 2025, we emailed users to announce the deprecation of several older preview models in favor of Meta's Llama 4 suite. The new Llama 4 Scout and Maverick models deliver exceptional multimodal performance that outpaces our previous offerings, enabling your applications to harness state-of-the-art AI capabilities with unparalleled speed on our platform.",
+    "url": "https://console.groq.com/docs/deprecations#april-14-2025-multiple-model-deprecations",
+    "content_hash": "0a65937408f442c4",
+    "scraped_at": "2026-05-22T16:30:40.110908+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "llama-3.2-90b-vision-preview",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2025-04-14",
+    "deprecation_date": "2025-04-07",
+    "replacement_models": [
+      "meta-llama/llama-4-scout-17b-16e-instruct"
+    ],
+    "deprecation_context": "In line with our commitment to bringing you cutting-edge models, on April 7, 2025, we emailed users to announce the deprecation of several older preview models in favor of Meta's Llama 4 suite. The new Llama 4 Scout and Maverick models deliver exceptional multimodal performance that outpaces our previous offerings, enabling your applications to harness state-of-the-art AI capabilities with unparalleled speed on our platform.",
+    "url": "https://console.groq.com/docs/deprecations#april-14-2025-multiple-model-deprecations",
+    "content_hash": "d1bd189c127ec5ae",
+    "scraped_at": "2026-05-22T16:30:40.110947+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "deepseek-r1-distill-qwen-32b",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2025-04-14",
+    "deprecation_date": "2025-04-07",
+    "replacement_models": [
+      "qwen-qwq-32b"
+    ],
+    "deprecation_context": "In line with our commitment to bringing you cutting-edge models, on April 7, 2025, we emailed users to announce the deprecation of several older preview models in favor of Meta's Llama 4 suite. The new Llama 4 Scout and Maverick models deliver exceptional multimodal performance that outpaces our previous offerings, enabling your applications to harness state-of-the-art AI capabilities with unparalleled speed on our platform.",
+    "url": "https://console.groq.com/docs/deprecations#april-14-2025-multiple-model-deprecations",
+    "content_hash": "8d85a5500ff722b3",
+    "scraped_at": "2026-05-22T16:30:40.110986+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "qwen-2.5-32b",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2025-04-14",
+    "deprecation_date": "2025-04-07",
+    "replacement_models": [
+      "qwen-qwq-32b",
+      "meta-llama/llama-4-scout-17b-16e-instruct"
+    ],
+    "deprecation_context": "In line with our commitment to bringing you cutting-edge models, on April 7, 2025, we emailed users to announce the deprecation of several older preview models in favor of Meta's Llama 4 suite. The new Llama 4 Scout and Maverick models deliver exceptional multimodal performance that outpaces our previous offerings, enabling your applications to harness state-of-the-art AI capabilities with unparalleled speed on our platform.",
+    "url": "https://console.groq.com/docs/deprecations#april-14-2025-multiple-model-deprecations",
+    "content_hash": "b2c5b01b5f090db3",
+    "scraped_at": "2026-05-22T16:30:40.111029+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "qwen-2.5-coder-32b",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2025-04-14",
+    "deprecation_date": "2025-04-07",
+    "replacement_models": [
+      "qwen-qwq-32b",
+      "openai/gpt-oss-120b"
+    ],
+    "deprecation_context": "In line with our commitment to bringing you cutting-edge models, on April 7, 2025, we emailed users to announce the deprecation of several older preview models in favor of Meta's Llama 4 suite. The new Llama 4 Scout and Maverick models deliver exceptional multimodal performance that outpaces our previous offerings, enabling your applications to harness state-of-the-art AI capabilities with unparalleled speed on our platform.",
+    "url": "https://console.groq.com/docs/deprecations#april-14-2025-multiple-model-deprecations",
+    "content_hash": "1fde5cbdc2352167",
+    "scraped_at": "2026-05-22T16:30:40.111069+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "llama-3.3-70b-specdec",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2025-04-14",
+    "deprecation_date": "2025-04-07",
+    "replacement_models": [
+      "meta-llama/llama-4-scout-17b-16e-instruct",
+      "llama-3.3-70b-versatile"
+    ],
+    "deprecation_context": "In line with our commitment to bringing you cutting-edge models, on April 7, 2025, we emailed users to announce the deprecation of several older preview models in favor of Meta's Llama 4 suite. The new Llama 4 Scout and Maverick models deliver exceptional multimodal performance that outpaces our previous offerings, enabling your applications to harness state-of-the-art AI capabilities with unparalleled speed on our platform.",
+    "url": "https://console.groq.com/docs/deprecations#april-14-2025-multiple-model-deprecations",
+    "content_hash": "b61c2d96c1c7ccd7",
+    "scraped_at": "2026-05-22T16:30:40.111112+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "deepseek-r1-distill-llama-70b-specdec",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2025-04-14",
+    "deprecation_date": "2025-04-07",
+    "replacement_models": [
+      "deepseek-r1-distill-llama-70b",
+      "deepseek-r1-distill-qwen-32b"
+    ],
+    "deprecation_context": "In line with our commitment to bringing you cutting-edge models, on April 7, 2025, we emailed users to announce the deprecation of several older preview models in favor of Meta's Llama 4 suite. The new Llama 4 Scout and Maverick models deliver exceptional multimodal performance that outpaces our previous offerings, enabling your applications to harness state-of-the-art AI capabilities with unparalleled speed on our platform.",
+    "url": "https://console.groq.com/docs/deprecations#april-14-2025-multiple-model-deprecations",
+    "content_hash": "41f9f039689b8e62",
+    "scraped_at": "2026-05-22T16:30:40.111156+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "mixtral-8x7b-32768",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2025-03-20",
+    "deprecation_date": "2026-05-22",
+    "replacement_models": [
+      "mistral-saba-24b",
+      "llama-3.3-70b-versatile"
+    ],
+    "deprecation_context": "On March 5, 2025, we emailed all users of the `mixtral-8x7b-32768` model that we would be deprecating this model ID in favor of newer, more performant models. The recommended replacement models offer superior multilingual capabilities and performance for various tasks from text generation to translation.",
+    "url": "https://console.groq.com/docs/deprecations#march-20-2025-mixtral-8x7b",
+    "content_hash": "3cec3e1a94b12098",
+    "scraped_at": "2026-05-22T16:30:40.111383+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "llama-3.1-70b-versatile",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2025-01-24",
+    "deprecation_date": "2026-05-22",
+    "replacement_models": [
+      "llama-3.3-70b-versatile"
+    ],
+    "deprecation_context": "On December 6, 2024, in partnership with Meta, we released `llama-3.3-70b-versatile` and `llama-3.3-70b-specdec`, and notified users that we would deprecate their 3.1 counterparts in favor of hosting Llama 3.3 with significant quality improvements for a better experience. To facilitate a smooth transition, we will maintain the current `llama-3.1-70b-versatile` and `llama-3.1-70b-specdec` model IDs until December 20, 2024\\. At that time, requests to these model IDs will automatically upgrade to their respective 3.3 versions. Beginning January 24, 2025, requests to both 3.1 model IDs will return errors. While these new models deliver improved quality, they may produce different responses than their predecessors. We recommend migrating to explicitly using `llama-3.3-70b-versatile` and `llama-3.3-70b-specdec` before December 20, 2024, for testing.",
+    "url": "https://console.groq.com/docs/deprecations#january-24-2025-llama-31-70b-and-llama-31-70b-speculative-decoding",
+    "content_hash": "dbe42318dcaf0b75",
+    "scraped_at": "2026-05-22T16:30:40.111517+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "llama-3.1-70b-specdec",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2025-01-24",
+    "deprecation_date": "2026-05-22",
+    "replacement_models": [
+      "llama-3.3-70b-specdec"
+    ],
+    "deprecation_context": "On December 6, 2024, in partnership with Meta, we released `llama-3.3-70b-versatile` and `llama-3.3-70b-specdec`, and notified users that we would deprecate their 3.1 counterparts in favor of hosting Llama 3.3 with significant quality improvements for a better experience. To facilitate a smooth transition, we will maintain the current `llama-3.1-70b-versatile` and `llama-3.1-70b-specdec` model IDs until December 20, 2024\\. At that time, requests to these model IDs will automatically upgrade to their respective 3.3 versions. Beginning January 24, 2025, requests to both 3.1 model IDs will return errors. While these new models deliver improved quality, they may produce different responses than their predecessors. We recommend migrating to explicitly using `llama-3.3-70b-versatile` and `llama-3.3-70b-specdec` before December 20, 2024, for testing.",
+    "url": "https://console.groq.com/docs/deprecations#january-24-2025-llama-31-70b-and-llama-31-70b-speculative-decoding",
+    "content_hash": "ded2d32ce5958284",
+    "scraped_at": "2026-05-22T16:30:40.111554+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "llama3-groq-8b-8192-tool-use-preview",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2025-01-06",
+    "deprecation_date": "2026-05-22",
+    "replacement_models": [
+      "llama-3.3-70b-versatile"
+    ],
+    "deprecation_context": "On January 6th, we deprecated our preview versions of Llama 3 fine-tuned for tool use, `llama3-groq-8b-8192-tool-use-preview` and `llama3-groq-70b-8192-tool-use-preview`, from GroqCloud™ in favor of transitioning users to our production-ready `llama-3.30-70b-versatile` model. Users of the tool use models were notified about the upcoming deprecation via email. The recommended replacement model, `llama-3.3-70b-versatile`, offers superior tool use capabilities and we strongly encourage users to migrate applications to this model for improved reliability and performance.",
+    "url": "https://console.groq.com/docs/deprecations#january-6-2025-llama-3-groq-tool-use-models",
+    "content_hash": "e8a65433d8f8fb9e",
+    "scraped_at": "2026-05-22T16:30:40.111717+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "llama3-groq-70b-8192-tool-use-preview",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2025-01-06",
+    "deprecation_date": "2026-05-22",
+    "replacement_models": [
+      "llama-3.3-70b-versatile"
+    ],
+    "deprecation_context": "On January 6th, we deprecated our preview versions of Llama 3 fine-tuned for tool use, `llama3-groq-8b-8192-tool-use-preview` and `llama3-groq-70b-8192-tool-use-preview`, from GroqCloud™ in favor of transitioning users to our production-ready `llama-3.30-70b-versatile` model. Users of the tool use models were notified about the upcoming deprecation via email. The recommended replacement model, `llama-3.3-70b-versatile`, offers superior tool use capabilities and we strongly encourage users to migrate applications to this model for improved reliability and performance.",
+    "url": "https://console.groq.com/docs/deprecations#january-6-2025-llama-3-groq-tool-use-models",
+    "content_hash": "515db4ba1ae3373b",
+    "scraped_at": "2026-05-22T16:30:40.111762+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "gemma-7b-it",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2024-12-18",
+    "deprecation_date": "2026-05-22",
+    "replacement_models": [
+      "gemma2-9b-it"
+    ],
+    "deprecation_context": "On December 11, 2024, we emailed all Gemma 7B users that we would deprecate it in favor of keeping the Gemma 9B model as it offers better performance.",
+    "url": "https://console.groq.com/docs/deprecations#december-18-2024-gemma-7b",
+    "content_hash": "05f0ae9cc95fafba",
+    "scraped_at": "2026-05-22T16:30:40.111869+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "llama-3.2-90b-text-preview",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2024-11-25",
+    "deprecation_date": "2026-05-22",
+    "replacement_models": [
+      "llama-3.2-90b-vision-preview",
+      "llama-3.1-70b-versatile"
+    ],
+    "deprecation_context": "In November 2024, we emailed all Llama 3.2 90B Text Preview users that we would deprecate it in favor of hosting the Llama 3.2 90B Vision Preview model for vision capabilities.",
+    "url": "https://console.groq.com/docs/deprecations#november-25-2024-llama-32-90b-text-preview",
+    "content_hash": "4a3ed3a489b9db52",
+    "scraped_at": "2026-05-22T16:30:40.112013+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "llava-v1.5-7b-4096-preview",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2024-10-28",
+    "deprecation_date": "2026-05-22",
+    "replacement_models": [
+      "llama-3.2-11b-vision-preview"
+    ],
+    "deprecation_context": "In September 2024, we made Meta's Llama 3.2 vision models available on GroqCloud and emailed all LLaVA 1.5 7B and Llama 3.2 11B Text Preview users that we would deprecate it in favor of hosting Llama 3.2 11B Vision for better performance and more robust vision capabilities.",
+    "url": "https://console.groq.com/docs/deprecations#october-18-2024-llava-15-7b-and-llama-32-11b-text-preview",
+    "content_hash": "2bd5dd00c3a7f9fd",
+    "scraped_at": "2026-05-22T16:30:40.112165+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
+    "provider": "Groq",
+    "model_id": "llama-3.2-11b-text-preview",
+    "announcement_date": "2026-05-22",
+    "shutdown_date": "2024-10-28",
+    "deprecation_date": "2026-05-22",
+    "replacement_models": [
+      "llama-3.2-11b-vision-preview",
+      "llama-3.1-8b-instant"
+    ],
+    "deprecation_context": "In September 2024, we made Meta's Llama 3.2 vision models available on GroqCloud and emailed all LLaVA 1.5 7B and Llama 3.2 11B Text Preview users that we would deprecate it in favor of hosting Llama 3.2 11B Vision for better performance and more robust vision capabilities.",
+    "url": "https://console.groq.com/docs/deprecations#october-18-2024-llava-15-7b-and-llama-32-11b-text-preview",
+    "content_hash": "bedb432071dd6aed",
+    "scraped_at": "2026-05-22T16:30:40.112222+00:00",
+    "first_observed": "2026-05-22",
+    "last_observed": "2026-05-22"
+  },
+  {
     "provider": "xAI",
     "model_id": "grok-4-1-fast",
     "announcement_date": "2026-05-14",

--- a/docs/v1/feed.json
+++ b/docs/v1/feed.json
@@ -5364,6 +5364,750 @@
       ]
     },
     {
+      "id": "groq-moonshotai/kimi-k2-instruct-0905",
+      "url": "https://console.groq.com/docs/deprecations#april-15-2026-moonshotaikimik2instruct0905",
+      "title": "Groq: moonshotai/kimi-k2-instruct-0905",
+      "content_text": "",
+      "date_published": "2026-05-22T16:30:40.109049+00:00",
+      "_deprecation": {
+        "provider": "Groq",
+        "model_id": "moonshotai/kimi-k2-instruct-0905",
+        "shutdown_date": "2026-04-15",
+        "deprecation_date": "2026-03-23",
+        "announcement_date": "2026-05-22",
+        "replacement_models": [
+          "openai/gpt-oss-120b"
+        ],
+        "first_observed": "2026-05-22",
+        "last_observed": "2026-05-22"
+      },
+      "tags": [
+        "Groq",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "groq-meta-llama/llama-4-maverick-17b-128e-instruct",
+      "url": "https://console.groq.com/docs/deprecations#march-9-2026-metallamallama4maverick17b128einstruct",
+      "title": "Groq: meta-llama/llama-4-maverick-17b-128e-instruct",
+      "content_text": "",
+      "date_published": "2026-05-22T16:30:40.109215+00:00",
+      "_deprecation": {
+        "provider": "Groq",
+        "model_id": "meta-llama/llama-4-maverick-17b-128e-instruct",
+        "shutdown_date": "2026-03-09",
+        "deprecation_date": "2026-02-20",
+        "announcement_date": "2026-05-22",
+        "replacement_models": [
+          "openai/gpt-oss-120b"
+        ],
+        "first_observed": "2026-05-22",
+        "last_observed": "2026-05-22"
+      },
+      "tags": [
+        "Groq",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "groq-meta-llama/llama-guard-4-12b",
+      "url": "https://console.groq.com/docs/deprecations#march-5-2026-metallamallamaguard412b",
+      "title": "Groq: meta-llama/llama-guard-4-12b",
+      "content_text": "",
+      "date_published": "2026-05-22T16:30:40.109338+00:00",
+      "_deprecation": {
+        "provider": "Groq",
+        "model_id": "meta-llama/llama-guard-4-12b",
+        "shutdown_date": "2026-03-05",
+        "deprecation_date": "2026-02-10",
+        "announcement_date": "2026-05-22",
+        "replacement_models": [
+          "openai/gpt-oss-safeguard-20b"
+        ],
+        "first_observed": "2026-05-22",
+        "last_observed": "2026-05-22"
+      },
+      "tags": [
+        "Groq",
+        "shutdown-2026"
+      ]
+    },
+    {
+      "id": "groq-playai-tts",
+      "url": "https://console.groq.com/docs/deprecations#december-31-2025-playaitts-and-playaittsarabic",
+      "title": "Groq: playai-tts",
+      "content_text": "",
+      "date_published": "2026-05-22T16:30:40.109464+00:00",
+      "_deprecation": {
+        "provider": "Groq",
+        "model_id": "playai-tts",
+        "shutdown_date": "2025-12-31",
+        "deprecation_date": "2025-12-23",
+        "announcement_date": "2026-05-22",
+        "replacement_models": [
+          "canopylabs/orpheus-v1-english"
+        ],
+        "first_observed": "2026-05-22",
+        "last_observed": "2026-05-22"
+      },
+      "tags": [
+        "Groq",
+        "shutdown-2025"
+      ]
+    },
+    {
+      "id": "groq-playai-tts-arabic",
+      "url": "https://console.groq.com/docs/deprecations#december-31-2025-playaitts-and-playaittsarabic",
+      "title": "Groq: playai-tts-arabic",
+      "content_text": "",
+      "date_published": "2026-05-22T16:30:40.109504+00:00",
+      "_deprecation": {
+        "provider": "Groq",
+        "model_id": "playai-tts-arabic",
+        "shutdown_date": "2025-12-31",
+        "deprecation_date": "2025-12-23",
+        "announcement_date": "2026-05-22",
+        "replacement_models": [
+          "canopylabs/orpheus-arabic-saudi"
+        ],
+        "first_observed": "2026-05-22",
+        "last_observed": "2026-05-22"
+      },
+      "tags": [
+        "Groq",
+        "shutdown-2025"
+      ]
+    },
+    {
+      "id": "groq-moonshotai/kimi-k2-instruct",
+      "url": "https://console.groq.com/docs/deprecations#october-10-2025-moonshotaikimik2instruct",
+      "title": "Groq: moonshotai/kimi-k2-instruct",
+      "content_text": "",
+      "date_published": "2026-05-22T16:30:40.109617+00:00",
+      "_deprecation": {
+        "provider": "Groq",
+        "model_id": "moonshotai/kimi-k2-instruct",
+        "shutdown_date": "2025-10-10",
+        "deprecation_date": "2025-09-10",
+        "announcement_date": "2026-05-22",
+        "replacement_models": [
+          "openai/gpt-oss-120b"
+        ],
+        "first_observed": "2026-05-22",
+        "last_observed": "2026-05-22"
+      },
+      "tags": [
+        "Groq",
+        "shutdown-2025"
+      ]
+    },
+    {
+      "id": "groq-gemma2-9b-it",
+      "url": "https://console.groq.com/docs/deprecations#october-8-2025-gemma29bit",
+      "title": "Groq: gemma2-9b-it",
+      "content_text": "",
+      "date_published": "2026-05-22T16:30:40.109726+00:00",
+      "_deprecation": {
+        "provider": "Groq",
+        "model_id": "gemma2-9b-it",
+        "shutdown_date": "2025-10-08",
+        "deprecation_date": "2025-08-08",
+        "announcement_date": "2026-05-22",
+        "replacement_models": [
+          "llama-3.1-8b-instant"
+        ],
+        "first_observed": "2026-05-22",
+        "last_observed": "2026-05-22"
+      },
+      "tags": [
+        "Groq",
+        "shutdown-2025"
+      ]
+    },
+    {
+      "id": "groq-deepseek-r1-distill-llama-70b",
+      "url": "https://console.groq.com/docs/deprecations#october-2-2025-deepseekr1distillllama70b",
+      "title": "Groq: deepseek-r1-distill-llama-70b",
+      "content_text": "",
+      "date_published": "2026-05-22T16:30:40.109846+00:00",
+      "_deprecation": {
+        "provider": "Groq",
+        "model_id": "deepseek-r1-distill-llama-70b",
+        "shutdown_date": "2025-10-02",
+        "deprecation_date": "2025-09-02",
+        "announcement_date": "2026-05-22",
+        "replacement_models": [
+          "llama-3.3-70b-versatile",
+          "openai/gpt-oss-120b"
+        ],
+        "first_observed": "2026-05-22",
+        "last_observed": "2026-05-22"
+      },
+      "tags": [
+        "Groq",
+        "shutdown-2025"
+      ]
+    },
+    {
+      "id": "groq-llama3-70b-8192",
+      "url": "https://console.groq.com/docs/deprecations#august-30-2025-llama370b8192-and-llama38b8192",
+      "title": "Groq: llama3-70b-8192",
+      "content_text": "",
+      "date_published": "2026-05-22T16:30:40.109963+00:00",
+      "_deprecation": {
+        "provider": "Groq",
+        "model_id": "llama3-70b-8192",
+        "shutdown_date": "2025-08-30",
+        "deprecation_date": "2025-05-31",
+        "announcement_date": "2026-05-22",
+        "replacement_models": [
+          "llama-3.3-70b-versatile"
+        ],
+        "first_observed": "2026-05-22",
+        "last_observed": "2026-05-22"
+      },
+      "tags": [
+        "Groq",
+        "shutdown-2025"
+      ]
+    },
+    {
+      "id": "groq-llama3-8b-8192",
+      "url": "https://console.groq.com/docs/deprecations#august-30-2025-llama370b8192-and-llama38b8192",
+      "title": "Groq: llama3-8b-8192",
+      "content_text": "",
+      "date_published": "2026-05-22T16:30:40.110002+00:00",
+      "_deprecation": {
+        "provider": "Groq",
+        "model_id": "llama3-8b-8192",
+        "shutdown_date": "2025-08-30",
+        "deprecation_date": "2025-05-31",
+        "announcement_date": "2026-05-22",
+        "replacement_models": [
+          "llama-3.1-8b-instant"
+        ],
+        "first_observed": "2026-05-22",
+        "last_observed": "2026-05-22"
+      },
+      "tags": [
+        "Groq",
+        "shutdown-2025"
+      ]
+    },
+    {
+      "id": "groq-distil-whisper-large-v3-en",
+      "url": "https://console.groq.com/docs/deprecations#august-23-2025-distil-whisper-large-v3-english",
+      "title": "Groq: distil-whisper-large-v3-en",
+      "content_text": "",
+      "date_published": "2026-05-22T16:30:40.110235+00:00",
+      "_deprecation": {
+        "provider": "Groq",
+        "model_id": "distil-whisper-large-v3-en",
+        "shutdown_date": "2025-08-23",
+        "deprecation_date": "2026-05-22",
+        "announcement_date": "2026-05-22",
+        "replacement_models": [
+          "whisper-large-v3-turbo"
+        ],
+        "first_observed": "2026-05-22",
+        "last_observed": "2026-05-22"
+      },
+      "tags": [
+        "Groq",
+        "shutdown-2025"
+      ]
+    },
+    {
+      "id": "groq-mistral-saba-24b",
+      "url": "https://console.groq.com/docs/deprecations#july-30-2025-mistral-saba-24b",
+      "title": "Groq: mistral-saba-24b",
+      "content_text": "",
+      "date_published": "2026-05-22T16:30:40.110341+00:00",
+      "_deprecation": {
+        "provider": "Groq",
+        "model_id": "mistral-saba-24b",
+        "shutdown_date": "2025-07-30",
+        "deprecation_date": "2026-05-22",
+        "announcement_date": "2026-05-22",
+        "replacement_models": [
+          "qwen/qwen3-32b"
+        ],
+        "first_observed": "2026-05-22",
+        "last_observed": "2026-05-22"
+      },
+      "tags": [
+        "Groq",
+        "shutdown-2025"
+      ]
+    },
+    {
+      "id": "groq-qwen-qwq-32b",
+      "url": "https://console.groq.com/docs/deprecations#july-14-2025-qwen-qwq-32b",
+      "title": "Groq: qwen-qwq-32b",
+      "content_text": "",
+      "date_published": "2026-05-22T16:30:40.110438+00:00",
+      "_deprecation": {
+        "provider": "Groq",
+        "model_id": "qwen-qwq-32b",
+        "shutdown_date": "2025-07-14",
+        "deprecation_date": "2026-05-22",
+        "announcement_date": "2026-05-22",
+        "replacement_models": [
+          "qwen/qwen3-32b"
+        ],
+        "first_observed": "2026-05-22",
+        "last_observed": "2026-05-22"
+      },
+      "tags": [
+        "Groq",
+        "shutdown-2025"
+      ]
+    },
+    {
+      "id": "groq-llama-guard-3-8b",
+      "url": "https://console.groq.com/docs/deprecations#june-6-2025-llama-guard-3",
+      "title": "Groq: llama-guard-3-8b",
+      "content_text": "",
+      "date_published": "2026-05-22T16:30:40.110542+00:00",
+      "_deprecation": {
+        "provider": "Groq",
+        "model_id": "llama-guard-3-8b",
+        "shutdown_date": "2025-06-06",
+        "deprecation_date": "2025-05-09",
+        "announcement_date": "2026-05-22",
+        "replacement_models": [
+          "meta-llama/llama-guard-4-12b"
+        ],
+        "first_observed": "2026-05-22",
+        "last_observed": "2026-05-22"
+      },
+      "tags": [
+        "Groq",
+        "shutdown-2025"
+      ]
+    },
+    {
+      "id": "groq-llama-3.2-1b-preview",
+      "url": "https://console.groq.com/docs/deprecations#april-14-2025-multiple-model-deprecations",
+      "title": "Groq: llama-3.2-1b-preview",
+      "content_text": "",
+      "date_published": "2026-05-22T16:30:40.110825+00:00",
+      "_deprecation": {
+        "provider": "Groq",
+        "model_id": "llama-3.2-1b-preview",
+        "shutdown_date": "2025-04-14",
+        "deprecation_date": "2025-04-07",
+        "announcement_date": "2026-05-22",
+        "replacement_models": [
+          "llama-3.1-8b-instant"
+        ],
+        "first_observed": "2026-05-22",
+        "last_observed": "2026-05-22"
+      },
+      "tags": [
+        "Groq",
+        "shutdown-2025"
+      ]
+    },
+    {
+      "id": "groq-llama-3.2-3b-preview",
+      "url": "https://console.groq.com/docs/deprecations#april-14-2025-multiple-model-deprecations",
+      "title": "Groq: llama-3.2-3b-preview",
+      "content_text": "",
+      "date_published": "2026-05-22T16:30:40.110867+00:00",
+      "_deprecation": {
+        "provider": "Groq",
+        "model_id": "llama-3.2-3b-preview",
+        "shutdown_date": "2025-04-14",
+        "deprecation_date": "2025-04-07",
+        "announcement_date": "2026-05-22",
+        "replacement_models": [
+          "llama-3.1-8b-instant"
+        ],
+        "first_observed": "2026-05-22",
+        "last_observed": "2026-05-22"
+      },
+      "tags": [
+        "Groq",
+        "shutdown-2025"
+      ]
+    },
+    {
+      "id": "groq-llama-3.2-11b-vision-preview",
+      "url": "https://console.groq.com/docs/deprecations#april-14-2025-multiple-model-deprecations",
+      "title": "Groq: llama-3.2-11b-vision-preview",
+      "content_text": "",
+      "date_published": "2026-05-22T16:30:40.110908+00:00",
+      "_deprecation": {
+        "provider": "Groq",
+        "model_id": "llama-3.2-11b-vision-preview",
+        "shutdown_date": "2025-04-14",
+        "deprecation_date": "2025-04-07",
+        "announcement_date": "2026-05-22",
+        "replacement_models": [
+          "meta-llama/llama-4-scout-17b-16e-instruct"
+        ],
+        "first_observed": "2026-05-22",
+        "last_observed": "2026-05-22"
+      },
+      "tags": [
+        "Groq",
+        "shutdown-2025"
+      ]
+    },
+    {
+      "id": "groq-llama-3.2-90b-vision-preview",
+      "url": "https://console.groq.com/docs/deprecations#april-14-2025-multiple-model-deprecations",
+      "title": "Groq: llama-3.2-90b-vision-preview",
+      "content_text": "",
+      "date_published": "2026-05-22T16:30:40.110947+00:00",
+      "_deprecation": {
+        "provider": "Groq",
+        "model_id": "llama-3.2-90b-vision-preview",
+        "shutdown_date": "2025-04-14",
+        "deprecation_date": "2025-04-07",
+        "announcement_date": "2026-05-22",
+        "replacement_models": [
+          "meta-llama/llama-4-scout-17b-16e-instruct"
+        ],
+        "first_observed": "2026-05-22",
+        "last_observed": "2026-05-22"
+      },
+      "tags": [
+        "Groq",
+        "shutdown-2025"
+      ]
+    },
+    {
+      "id": "groq-deepseek-r1-distill-qwen-32b",
+      "url": "https://console.groq.com/docs/deprecations#april-14-2025-multiple-model-deprecations",
+      "title": "Groq: deepseek-r1-distill-qwen-32b",
+      "content_text": "",
+      "date_published": "2026-05-22T16:30:40.110986+00:00",
+      "_deprecation": {
+        "provider": "Groq",
+        "model_id": "deepseek-r1-distill-qwen-32b",
+        "shutdown_date": "2025-04-14",
+        "deprecation_date": "2025-04-07",
+        "announcement_date": "2026-05-22",
+        "replacement_models": [
+          "qwen-qwq-32b"
+        ],
+        "first_observed": "2026-05-22",
+        "last_observed": "2026-05-22"
+      },
+      "tags": [
+        "Groq",
+        "shutdown-2025"
+      ]
+    },
+    {
+      "id": "groq-qwen-2.5-32b",
+      "url": "https://console.groq.com/docs/deprecations#april-14-2025-multiple-model-deprecations",
+      "title": "Groq: qwen-2.5-32b",
+      "content_text": "",
+      "date_published": "2026-05-22T16:30:40.111029+00:00",
+      "_deprecation": {
+        "provider": "Groq",
+        "model_id": "qwen-2.5-32b",
+        "shutdown_date": "2025-04-14",
+        "deprecation_date": "2025-04-07",
+        "announcement_date": "2026-05-22",
+        "replacement_models": [
+          "qwen-qwq-32b",
+          "meta-llama/llama-4-scout-17b-16e-instruct"
+        ],
+        "first_observed": "2026-05-22",
+        "last_observed": "2026-05-22"
+      },
+      "tags": [
+        "Groq",
+        "shutdown-2025"
+      ]
+    },
+    {
+      "id": "groq-qwen-2.5-coder-32b",
+      "url": "https://console.groq.com/docs/deprecations#april-14-2025-multiple-model-deprecations",
+      "title": "Groq: qwen-2.5-coder-32b",
+      "content_text": "",
+      "date_published": "2026-05-22T16:30:40.111069+00:00",
+      "_deprecation": {
+        "provider": "Groq",
+        "model_id": "qwen-2.5-coder-32b",
+        "shutdown_date": "2025-04-14",
+        "deprecation_date": "2025-04-07",
+        "announcement_date": "2026-05-22",
+        "replacement_models": [
+          "qwen-qwq-32b",
+          "openai/gpt-oss-120b"
+        ],
+        "first_observed": "2026-05-22",
+        "last_observed": "2026-05-22"
+      },
+      "tags": [
+        "Groq",
+        "shutdown-2025"
+      ]
+    },
+    {
+      "id": "groq-llama-3.3-70b-specdec",
+      "url": "https://console.groq.com/docs/deprecations#april-14-2025-multiple-model-deprecations",
+      "title": "Groq: llama-3.3-70b-specdec",
+      "content_text": "",
+      "date_published": "2026-05-22T16:30:40.111112+00:00",
+      "_deprecation": {
+        "provider": "Groq",
+        "model_id": "llama-3.3-70b-specdec",
+        "shutdown_date": "2025-04-14",
+        "deprecation_date": "2025-04-07",
+        "announcement_date": "2026-05-22",
+        "replacement_models": [
+          "meta-llama/llama-4-scout-17b-16e-instruct",
+          "llama-3.3-70b-versatile"
+        ],
+        "first_observed": "2026-05-22",
+        "last_observed": "2026-05-22"
+      },
+      "tags": [
+        "Groq",
+        "shutdown-2025"
+      ]
+    },
+    {
+      "id": "groq-deepseek-r1-distill-llama-70b-specdec",
+      "url": "https://console.groq.com/docs/deprecations#april-14-2025-multiple-model-deprecations",
+      "title": "Groq: deepseek-r1-distill-llama-70b-specdec",
+      "content_text": "",
+      "date_published": "2026-05-22T16:30:40.111156+00:00",
+      "_deprecation": {
+        "provider": "Groq",
+        "model_id": "deepseek-r1-distill-llama-70b-specdec",
+        "shutdown_date": "2025-04-14",
+        "deprecation_date": "2025-04-07",
+        "announcement_date": "2026-05-22",
+        "replacement_models": [
+          "deepseek-r1-distill-llama-70b",
+          "deepseek-r1-distill-qwen-32b"
+        ],
+        "first_observed": "2026-05-22",
+        "last_observed": "2026-05-22"
+      },
+      "tags": [
+        "Groq",
+        "shutdown-2025"
+      ]
+    },
+    {
+      "id": "groq-mixtral-8x7b-32768",
+      "url": "https://console.groq.com/docs/deprecations#march-20-2025-mixtral-8x7b",
+      "title": "Groq: mixtral-8x7b-32768",
+      "content_text": "",
+      "date_published": "2026-05-22T16:30:40.111383+00:00",
+      "_deprecation": {
+        "provider": "Groq",
+        "model_id": "mixtral-8x7b-32768",
+        "shutdown_date": "2025-03-20",
+        "deprecation_date": "2026-05-22",
+        "announcement_date": "2026-05-22",
+        "replacement_models": [
+          "mistral-saba-24b",
+          "llama-3.3-70b-versatile"
+        ],
+        "first_observed": "2026-05-22",
+        "last_observed": "2026-05-22"
+      },
+      "tags": [
+        "Groq",
+        "shutdown-2025"
+      ]
+    },
+    {
+      "id": "groq-llama-3.1-70b-versatile",
+      "url": "https://console.groq.com/docs/deprecations#january-24-2025-llama-31-70b-and-llama-31-70b-speculative-decoding",
+      "title": "Groq: llama-3.1-70b-versatile",
+      "content_text": "",
+      "date_published": "2026-05-22T16:30:40.111517+00:00",
+      "_deprecation": {
+        "provider": "Groq",
+        "model_id": "llama-3.1-70b-versatile",
+        "shutdown_date": "2025-01-24",
+        "deprecation_date": "2026-05-22",
+        "announcement_date": "2026-05-22",
+        "replacement_models": [
+          "llama-3.3-70b-versatile"
+        ],
+        "first_observed": "2026-05-22",
+        "last_observed": "2026-05-22"
+      },
+      "tags": [
+        "Groq",
+        "shutdown-2025"
+      ]
+    },
+    {
+      "id": "groq-llama-3.1-70b-specdec",
+      "url": "https://console.groq.com/docs/deprecations#january-24-2025-llama-31-70b-and-llama-31-70b-speculative-decoding",
+      "title": "Groq: llama-3.1-70b-specdec",
+      "content_text": "",
+      "date_published": "2026-05-22T16:30:40.111554+00:00",
+      "_deprecation": {
+        "provider": "Groq",
+        "model_id": "llama-3.1-70b-specdec",
+        "shutdown_date": "2025-01-24",
+        "deprecation_date": "2026-05-22",
+        "announcement_date": "2026-05-22",
+        "replacement_models": [
+          "llama-3.3-70b-specdec"
+        ],
+        "first_observed": "2026-05-22",
+        "last_observed": "2026-05-22"
+      },
+      "tags": [
+        "Groq",
+        "shutdown-2025"
+      ]
+    },
+    {
+      "id": "groq-llama3-groq-8b-8192-tool-use-preview",
+      "url": "https://console.groq.com/docs/deprecations#january-6-2025-llama-3-groq-tool-use-models",
+      "title": "Groq: llama3-groq-8b-8192-tool-use-preview",
+      "content_text": "",
+      "date_published": "2026-05-22T16:30:40.111717+00:00",
+      "_deprecation": {
+        "provider": "Groq",
+        "model_id": "llama3-groq-8b-8192-tool-use-preview",
+        "shutdown_date": "2025-01-06",
+        "deprecation_date": "2026-05-22",
+        "announcement_date": "2026-05-22",
+        "replacement_models": [
+          "llama-3.3-70b-versatile"
+        ],
+        "first_observed": "2026-05-22",
+        "last_observed": "2026-05-22"
+      },
+      "tags": [
+        "Groq",
+        "shutdown-2025"
+      ]
+    },
+    {
+      "id": "groq-llama3-groq-70b-8192-tool-use-preview",
+      "url": "https://console.groq.com/docs/deprecations#january-6-2025-llama-3-groq-tool-use-models",
+      "title": "Groq: llama3-groq-70b-8192-tool-use-preview",
+      "content_text": "",
+      "date_published": "2026-05-22T16:30:40.111762+00:00",
+      "_deprecation": {
+        "provider": "Groq",
+        "model_id": "llama3-groq-70b-8192-tool-use-preview",
+        "shutdown_date": "2025-01-06",
+        "deprecation_date": "2026-05-22",
+        "announcement_date": "2026-05-22",
+        "replacement_models": [
+          "llama-3.3-70b-versatile"
+        ],
+        "first_observed": "2026-05-22",
+        "last_observed": "2026-05-22"
+      },
+      "tags": [
+        "Groq",
+        "shutdown-2025"
+      ]
+    },
+    {
+      "id": "groq-gemma-7b-it",
+      "url": "https://console.groq.com/docs/deprecations#december-18-2024-gemma-7b",
+      "title": "Groq: gemma-7b-it",
+      "content_text": "",
+      "date_published": "2026-05-22T16:30:40.111869+00:00",
+      "_deprecation": {
+        "provider": "Groq",
+        "model_id": "gemma-7b-it",
+        "shutdown_date": "2024-12-18",
+        "deprecation_date": "2026-05-22",
+        "announcement_date": "2026-05-22",
+        "replacement_models": [
+          "gemma2-9b-it"
+        ],
+        "first_observed": "2026-05-22",
+        "last_observed": "2026-05-22"
+      },
+      "tags": [
+        "Groq",
+        "shutdown-2024"
+      ]
+    },
+    {
+      "id": "groq-llama-3.2-90b-text-preview",
+      "url": "https://console.groq.com/docs/deprecations#november-25-2024-llama-32-90b-text-preview",
+      "title": "Groq: llama-3.2-90b-text-preview",
+      "content_text": "",
+      "date_published": "2026-05-22T16:30:40.112013+00:00",
+      "_deprecation": {
+        "provider": "Groq",
+        "model_id": "llama-3.2-90b-text-preview",
+        "shutdown_date": "2024-11-25",
+        "deprecation_date": "2026-05-22",
+        "announcement_date": "2026-05-22",
+        "replacement_models": [
+          "llama-3.2-90b-vision-preview",
+          "llama-3.1-70b-versatile"
+        ],
+        "first_observed": "2026-05-22",
+        "last_observed": "2026-05-22"
+      },
+      "tags": [
+        "Groq",
+        "shutdown-2024"
+      ]
+    },
+    {
+      "id": "groq-llava-v1.5-7b-4096-preview",
+      "url": "https://console.groq.com/docs/deprecations#october-18-2024-llava-15-7b-and-llama-32-11b-text-preview",
+      "title": "Groq: llava-v1.5-7b-4096-preview",
+      "content_text": "",
+      "date_published": "2026-05-22T16:30:40.112165+00:00",
+      "_deprecation": {
+        "provider": "Groq",
+        "model_id": "llava-v1.5-7b-4096-preview",
+        "shutdown_date": "2024-10-28",
+        "deprecation_date": "2026-05-22",
+        "announcement_date": "2026-05-22",
+        "replacement_models": [
+          "llama-3.2-11b-vision-preview"
+        ],
+        "first_observed": "2026-05-22",
+        "last_observed": "2026-05-22"
+      },
+      "tags": [
+        "Groq",
+        "shutdown-2024"
+      ]
+    },
+    {
+      "id": "groq-llama-3.2-11b-text-preview",
+      "url": "https://console.groq.com/docs/deprecations#october-18-2024-llava-15-7b-and-llama-32-11b-text-preview",
+      "title": "Groq: llama-3.2-11b-text-preview",
+      "content_text": "",
+      "date_published": "2026-05-22T16:30:40.112222+00:00",
+      "_deprecation": {
+        "provider": "Groq",
+        "model_id": "llama-3.2-11b-text-preview",
+        "shutdown_date": "2024-10-28",
+        "deprecation_date": "2026-05-22",
+        "announcement_date": "2026-05-22",
+        "replacement_models": [
+          "llama-3.2-11b-vision-preview",
+          "llama-3.1-8b-instant"
+        ],
+        "first_observed": "2026-05-22",
+        "last_observed": "2026-05-22"
+      },
+      "tags": [
+        "Groq",
+        "shutdown-2024"
+      ]
+    },
+    {
       "id": "xai-grok-4-1-fast",
       "url": "https://docs.x.ai/developers/models",
       "title": "xAI: grok-4-1-fast",

--- a/docs/v1/feed.xml
+++ b/docs/v1/feed.xml
@@ -4,7 +4,7 @@
     <title>AI Model Deprecations</title>
     <link>https://deprecations.info/</link>
     <description>RSS feed tracking deprecations across major AI providers</description>
-    <lastBuildDate>Fri, 22 May 2026 06:09:45 GMT</lastBuildDate>
+    <lastBuildDate>Fri, 22 May 2026 16:30:40 GMT</lastBuildDate>
     <item>
       <title>OpenAI: gpt-5.2-chat-latest</title>
       <link>https://platform.openai.com/docs/deprecations#2026-05-08-gpt-5-2-chat-latest-and-gpt-5-3-chat-latest-model-snapshots</link>
@@ -3324,6 +3324,454 @@ Last Observed: 2026-05-01
 On December 2nd, 2024, we announced the release of Rerank-v3.5 along with the deprecation of the Rerank-v2.0 model family. Fine-tuned models created from these base models are not affected by this deprecation. | Shutdown Date | Deprecated Model           | Deprecated Model Price | Recommended Replacement | | ------------- | -------------------------- | ---------------------- | ----------------------- | | 2025-04-30    | `rerank-english-v2.0`      | \$1.00 / 1K searches   | `rerank-v3.5`         ...</description>
       <pubDate>Fri, 01 May 2026 21:39:32 GMT</pubDate>
       <guid isPermaLink="false">Cohere-rerank-multilingual-v2.0-2025-04-30-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Groq: moonshotai/kimi-k2-instruct-0905</title>
+      <link>https://console.groq.com/docs/deprecations#april-15-2026-moonshotaikimik2instruct0905</link>
+      <description>Provider: Groq
+Model ID: moonshotai/kimi-k2-instruct-0905
+Deprecation Date: 2026-03-23
+Shutdown Date: 2026-04-15
+First Observed: 2026-05-22
+Last Observed: 2026-05-22
+
+In line with our commitment to bringing you cutting-edge models, on March 23, 2026, we emailed users to announce the deprecation of `moonshotai/kimi-k2-instruct-0905` in favor of`openai/gpt-oss-120b`. The GPT-OSS 120B model delivers exceptional reasoning performance with faster inference, enabling your applications to harness state-of-the-art AI capabilities with unparalleled speed on our platform.</description>
+      <pubDate>Fri, 22 May 2026 16:30:40 GMT</pubDate>
+      <guid isPermaLink="false">Groq-moonshotai/kimi-k2-instruct-0905-2026-04-15-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Groq: meta-llama/llama-4-maverick-17b-128e-instruct</title>
+      <link>https://console.groq.com/docs/deprecations#march-9-2026-metallamallama4maverick17b128einstruct</link>
+      <description>Provider: Groq
+Model ID: meta-llama/llama-4-maverick-17b-128e-instruct
+Deprecation Date: 2026-02-20
+Shutdown Date: 2026-03-09
+First Observed: 2026-05-22
+Last Observed: 2026-05-22
+
+In line with our commitment to bringing you cutting-edge models, on February 20, 2026, we emailed users to announce the deprecation of `meta-llama/llama-4-maverick-17b-128e-instruct` in favor of`openai/gpt-oss-120b`. The GPT-OSS 120B model delivers exceptional reasoning performance with faster inference, enabling your applications to harness state-of-the-art AI capabilities with unparalleled speed on our platform.</description>
+      <pubDate>Fri, 22 May 2026 16:30:40 GMT</pubDate>
+      <guid isPermaLink="false">Groq-meta-llama/llama-4-maverick-17b-128e-instruct-2026-03-09-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Groq: meta-llama/llama-guard-4-12b</title>
+      <link>https://console.groq.com/docs/deprecations#march-5-2026-metallamallamaguard412b</link>
+      <description>Provider: Groq
+Model ID: meta-llama/llama-guard-4-12b
+Deprecation Date: 2026-02-10
+Shutdown Date: 2026-03-05
+First Observed: 2026-05-22
+Last Observed: 2026-05-22
+
+In line with our commitment to bringing you cutting-edge models, on February 10, 2026, we emailed users to announce the deprecation of `meta-llama/llama-guard-4-12b` in favor of`openai/gpt-oss-safeguard-20b`. The new GPT-OSS-Safeguard model delivers policy-following reasoning capabilities for Trust &amp; Safety workflows, enabling customizable content moderation with bring-your-own-policy support.</description>
+      <pubDate>Fri, 22 May 2026 16:30:40 GMT</pubDate>
+      <guid isPermaLink="false">Groq-meta-llama/llama-guard-4-12b-2026-03-05-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Groq: playai-tts</title>
+      <link>https://console.groq.com/docs/deprecations#december-31-2025-playaitts-and-playaittsarabic</link>
+      <description>Provider: Groq
+Model ID: playai-tts
+Deprecation Date: 2025-12-23
+Shutdown Date: 2025-12-31
+First Observed: 2026-05-22
+Last Observed: 2026-05-22
+
+In line with our commitment to bringing you cutting-edge models, on December 23, 2025, we emailed users to announce the deprecation of `playai-tts` and `playai-tts-arabic` in favor of the newer Orpheus text-to-speech models from Canopy Labs. The new Orpheus models deliver enhanced expressiveness with vocal direction controls, faster inference, and improved audio quality for your text-to-speech applications.</description>
+      <pubDate>Fri, 22 May 2026 16:30:40 GMT</pubDate>
+      <guid isPermaLink="false">Groq-playai-tts-2025-12-31-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Groq: playai-tts-arabic</title>
+      <link>https://console.groq.com/docs/deprecations#december-31-2025-playaitts-and-playaittsarabic</link>
+      <description>Provider: Groq
+Model ID: playai-tts-arabic
+Deprecation Date: 2025-12-23
+Shutdown Date: 2025-12-31
+First Observed: 2026-05-22
+Last Observed: 2026-05-22
+
+In line with our commitment to bringing you cutting-edge models, on December 23, 2025, we emailed users to announce the deprecation of `playai-tts` and `playai-tts-arabic` in favor of the newer Orpheus text-to-speech models from Canopy Labs. The new Orpheus models deliver enhanced expressiveness with vocal direction controls, faster inference, and improved audio quality for your text-to-speech applications.</description>
+      <pubDate>Fri, 22 May 2026 16:30:40 GMT</pubDate>
+      <guid isPermaLink="false">Groq-playai-tts-arabic-2025-12-31-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Groq: moonshotai/kimi-k2-instruct</title>
+      <link>https://console.groq.com/docs/deprecations#october-10-2025-moonshotaikimik2instruct</link>
+      <description>Provider: Groq
+Model ID: moonshotai/kimi-k2-instruct
+Deprecation Date: 2025-09-10
+Shutdown Date: 2025-10-10
+First Observed: 2026-05-22
+Last Observed: 2026-05-22
+
+In line with our commitment to bringing you cutting-edge models, on September 10, 2025, we emailed users to announce the deprecation of `moonshotai/kimi-k2-instruct` in favor of `moonshotai/kimi-k2-instruct-0905`. The newer Kimi K2 0905 model delivers a 256K context window and improved agentic coding capabilities at the same speed and price as the original Kimi K2 model.</description>
+      <pubDate>Fri, 22 May 2026 16:30:40 GMT</pubDate>
+      <guid isPermaLink="false">Groq-moonshotai/kimi-k2-instruct-2025-10-10-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Groq: gemma2-9b-it</title>
+      <link>https://console.groq.com/docs/deprecations#october-8-2025-gemma29bit</link>
+      <description>Provider: Groq
+Model ID: gemma2-9b-it
+Deprecation Date: 2025-08-08
+Shutdown Date: 2025-10-08
+First Observed: 2026-05-22
+Last Observed: 2026-05-22
+
+In line with our commitment to bringing you cutting-edge models, on August 8, 2025, we emailed users to announce the deprecation of `gemma2-9b-it` in favor of `llama-3.1-8b-instant`. The newer Llama 3.1 8B model delivers exceptional price-performance at the same speed as the Gemma 2 9B model.</description>
+      <pubDate>Fri, 22 May 2026 16:30:40 GMT</pubDate>
+      <guid isPermaLink="false">Groq-gemma2-9b-it-2025-10-08-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Groq: deepseek-r1-distill-llama-70b</title>
+      <link>https://console.groq.com/docs/deprecations#october-2-2025-deepseekr1distillllama70b</link>
+      <description>Provider: Groq
+Model ID: deepseek-r1-distill-llama-70b
+Deprecation Date: 2025-09-02
+Shutdown Date: 2025-10-02
+First Observed: 2026-05-22
+Last Observed: 2026-05-22
+
+In line with our commitment to bringing you cutting-edge models, on September 2, 2025, we emailed users to announce the deprecation of `deepseek-r1-distill-llama-70b` in favor of `llama-3.3-70b-versatile` or `openai/gpt-oss-120b`. The Llama 3.3 70B and GPT-OSS 120B models deliver exceptional performance, enabling your applications to harness state-of-the-art text generation with unparalleled speed on our platform.</description>
+      <pubDate>Fri, 22 May 2026 16:30:40 GMT</pubDate>
+      <guid isPermaLink="false">Groq-deepseek-r1-distill-llama-70b-2025-10-02-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Groq: llama3-70b-8192</title>
+      <link>https://console.groq.com/docs/deprecations#august-30-2025-llama370b8192-and-llama38b8192</link>
+      <description>Provider: Groq
+Model ID: llama3-70b-8192
+Deprecation Date: 2025-05-31
+Shutdown Date: 2025-08-30
+First Observed: 2026-05-22
+Last Observed: 2026-05-22
+
+In line with our commitment to bringing you cutting-edge models, on May 31, 2025, we emailed users to announce the deprecation of `llama3-70b-8192` and `llama3-8b-8192` in favor of`llama-3.3-70b-versatile` and `llama-3.1-8b-instant` respectively. The newer Llama 3.3 70B and Llama 3.1 8B models deliver exceptional performance, enabling your applications to harness state-of-the-art text generation with unparalleled speed on our platform.</description>
+      <pubDate>Fri, 22 May 2026 16:30:40 GMT</pubDate>
+      <guid isPermaLink="false">Groq-llama3-70b-8192-2025-08-30-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Groq: llama3-8b-8192</title>
+      <link>https://console.groq.com/docs/deprecations#august-30-2025-llama370b8192-and-llama38b8192</link>
+      <description>Provider: Groq
+Model ID: llama3-8b-8192
+Deprecation Date: 2025-05-31
+Shutdown Date: 2025-08-30
+First Observed: 2026-05-22
+Last Observed: 2026-05-22
+
+In line with our commitment to bringing you cutting-edge models, on May 31, 2025, we emailed users to announce the deprecation of `llama3-70b-8192` and `llama3-8b-8192` in favor of`llama-3.3-70b-versatile` and `llama-3.1-8b-instant` respectively. The newer Llama 3.3 70B and Llama 3.1 8B models deliver exceptional performance, enabling your applications to harness state-of-the-art text generation with unparalleled speed on our platform.</description>
+      <pubDate>Fri, 22 May 2026 16:30:40 GMT</pubDate>
+      <guid isPermaLink="false">Groq-llama3-8b-8192-2025-08-30-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Groq: distil-whisper-large-v3-en</title>
+      <link>https://console.groq.com/docs/deprecations#august-23-2025-distil-whisper-large-v3-english</link>
+      <description>Provider: Groq
+Model ID: distil-whisper-large-v3-en
+Deprecation Date: 2026-05-22
+Shutdown Date: 2025-08-23
+First Observed: 2026-05-22
+Last Observed: 2026-05-22
+
+In line with our commitment to bringing you cutting-edge models, we are announcing the deprecation of `distil-whisper-large-v3-en` in favor of`whisper-large-v3-turbo`. Whisper Large V3 Turbo is a more performant model for speech recognition and transcription tasks, and supports more languages.</description>
+      <pubDate>Fri, 22 May 2026 16:30:40 GMT</pubDate>
+      <guid isPermaLink="false">Groq-distil-whisper-large-v3-en-2025-08-23-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Groq: mistral-saba-24b</title>
+      <link>https://console.groq.com/docs/deprecations#july-30-2025-mistral-saba-24b</link>
+      <description>Provider: Groq
+Model ID: mistral-saba-24b
+Deprecation Date: 2026-05-22
+Shutdown Date: 2025-07-30
+First Observed: 2026-05-22
+Last Observed: 2026-05-22
+
+In line with our commitment to bringing you cutting-edge models, we are announcing the deprecation of `mistral-saba-24b` in favor of`qwen/qwen3-32b`. The new Qwen 3 32B model delivers exceptional performance, enabling your applications to harness state-of-the-art text generation with unparalleled speed on our platform.</description>
+      <pubDate>Fri, 22 May 2026 16:30:40 GMT</pubDate>
+      <guid isPermaLink="false">Groq-mistral-saba-24b-2025-07-30-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Groq: qwen-qwq-32b</title>
+      <link>https://console.groq.com/docs/deprecations#july-14-2025-qwen-qwq-32b</link>
+      <description>Provider: Groq
+Model ID: qwen-qwq-32b
+Deprecation Date: 2026-05-22
+Shutdown Date: 2025-07-14
+First Observed: 2026-05-22
+Last Observed: 2026-05-22
+
+In line with our commitment to bringing you cutting-edge models, we are announcing the deprecation of `qwen-qwq-32b` in favor of`qwen/qwen3-32b`. The new Qwen 3 32B model delivers exceptional performance, enabling your applications to harness state-of-the-art text generation with unparalleled speed on our platform.</description>
+      <pubDate>Fri, 22 May 2026 16:30:40 GMT</pubDate>
+      <guid isPermaLink="false">Groq-qwen-qwq-32b-2025-07-14-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Groq: llama-guard-3-8b</title>
+      <link>https://console.groq.com/docs/deprecations#june-6-2025-llama-guard-3</link>
+      <description>Provider: Groq
+Model ID: llama-guard-3-8b
+Deprecation Date: 2025-05-09
+Shutdown Date: 2025-06-06
+First Observed: 2026-05-22
+Last Observed: 2026-05-22
+
+In line with our commitment to bringing you cutting-edge models, on May 9, 2025, we emailed users to announce the deprecation of `llama-guard-3-8b` in favor of`meta-llama/llama-guard-4-12b`. The new Llama Guard 4 model delivers exceptional multimodal performance, enabling your applications to harness state-of-the-art AI content moderation with unparalleled speed on our platform.</description>
+      <pubDate>Fri, 22 May 2026 16:30:40 GMT</pubDate>
+      <guid isPermaLink="false">Groq-llama-guard-3-8b-2025-06-06-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Groq: llama-3.2-1b-preview</title>
+      <link>https://console.groq.com/docs/deprecations#april-14-2025-multiple-model-deprecations</link>
+      <description>Provider: Groq
+Model ID: llama-3.2-1b-preview
+Deprecation Date: 2025-04-07
+Shutdown Date: 2025-04-14
+First Observed: 2026-05-22
+Last Observed: 2026-05-22
+
+In line with our commitment to bringing you cutting-edge models, on April 7, 2025, we emailed users to announce the deprecation of several older preview models in favor of Meta's Llama 4 suite. The new Llama 4 Scout and Maverick models deliver exceptional multimodal performance that outpaces our previous offerings, enabling your applications to harness state-of-the-art AI capabilities with unparalleled speed on our platform.</description>
+      <pubDate>Fri, 22 May 2026 16:30:40 GMT</pubDate>
+      <guid isPermaLink="false">Groq-llama-3.2-1b-preview-2025-04-14-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Groq: llama-3.2-3b-preview</title>
+      <link>https://console.groq.com/docs/deprecations#april-14-2025-multiple-model-deprecations</link>
+      <description>Provider: Groq
+Model ID: llama-3.2-3b-preview
+Deprecation Date: 2025-04-07
+Shutdown Date: 2025-04-14
+First Observed: 2026-05-22
+Last Observed: 2026-05-22
+
+In line with our commitment to bringing you cutting-edge models, on April 7, 2025, we emailed users to announce the deprecation of several older preview models in favor of Meta's Llama 4 suite. The new Llama 4 Scout and Maverick models deliver exceptional multimodal performance that outpaces our previous offerings, enabling your applications to harness state-of-the-art AI capabilities with unparalleled speed on our platform.</description>
+      <pubDate>Fri, 22 May 2026 16:30:40 GMT</pubDate>
+      <guid isPermaLink="false">Groq-llama-3.2-3b-preview-2025-04-14-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Groq: llama-3.2-11b-vision-preview</title>
+      <link>https://console.groq.com/docs/deprecations#april-14-2025-multiple-model-deprecations</link>
+      <description>Provider: Groq
+Model ID: llama-3.2-11b-vision-preview
+Deprecation Date: 2025-04-07
+Shutdown Date: 2025-04-14
+First Observed: 2026-05-22
+Last Observed: 2026-05-22
+
+In line with our commitment to bringing you cutting-edge models, on April 7, 2025, we emailed users to announce the deprecation of several older preview models in favor of Meta's Llama 4 suite. The new Llama 4 Scout and Maverick models deliver exceptional multimodal performance that outpaces our previous offerings, enabling your applications to harness state-of-the-art AI capabilities with unparalleled speed on our platform.</description>
+      <pubDate>Fri, 22 May 2026 16:30:40 GMT</pubDate>
+      <guid isPermaLink="false">Groq-llama-3.2-11b-vision-preview-2025-04-14-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Groq: llama-3.2-90b-vision-preview</title>
+      <link>https://console.groq.com/docs/deprecations#april-14-2025-multiple-model-deprecations</link>
+      <description>Provider: Groq
+Model ID: llama-3.2-90b-vision-preview
+Deprecation Date: 2025-04-07
+Shutdown Date: 2025-04-14
+First Observed: 2026-05-22
+Last Observed: 2026-05-22
+
+In line with our commitment to bringing you cutting-edge models, on April 7, 2025, we emailed users to announce the deprecation of several older preview models in favor of Meta's Llama 4 suite. The new Llama 4 Scout and Maverick models deliver exceptional multimodal performance that outpaces our previous offerings, enabling your applications to harness state-of-the-art AI capabilities with unparalleled speed on our platform.</description>
+      <pubDate>Fri, 22 May 2026 16:30:40 GMT</pubDate>
+      <guid isPermaLink="false">Groq-llama-3.2-90b-vision-preview-2025-04-14-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Groq: deepseek-r1-distill-qwen-32b</title>
+      <link>https://console.groq.com/docs/deprecations#april-14-2025-multiple-model-deprecations</link>
+      <description>Provider: Groq
+Model ID: deepseek-r1-distill-qwen-32b
+Deprecation Date: 2025-04-07
+Shutdown Date: 2025-04-14
+First Observed: 2026-05-22
+Last Observed: 2026-05-22
+
+In line with our commitment to bringing you cutting-edge models, on April 7, 2025, we emailed users to announce the deprecation of several older preview models in favor of Meta's Llama 4 suite. The new Llama 4 Scout and Maverick models deliver exceptional multimodal performance that outpaces our previous offerings, enabling your applications to harness state-of-the-art AI capabilities with unparalleled speed on our platform.</description>
+      <pubDate>Fri, 22 May 2026 16:30:40 GMT</pubDate>
+      <guid isPermaLink="false">Groq-deepseek-r1-distill-qwen-32b-2025-04-14-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Groq: qwen-2.5-32b</title>
+      <link>https://console.groq.com/docs/deprecations#april-14-2025-multiple-model-deprecations</link>
+      <description>Provider: Groq
+Model ID: qwen-2.5-32b
+Deprecation Date: 2025-04-07
+Shutdown Date: 2025-04-14
+First Observed: 2026-05-22
+Last Observed: 2026-05-22
+
+In line with our commitment to bringing you cutting-edge models, on April 7, 2025, we emailed users to announce the deprecation of several older preview models in favor of Meta's Llama 4 suite. The new Llama 4 Scout and Maverick models deliver exceptional multimodal performance that outpaces our previous offerings, enabling your applications to harness state-of-the-art AI capabilities with unparalleled speed on our platform.</description>
+      <pubDate>Fri, 22 May 2026 16:30:40 GMT</pubDate>
+      <guid isPermaLink="false">Groq-qwen-2.5-32b-2025-04-14-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Groq: qwen-2.5-coder-32b</title>
+      <link>https://console.groq.com/docs/deprecations#april-14-2025-multiple-model-deprecations</link>
+      <description>Provider: Groq
+Model ID: qwen-2.5-coder-32b
+Deprecation Date: 2025-04-07
+Shutdown Date: 2025-04-14
+First Observed: 2026-05-22
+Last Observed: 2026-05-22
+
+In line with our commitment to bringing you cutting-edge models, on April 7, 2025, we emailed users to announce the deprecation of several older preview models in favor of Meta's Llama 4 suite. The new Llama 4 Scout and Maverick models deliver exceptional multimodal performance that outpaces our previous offerings, enabling your applications to harness state-of-the-art AI capabilities with unparalleled speed on our platform.</description>
+      <pubDate>Fri, 22 May 2026 16:30:40 GMT</pubDate>
+      <guid isPermaLink="false">Groq-qwen-2.5-coder-32b-2025-04-14-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Groq: llama-3.3-70b-specdec</title>
+      <link>https://console.groq.com/docs/deprecations#april-14-2025-multiple-model-deprecations</link>
+      <description>Provider: Groq
+Model ID: llama-3.3-70b-specdec
+Deprecation Date: 2025-04-07
+Shutdown Date: 2025-04-14
+First Observed: 2026-05-22
+Last Observed: 2026-05-22
+
+In line with our commitment to bringing you cutting-edge models, on April 7, 2025, we emailed users to announce the deprecation of several older preview models in favor of Meta's Llama 4 suite. The new Llama 4 Scout and Maverick models deliver exceptional multimodal performance that outpaces our previous offerings, enabling your applications to harness state-of-the-art AI capabilities with unparalleled speed on our platform.</description>
+      <pubDate>Fri, 22 May 2026 16:30:40 GMT</pubDate>
+      <guid isPermaLink="false">Groq-llama-3.3-70b-specdec-2025-04-14-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Groq: deepseek-r1-distill-llama-70b-specdec</title>
+      <link>https://console.groq.com/docs/deprecations#april-14-2025-multiple-model-deprecations</link>
+      <description>Provider: Groq
+Model ID: deepseek-r1-distill-llama-70b-specdec
+Deprecation Date: 2025-04-07
+Shutdown Date: 2025-04-14
+First Observed: 2026-05-22
+Last Observed: 2026-05-22
+
+In line with our commitment to bringing you cutting-edge models, on April 7, 2025, we emailed users to announce the deprecation of several older preview models in favor of Meta's Llama 4 suite. The new Llama 4 Scout and Maverick models deliver exceptional multimodal performance that outpaces our previous offerings, enabling your applications to harness state-of-the-art AI capabilities with unparalleled speed on our platform.</description>
+      <pubDate>Fri, 22 May 2026 16:30:40 GMT</pubDate>
+      <guid isPermaLink="false">Groq-deepseek-r1-distill-llama-70b-specdec-2025-04-14-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Groq: mixtral-8x7b-32768</title>
+      <link>https://console.groq.com/docs/deprecations#march-20-2025-mixtral-8x7b</link>
+      <description>Provider: Groq
+Model ID: mixtral-8x7b-32768
+Deprecation Date: 2026-05-22
+Shutdown Date: 2025-03-20
+First Observed: 2026-05-22
+Last Observed: 2026-05-22
+
+On March 5, 2025, we emailed all users of the `mixtral-8x7b-32768` model that we would be deprecating this model ID in favor of newer, more performant models. The recommended replacement models offer superior multilingual capabilities and performance for various tasks from text generation to translation.</description>
+      <pubDate>Fri, 22 May 2026 16:30:40 GMT</pubDate>
+      <guid isPermaLink="false">Groq-mixtral-8x7b-32768-2025-03-20-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Groq: llama-3.1-70b-versatile</title>
+      <link>https://console.groq.com/docs/deprecations#january-24-2025-llama-31-70b-and-llama-31-70b-speculative-decoding</link>
+      <description>Provider: Groq
+Model ID: llama-3.1-70b-versatile
+Deprecation Date: 2026-05-22
+Shutdown Date: 2025-01-24
+First Observed: 2026-05-22
+Last Observed: 2026-05-22
+
+On December 6, 2024, in partnership with Meta, we released `llama-3.3-70b-versatile` and `llama-3.3-70b-specdec`, and notified users that we would deprecate their 3.1 counterparts in favor of hosting Llama 3.3 with significant quality improvements for a better experience. To facilitate a smooth transition, we will maintain the current `llama-3.1-70b-versatile` and `llama-3.1-70b-specdec` model IDs until December 20, 2024\. At that time, requests to these model IDs will automatically upgrade to t...</description>
+      <pubDate>Fri, 22 May 2026 16:30:40 GMT</pubDate>
+      <guid isPermaLink="false">Groq-llama-3.1-70b-versatile-2025-01-24-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Groq: llama-3.1-70b-specdec</title>
+      <link>https://console.groq.com/docs/deprecations#january-24-2025-llama-31-70b-and-llama-31-70b-speculative-decoding</link>
+      <description>Provider: Groq
+Model ID: llama-3.1-70b-specdec
+Deprecation Date: 2026-05-22
+Shutdown Date: 2025-01-24
+First Observed: 2026-05-22
+Last Observed: 2026-05-22
+
+On December 6, 2024, in partnership with Meta, we released `llama-3.3-70b-versatile` and `llama-3.3-70b-specdec`, and notified users that we would deprecate their 3.1 counterparts in favor of hosting Llama 3.3 with significant quality improvements for a better experience. To facilitate a smooth transition, we will maintain the current `llama-3.1-70b-versatile` and `llama-3.1-70b-specdec` model IDs until December 20, 2024\. At that time, requests to these model IDs will automatically upgrade to t...</description>
+      <pubDate>Fri, 22 May 2026 16:30:40 GMT</pubDate>
+      <guid isPermaLink="false">Groq-llama-3.1-70b-specdec-2025-01-24-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Groq: llama3-groq-8b-8192-tool-use-preview</title>
+      <link>https://console.groq.com/docs/deprecations#january-6-2025-llama-3-groq-tool-use-models</link>
+      <description>Provider: Groq
+Model ID: llama3-groq-8b-8192-tool-use-preview
+Deprecation Date: 2026-05-22
+Shutdown Date: 2025-01-06
+First Observed: 2026-05-22
+Last Observed: 2026-05-22
+
+On January 6th, we deprecated our preview versions of Llama 3 fine-tuned for tool use, `llama3-groq-8b-8192-tool-use-preview` and `llama3-groq-70b-8192-tool-use-preview`, from GroqCloud™ in favor of transitioning users to our production-ready `llama-3.30-70b-versatile` model. Users of the tool use models were notified about the upcoming deprecation via email. The recommended replacement model, `llama-3.3-70b-versatile`, offers superior tool use capabilities and we strongly encourage users to mig...</description>
+      <pubDate>Fri, 22 May 2026 16:30:40 GMT</pubDate>
+      <guid isPermaLink="false">Groq-llama3-groq-8b-8192-tool-use-preview-2025-01-06-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Groq: llama3-groq-70b-8192-tool-use-preview</title>
+      <link>https://console.groq.com/docs/deprecations#january-6-2025-llama-3-groq-tool-use-models</link>
+      <description>Provider: Groq
+Model ID: llama3-groq-70b-8192-tool-use-preview
+Deprecation Date: 2026-05-22
+Shutdown Date: 2025-01-06
+First Observed: 2026-05-22
+Last Observed: 2026-05-22
+
+On January 6th, we deprecated our preview versions of Llama 3 fine-tuned for tool use, `llama3-groq-8b-8192-tool-use-preview` and `llama3-groq-70b-8192-tool-use-preview`, from GroqCloud™ in favor of transitioning users to our production-ready `llama-3.30-70b-versatile` model. Users of the tool use models were notified about the upcoming deprecation via email. The recommended replacement model, `llama-3.3-70b-versatile`, offers superior tool use capabilities and we strongly encourage users to mig...</description>
+      <pubDate>Fri, 22 May 2026 16:30:40 GMT</pubDate>
+      <guid isPermaLink="false">Groq-llama3-groq-70b-8192-tool-use-preview-2025-01-06-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Groq: gemma-7b-it</title>
+      <link>https://console.groq.com/docs/deprecations#december-18-2024-gemma-7b</link>
+      <description>Provider: Groq
+Model ID: gemma-7b-it
+Deprecation Date: 2026-05-22
+Shutdown Date: 2024-12-18
+First Observed: 2026-05-22
+Last Observed: 2026-05-22
+
+On December 11, 2024, we emailed all Gemma 7B users that we would deprecate it in favor of keeping the Gemma 9B model as it offers better performance.</description>
+      <pubDate>Fri, 22 May 2026 16:30:40 GMT</pubDate>
+      <guid isPermaLink="false">Groq-gemma-7b-it-2024-12-18-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Groq: llama-3.2-90b-text-preview</title>
+      <link>https://console.groq.com/docs/deprecations#november-25-2024-llama-32-90b-text-preview</link>
+      <description>Provider: Groq
+Model ID: llama-3.2-90b-text-preview
+Deprecation Date: 2026-05-22
+Shutdown Date: 2024-11-25
+First Observed: 2026-05-22
+Last Observed: 2026-05-22
+
+In November 2024, we emailed all Llama 3.2 90B Text Preview users that we would deprecate it in favor of hosting the Llama 3.2 90B Vision Preview model for vision capabilities.</description>
+      <pubDate>Fri, 22 May 2026 16:30:40 GMT</pubDate>
+      <guid isPermaLink="false">Groq-llama-3.2-90b-text-preview-2024-11-25-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Groq: llava-v1.5-7b-4096-preview</title>
+      <link>https://console.groq.com/docs/deprecations#october-18-2024-llava-15-7b-and-llama-32-11b-text-preview</link>
+      <description>Provider: Groq
+Model ID: llava-v1.5-7b-4096-preview
+Deprecation Date: 2026-05-22
+Shutdown Date: 2024-10-28
+First Observed: 2026-05-22
+Last Observed: 2026-05-22
+
+In September 2024, we made Meta's Llama 3.2 vision models available on GroqCloud and emailed all LLaVA 1.5 7B and Llama 3.2 11B Text Preview users that we would deprecate it in favor of hosting Llama 3.2 11B Vision for better performance and more robust vision capabilities.</description>
+      <pubDate>Fri, 22 May 2026 16:30:40 GMT</pubDate>
+      <guid isPermaLink="false">Groq-llava-v1.5-7b-4096-preview-2024-10-28-e3b0c442</guid>
+    </item>
+    <item>
+      <title>Groq: llama-3.2-11b-text-preview</title>
+      <link>https://console.groq.com/docs/deprecations#october-18-2024-llava-15-7b-and-llama-32-11b-text-preview</link>
+      <description>Provider: Groq
+Model ID: llama-3.2-11b-text-preview
+Deprecation Date: 2026-05-22
+Shutdown Date: 2024-10-28
+First Observed: 2026-05-22
+Last Observed: 2026-05-22
+
+In September 2024, we made Meta's Llama 3.2 vision models available on GroqCloud and emailed all LLaVA 1.5 7B and Llama 3.2 11B Text Preview users that we would deprecate it in favor of hosting Llama 3.2 11B Vision for better performance and more robust vision capabilities.</description>
+      <pubDate>Fri, 22 May 2026 16:30:40 GMT</pubDate>
+      <guid isPermaLink="false">Groq-llama-3.2-11b-text-preview-2024-10-28-e3b0c442</guid>
     </item>
     <item>
       <title>xAI: grok-4-1-fast</title>

--- a/docs/v1/providers.json
+++ b/docs/v1/providers.json
@@ -30,6 +30,11 @@
     "url": "https://docs.cohere.com/docs/deprecations"
   },
   {
+    "provider": "Groq",
+    "label": "Groq Model Deprecations",
+    "url": "https://console.groq.com/docs/deprecations"
+  },
+  {
     "provider": "xAI",
     "label": "xAI Models",
     "url": "https://docs.x.ai/developers/models"

--- a/src/providers.py
+++ b/src/providers.py
@@ -6,6 +6,7 @@ from .scrapers.google_scraper import GoogleScraper
 from .scrapers.google_vertex_scraper import GoogleVertexScraper
 from .scrapers.aws_bedrock_scraper import AWSBedrockScraper
 from .scrapers.cohere_scraper import CohereScraper
+from .scrapers.groq_scraper import GroqScraper
 from .scrapers.xai_scraper import XAIScraper
 from .scrapers.azure_foundry_scraper import AzureFoundryScraper
 
@@ -16,6 +17,7 @@ SCRAPERS = [
     GoogleVertexScraper,
     AWSBedrockScraper,
     CohereScraper,
+    GroqScraper,
     XAIScraper,
     AzureFoundryScraper,
 ]
@@ -50,6 +52,11 @@ TRACKED_PROVIDER_PAGES = [
         "provider": CohereScraper.provider_name,
         "label": "Cohere Deprecations",
         "url": CohereScraper.url,
+    },
+    {
+        "provider": GroqScraper.provider_name,
+        "label": "Groq Model Deprecations",
+        "url": GroqScraper.url,
     },
     {
         "provider": XAIScraper.provider_name,

--- a/src/scrapers/groq_scraper.py
+++ b/src/scrapers/groq_scraper.py
@@ -1,0 +1,213 @@
+"""Groq model deprecations scraper."""
+
+from __future__ import annotations
+
+import re
+from typing import List
+
+from bs4 import BeautifulSoup
+
+from ..base_scraper import EnhancedBaseScraper
+from ..markdown_utils import (
+    extract_code_spans,
+    extract_markdown_tables,
+    is_markdown,
+    parse_markdown_table,
+    split_markdown_sections,
+)
+from ..models import DeprecationItem
+
+
+class GroqScraper(EnhancedBaseScraper):
+    """Scraper for Groq model deprecation notices."""
+
+    provider_name = "Groq"
+    url = "https://console.groq.com/docs/deprecations"
+    markdown_url = "https://console.groq.com/docs/deprecations.md"
+    requires_playwright = False
+    require_shutdown_dates = True
+
+    def get_source_url(self) -> str:
+        """Prefer Groq's markdown source for deterministic parsing."""
+        return self.markdown_url
+
+    def parse_date(self, date_str: str) -> str:
+        """Parse Groq dates, including compact MM/DD/YY shutdown dates."""
+        parsed = super().parse_date(date_str)
+        if parsed:
+            return parsed
+
+        normalized = (date_str or "").replace("\\.", ".").strip().rstrip(".")
+        short_match = re.fullmatch(r"(\d{1,2})/(\d{1,2})/(\d{2})", normalized)
+        if short_match:
+            month, day, year = (int(part) for part in short_match.groups())
+            return f"20{year:02d}-{month:02d}-{day:02d}"
+
+        return ""
+
+    def extract_structured_deprecations(self, html: str) -> List[DeprecationItem]:
+        """Extract deprecations from Groq markdown or HTML."""
+        if is_markdown(html):
+            return self._extract_from_markdown(html)
+        return self._extract_from_html(html)
+
+    def _extract_from_markdown(self, content: str) -> List[DeprecationItem]:
+        """Extract deprecation history entries from Groq's markdown page."""
+        items: list[DeprecationItem] = []
+
+        for raw_heading, body in split_markdown_sections(content):
+            heading_text, anchor = self._parse_linked_heading(raw_heading)
+            heading_date = self._extract_heading_date(heading_text)
+            if not heading_date:
+                continue
+
+            lines = body.splitlines()
+            tables = extract_markdown_tables(lines)
+            if not tables:
+                continue
+
+            section_url = f"{self.url}#{anchor}" if anchor else self.url
+            first_table_start = tables[0][0]
+            context = " ".join(
+                line.strip()
+                for line in lines[:first_table_start]
+                if line.strip() and not line.strip().startswith("#")
+            )
+            announcement_date = self._extract_announcement_date(
+                context, fallback_year=heading_date[:4]
+            )
+
+            for _, _, block in tables:
+                headers, rows = parse_markdown_table(block)
+                items.extend(
+                    self._extract_table_rows(
+                        headers, rows, announcement_date, context, section_url
+                    )
+                )
+
+        return self._dedupe_items(items)
+
+    def _extract_table_rows(
+        self,
+        headers: list[str],
+        rows: list[list[str]],
+        announcement_date: str,
+        context: str,
+        url: str,
+    ) -> List[DeprecationItem]:
+        """Extract Groq deprecation rows from a markdown table."""
+        header_map = {header.lower(): idx for idx, header in enumerate(headers)}
+        model_idx = header_map.get("deprecated model", header_map.get("model id"))
+        shutdown_idx = header_map.get("shutdown date")
+        replacement_idx = header_map.get("recommended replacement model id")
+        if model_idx is None or shutdown_idx is None:
+            return []
+
+        items = []
+        for row in rows:
+            if len(row) <= max(model_idx, shutdown_idx):
+                continue
+
+            model_ids = self._extract_model_ids(row[model_idx])
+            shutdown_date = self.parse_date(row[shutdown_idx])
+            if not model_ids or not shutdown_date:
+                continue
+
+            replacement_models = None
+            if replacement_idx is not None and replacement_idx < len(row):
+                replacement_models = self._extract_model_ids(row[replacement_idx])
+
+            for model_id in model_ids:
+                items.append(
+                    DeprecationItem(
+                        provider=self.provider_name,
+                        model_id=model_id,
+                        announcement_date=announcement_date,
+                        shutdown_date=shutdown_date,
+                        replacement_models=replacement_models or None,
+                        deprecation_context=context,
+                        url=url,
+                    )
+                )
+
+        return items
+
+    def _extract_from_html(self, html: str) -> List[DeprecationItem]:
+        """Fallback parser for rendered Groq HTML tables."""
+        soup = BeautifulSoup(html, "html.parser")
+        main = soup.find("main") or soup.find("article") or soup
+        items = []
+        for table in main.find_all("table"):
+            items.extend(self.extract_table_deprecations(table))
+        return [item for item in items if self._looks_like_model_id(item.model_id)]
+
+    def _parse_linked_heading(self, heading: str) -> tuple[str, str]:
+        """Return display text and anchor from a markdown linked heading."""
+        match = re.fullmatch(r"\[(?P<text>.+)]\(#(?P<anchor>[^)]+)\)", heading)
+        if not match:
+            return heading, ""
+        return match.group("text"), match.group("anchor")
+
+    def _extract_heading_date(self, heading: str) -> str:
+        """Extract the shutdown/deprecation heading date from a section title."""
+        date_text = heading.split(":", 1)[0].strip()
+        return self.parse_date(date_text)
+
+    def _extract_announcement_date(self, context: str, fallback_year: str) -> str:
+        """Extract the provider announcement date from section prose when available."""
+        full_date_match = re.search(
+            r"\bon\s+([A-Z][a-z]+\s+\d{1,2}(?:st|nd|rd|th)?,\s*\d{4})\b",
+            context,
+        )
+        if full_date_match:
+            return self.parse_date(full_date_match.group(1))
+
+        day_without_year_match = re.search(
+            r"\bon\s+([A-Z][a-z]+\s+\d{1,2}(?:st|nd|rd|th)?)\b",
+            context,
+        )
+        if day_without_year_match and fallback_year:
+            return self.parse_date(
+                f"{day_without_year_match.group(1)}, {fallback_year}"
+            )
+
+        return ""
+
+    def _extract_model_ids(self, text: str) -> list[str]:
+        """Extract one or more model IDs from table cells or code spans."""
+        code_spans = extract_code_spans(text)
+        candidates = code_spans or re.split(r"\s+(?:or|and)\s+|,|\s+", text)
+        model_ids: list[str] = []
+        for candidate in candidates:
+            cleaned = re.sub(r"\([^)]*\)", "", candidate).strip(" `.;")
+            if self._looks_like_model_id(cleaned) and cleaned not in model_ids:
+                model_ids.append(cleaned)
+        return model_ids
+
+    def _looks_like_model_id(self, value: str) -> bool:
+        """Return True for Groq model identifiers and False for prose fragments."""
+        if not value or any(char.isspace() for char in value):
+            return False
+        lowered = value.lower().strip()
+        if lowered in {"n/a", "none", "model", "model-id"}:
+            return False
+        if lowered.startswith(("http://", "https://")):
+            return False
+        if not re.fullmatch(r"[a-z0-9][a-z0-9._/-]*[a-z0-9]", lowered):
+            return False
+        return any(separator in lowered for separator in ["-", "/", "."])
+
+    def _dedupe_items(self, items: list[DeprecationItem]) -> list[DeprecationItem]:
+        """Deduplicate by model ID, preferring richer context."""
+        deduped: dict[str, DeprecationItem] = {}
+        for item in items:
+            existing = deduped.get(item.model_id)
+            if existing is None or len(item.deprecation_context or "") > len(
+                existing.deprecation_context or ""
+            ):
+                deduped[item.model_id] = item
+        return list(deduped.values())
+
+    def extract_unstructured_deprecations(self, html: str) -> List[DeprecationItem]:
+        """Groq deprecations are handled by structured history tables."""
+        return []

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -28,6 +28,7 @@ def test_scraper_imports():
         from src.scrapers.google_vertex_scraper import GoogleVertexScraper  # noqa: F401
         from src.scrapers.aws_bedrock_scraper import AWSBedrockScraper  # noqa: F401
         from src.scrapers.cohere_scraper import CohereScraper  # noqa: F401
+        from src.scrapers.groq_scraper import GroqScraper  # noqa: F401
         from src.scrapers.xai_scraper import XAIScraper  # noqa: F401
         from src.scrapers.azure_foundry_scraper import AzureFoundryScraper  # noqa: F401
 

--- a/tests/test_groq_scraper.py
+++ b/tests/test_groq_scraper.py
@@ -1,0 +1,113 @@
+"""Tests for the Groq deprecations scraper."""
+
+from src.scrapers.groq_scraper import GroqScraper
+
+
+GROQ_DEPRECATIONS_MARKDOWN = """
+---
+title: Model Deprecation - GroqDocs
+---
+
+## [Model Deprecation](#model-deprecation)
+
+Deprecation refers to the process of retiring older models or endpoints.
+
+### [Production vs. Preview Models](#production-vs-preview-models)
+
+Preview models may be discontinued at short notice with limited advance warning.
+
+### [April 15, 2026: moonshotai/kimi-k2-instruct-0905](#april-15-2026-moonshotaikimik2instruct0905)
+
+In line with our commitment to bringing you cutting-edge models, on March 23, 2026, we emailed users to announce the deprecation of `moonshotai/kimi-k2-instruct-0905` in favor of `openai/gpt-oss-120b`.
+
+| Deprecated Model                 | Shutdown Date | Recommended Replacement Model ID |
+| -------------------------------- | ------------- | -------------------------------- |
+| moonshotai/kimi-k2-instruct-0905 | 04/15/26      | openai/gpt-oss-120b              |
+
+### [December 31, 2025: playai-tts and playai-tts-arabic](#december-31-2025-playaitts-and-playaittsarabic)
+
+In line with our commitment to bringing you cutting-edge models, on December 23, 2025, we emailed users to announce the deprecation of `playai-tts` and `playai-tts-arabic` in favor of the newer Orpheus text-to-speech models from Canopy Labs.
+
+| Deprecated Model  | Shutdown Date | Recommended Replacement Model ID |
+| ----------------- | ------------- | -------------------------------- |
+| playai-tts        | 12/31/25      | canopylabs/orpheus-v1-english    |
+| playai-tts-arabic | 12/31/25      | canopylabs/orpheus-arabic-saudi  |
+
+### [October 2, 2025: deepseek-r1-distill-llama-70b](#october-2-2025-deepseekr1distillllama70b)
+
+In line with our commitment to bringing you cutting-edge models, on September 2, 2025, we emailed users to announce the deprecation of `deepseek-r1-distill-llama-70b` in favor of `llama-3.3-70b-versatile` or `openai/gpt-oss-120b`.
+
+| Deprecated Model              | Shutdown Date | Recommended Replacement Model ID               |
+| ----------------------------- | ------------- | ---------------------------------------------- |
+| deepseek-r1-distill-llama-70b | 10/02/25      | llama-3.3-70b-versatile or openai/gpt-oss-120b |
+
+### [March 20, 2025: Mixtral 8x7B](#march-20-2025-mixtral-8x7b)
+
+On March 5, 2025, we emailed all users of the `mixtral-8x7b-32768` model that we would be deprecating this model ID in favor of newer, more performant models.
+
+| Model ID           | Shutdown Date | Recommended Replacement Model ID         |
+| ------------------ | ------------- | ---------------------------------------- |
+| mixtral-8x7b-32768 | 03/20/25      | mistral-saba-24b llama-3.3-70b-versatile |
+"""
+
+
+def test_groq_extracts_markdown_deprecation_history():
+    """Groq markdown history tables should produce model-level items."""
+    items = GroqScraper().extract_structured_deprecations(GROQ_DEPRECATIONS_MARKDOWN)
+
+    assert [item.model_id for item in items] == [
+        "moonshotai/kimi-k2-instruct-0905",
+        "playai-tts",
+        "playai-tts-arabic",
+        "deepseek-r1-distill-llama-70b",
+        "mixtral-8x7b-32768",
+    ]
+    assert all(item.provider == "Groq" for item in items)
+    assert all(item.shutdown_date for item in items)
+
+
+def test_groq_parses_dates_replacements_and_urls():
+    """Groq-specific dates, replacements, and anchors should be normalized."""
+    items = GroqScraper().extract_structured_deprecations(GROQ_DEPRECATIONS_MARKDOWN)
+    by_model = {item.model_id: item for item in items}
+
+    kimi = by_model["moonshotai/kimi-k2-instruct-0905"]
+    assert kimi.announcement_date == "2026-03-23"
+    assert kimi.deprecation_date == "2026-03-23"
+    assert kimi.shutdown_date == "2026-04-15"
+    assert kimi.replacement_models == ["openai/gpt-oss-120b"]
+    assert kimi.url == (
+        "https://console.groq.com/docs/deprecations"
+        "#april-15-2026-moonshotaikimik2instruct0905"
+    )
+
+    deepseek = by_model["deepseek-r1-distill-llama-70b"]
+    assert deepseek.replacement_models == [
+        "llama-3.3-70b-versatile",
+        "openai/gpt-oss-120b",
+    ]
+
+    mixtral = by_model["mixtral-8x7b-32768"]
+    assert mixtral.replacement_models == [
+        "mistral-saba-24b",
+        "llama-3.3-70b-versatile",
+    ]
+
+
+def test_groq_ignores_lifecycle_guidance_without_tables():
+    """Generic deprecation policy text should not create false positives."""
+    markdown = """
+# Model Deprecation
+
+### [Production vs. Preview Models](#production-vs-preview-models)
+
+Preview models may be discontinued at short notice with limited advance warning.
+"""
+
+    assert GroqScraper().extract_structured_deprecations(markdown) == []
+
+
+def test_groq_scrape_uses_markdown_source():
+    """The provider registry should scrape Groq's deterministic markdown endpoint."""
+    scraper = GroqScraper()
+    assert scraper.get_source_url() == "https://console.groq.com/docs/deprecations.md"


### PR DESCRIPTION
## Summary
- Add Groq as a tracked provider using the deterministic `https://console.groq.com/docs/deprecations.md` source
- Parse Groq deprecation-history sections into model-level records with normalized shutdown dates, announcement/deprecation dates, replacement model IDs, context, and source anchors
- Register Groq across provider interfaces: scraper registry, tracked provider metadata, README, and `docs/v1/providers.json`
- Add Groq to the static-site provider filters/badges using `#f43e01`
- Include newly generated Groq records in `data.json` and `docs/v1/*` feeds
- Rebased on latest `main` after the xAI PR merge

## Implementation review
- **Source reliability:** uses Groq’s markdown endpoint instead of rendered Next.js HTML; keeps an HTML table fallback.
- **Data quality:** extracts only dated deprecation-history tables, requires shutdown dates, dedupes by model ID, and ignores lifecycle guidance prose.
- **Interface impact:** updates registry, public provider metadata, README, static-site filters/badges, raw data, JSON Feed, and RSS output.
- **Operational validation:** full scrape returned 368 total records including 32 Groq records and 5 xAI records.

Closes #88.

## Tests
- `SCRAPE_STATUS_FILE=.scrape-status.json uv run python -m src.main`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run pytest tests/ -v`