### PR TITLE
Use AWS Bedrock markdown lifecycle source

### DIFF
--- a/src/scrapers/aws_bedrock_scraper.py
+++ b/src/scrapers/aws_bedrock_scraper.py
@@ -1,10 +1,12 @@
 """AWS Bedrock deprecations scraper with individual model extraction."""
 
+import re
 from datetime import datetime
 from typing import List
 from bs4 import BeautifulSoup
 
 from ..base_scraper import EnhancedBaseScraper
+from ..markdown_utils import is_markdown
 from ..models import DeprecationItem
 
 
@@ -13,10 +15,20 @@ class AWSBedrockScraper(EnhancedBaseScraper):
 
     provider_name = "AWS Bedrock"
     url = "https://docs.aws.amazon.com/bedrock/latest/userguide/model-lifecycle.html"
+    markdown_url = (
+        "https://docs.aws.amazon.com/bedrock/latest/userguide/model-lifecycle.md"
+    )
     requires_playwright = False
 
+    def get_source_url(self) -> str:
+        """Prefer AWS's markdown source to avoid HTML page fetch failures."""
+        return self.markdown_url
+
     def extract_structured_deprecations(self, html: str) -> List[DeprecationItem]:
-        """Extract deprecations from AWS Bedrock lifecycle tables."""
+        """Extract deprecations from AWS Bedrock lifecycle tables or markdown."""
+        if is_markdown(html):
+            return self._extract_from_markdown(html)
+
         items: list[DeprecationItem] = []
         soup = BeautifulSoup(html, "html.parser")
 
@@ -133,6 +145,114 @@ class AWSBedrockScraper(EnhancedBaseScraper):
                 )
 
         return self._merge_duplicate_models(items)
+
+    def _extract_from_markdown(self, content: str) -> list[DeprecationItem]:
+        """Extract lifecycle records from AWS's generated markdown source."""
+        items: list[DeprecationItem] = []
+        for record in self._markdown_records(content):
+            items.extend(self._extract_markdown_record(record))
+        return self._merge_duplicate_models(items)
+
+    def _markdown_records(self, content: str) -> list[list[str]]:
+        """Split the AWS markdown lifecycle list into provider/model records."""
+        records: list[list[str]] = []
+        current: list[str] = []
+
+        for line in content.splitlines():
+            if re.match(r"^- \*\*.+\*\*$", line):
+                if current:
+                    records.append(current)
+                current = [line]
+                continue
+            if current:
+                if line.startswith("  - ") or not line.strip():
+                    current.append(line)
+                else:
+                    records.append(current)
+                    current = []
+
+        if current:
+            records.append(current)
+
+        return records
+
+    def _extract_markdown_record(self, record: list[str]) -> list[DeprecationItem]:
+        """Extract one markdown lifecycle list record into one or more schedules."""
+        model_name = ""
+        model_id = ""
+        replacement_models: list[str] | None = None
+        standalone_legacy_date = ""
+        standalone_eol_date = ""
+        schedules: list[tuple[str, str]] = []
+
+        for line in record[1:]:
+            match = re.match(r"^\s+- \*\*(?P<key>[^*]+):\*\*\s*(?P<value>.*)$", line)
+            if not match:
+                continue
+
+            key = match.group("key").strip().lower()
+            raw_value = match.group("value")
+            value = self._clean_markdown_value(raw_value)
+            if key == "model name":
+                model_name = value
+            elif key == "model id":
+                model_id = value
+            elif key == "legacy date":
+                standalone_legacy_date = self.parse_date(value)
+            elif key == "eol date":
+                standalone_eol_date = self.parse_date(value)
+            elif key == "regions":
+                legacy_date = self._extract_markdown_inline_date(
+                    raw_value, "Legacy date"
+                )
+                eol_date = self._extract_markdown_inline_date(raw_value, "EOL date")
+                if legacy_date or eol_date:
+                    schedules.append((legacy_date, eol_date))
+            elif "recommended" in key and "model id" in key:
+                replacement_models = self.parse_replacements(value)
+
+        if standalone_legacy_date or standalone_eol_date:
+            schedules.append((standalone_legacy_date, standalone_eol_date))
+
+        if not model_id:
+            return []
+
+        items: list[DeprecationItem] = []
+        for legacy_date, eol_date in schedules:
+            if not (legacy_date or eol_date):
+                continue
+            items.append(
+                DeprecationItem(
+                    provider=self.provider_name,
+                    model_id=model_id,
+                    announcement_date=legacy_date or eol_date,
+                    shutdown_date=eol_date or legacy_date,
+                    replacement_models=replacement_models,
+                    deprecation_context=self._build_context(
+                        model_id,
+                        model_name,
+                        legacy_date,
+                        eol_date,
+                        replacement_models,
+                    ),
+                    url=self.url,
+                )
+            )
+
+        return items
+
+    def _extract_markdown_inline_date(self, value: str, label: str) -> str:
+        """Extract a bolded inline date field from a markdown list item."""
+        pattern = rf"\*\*{re.escape(label)}:\*\*\s*(.*?)(?=\s*/\s*\*\*|$)"
+        match = re.search(pattern, value)
+        if not match:
+            return ""
+        return self.parse_date(self._clean_markdown_value(match.group(1)))
+
+    def _clean_markdown_value(self, value: str) -> str:
+        """Remove lightweight markdown formatting from a lifecycle field value."""
+        cleaned = re.sub(r"\*\*([^*]+)\*\*", r"\1", value)
+        return cleaned.replace("\\+", "+").strip()
 
     def _build_active_model_id_map(self, content) -> dict[str, str]:
         """Map active model version labels to Bedrock model IDs."""

--- a/tests/test_aws_bedrock_scraper.py
+++ b/tests/test_aws_bedrock_scraper.py
@@ -21,7 +21,52 @@ def test_scraper_initialization():
         scraper.url
         == "https://docs.aws.amazon.com/bedrock/latest/userguide/model-lifecycle.html"
     )
+    assert scraper.get_source_url() == (
+        "https://docs.aws.amazon.com/bedrock/latest/userguide/model-lifecycle.md"
+    )
     assert scraper.requires_playwright is False
+
+
+def test_extracts_from_markdown_source():
+    """Should parse the AWS markdown source used by the scheduled scraper."""
+    scraper = AWSBedrockScraper()
+    markdown = r"""
+# Model lifecycle
+
+- **Anthropic**
+  - **Model name:** Claude 3.5 Sonnet
+  - **Model ID:** anthropic.claude-3-5-sonnet-20240620-v1:0
+  - **Regions:** ap-northeast-1, ap-southeast-2 / **Legacy date:** January 30, 2026 / **EOL date:** July 30, 2026 / **Public extended access start date:** April 30, 2026
+  - **Regions:** eu-central-2 / **Legacy date:** August 25, 2025 / **EOL date:** June 1, 2026 / **Public extended access start date:** December 1, 2025
+
+- **Cohere**
+  - **Model name:** Command R\+
+  - **Model ID:** cohere.command-r-plus-v1:0
+  - **Regions:** us-east-1, us-west-2
+  - **Legacy date:** February 19, 2026
+  - **EOL date:** August 19, 2026
+  - **Public extended access start date:** May 19, 2026
+"""
+
+    items = scraper.extract_structured_deprecations(markdown)
+
+    assert {item.model_id for item in items} == {
+        "anthropic.claude-3-5-sonnet-20240620-v1:0",
+        "cohere.command-r-plus-v1:0",
+    }
+    sonnet = next(
+        item
+        for item in items
+        if item.model_id == "anthropic.claude-3-5-sonnet-20240620-v1:0"
+    )
+    assert sonnet.announcement_date == "2025-08-25"
+    assert sonnet.shutdown_date == "2026-06-01"
+    assert "Additional regional schedule" in sonnet.deprecation_context
+
+    command_r_plus = next(
+        item for item in items if item.model_id == "cohere.command-r-plus-v1:0"
+    )
+    assert "Command R+" in command_r_plus.deprecation_context
 
 
 def test_extracts_true_model_ids_from_active_lookup(fixture_html):


### PR DESCRIPTION
## Summary
- Switch the AWS Bedrock scraper to AWS's generated markdown lifecycle source instead of the HTML page that returned 403 in the scheduled GitHub Actions run.
- Add markdown parsing for AWS lifecycle records, including region-specific inline lifecycle dates.
- Keep the public item URLs pointed at the canonical HTML page.

## Failure analysis
The latest scheduled `Scrape Deprecations` workflow failed in `Check scrape status` because AWS Bedrock recorded a provider-level scrape failure:

```
403 Forbidden for https://docs.aws.amazon.com/bedrock/latest/userguide/model-lifecycle.html
```

The scraper then correctly fell back to 23 cached AWS items, generated unchanged feeds, and failed after generation so the provider failure would not be hidden. The other notable output (`Google` fetching twice) is expected: that scraper combines the Gemini deprecations page with the Gemini changelog.

## Verification
- `.venv/bin/python -m ruff format --check .`
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m pytest -q`
- `SCRAPE_STATUS_FILE=.scrape-status.json .venv/bin/python -m src.main && SCRAPE_OUTCOME=success SCRAPE_STATUS_FILE=.scrape-status.json .venv/bin/python -m src.check_scrape_status`

The scrape verification produced 397 total deprecations, 23 AWS Bedrock items, no content changes, and no provider failures recorded.
