### PR TITLE
docs: update repository links

### DIFF
--- a/README.md
+++ b/README.md
@@ -799,7 +799,7 @@ end
 ## Contributing
 See [CONTRIBUTING.md](CONTRIBUTING.md). Found a bug? Provider changed their
 page format? Open an
-[issue](https://github.com/leblancfg/deprecations-rss/issues), or submit a PR!
+[issue](https://github.com/deprecations/deprecations-rss/issues), or submit a PR!
 
 
 ## Sponsors

--- a/docs/index.html
+++ b/docs/index.html
@@ -49,7 +49,7 @@
                     <div class="provider-badges" id="provider-badges">
                         <span class="provider-badge">…</span>
                     </div>
-                    <a href="https://github.com/leblancfg/deprecations-rss" target="_blank" rel="noopener"
+                    <a href="https://github.com/deprecations/deprecations-rss" target="_blank" rel="noopener"
                         class="github-link">
                         <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
                             <path
@@ -1379,7 +1379,7 @@ end</code></pre>
         <div class="container">
             <p>
                 Updated daily •
-                <a href="https://github.com/leblancfg/deprecations-rss" target="_blank" rel="noopener">GitHub</a> •
+                <a href="https://github.com/deprecations/deprecations-rss" target="_blank" rel="noopener">GitHub</a> •
                 <a href="https://github.com/sponsors/leblancfg" target="_blank" rel="noopener">Sponsor</a>
             </p>
         </div>


### PR DESCRIPTION
## Problem

The project has moved to the `deprecations` GitHub organization, but the README and homepage still link to `leblancfg/deprecations-rss`.

That sends contributors to the old location for issues and source links, which is especially confusing now that GitHub webhooks and project ownership are set up on `deprecations/deprecations-rss`.

## Change

- Update README issue links to `https://github.com/deprecations/deprecations-rss`.
- Update homepage GitHub links to the same canonical repository.

## Verification

- Searched README/homepage for remaining `github.com/leblancfg/deprecations-rss` references.
- `git diff --check`
